### PR TITLE
fix(build): Fix yarn install warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,8 @@ plugins:
     spec: "@yarnpkg/plugin-exec"
 
 yarnPath: .yarn/releases/yarn-3.6.1.cjs
+
+packageExtensions:
+  "uniforms-bridge-json-schema@4.0.0-alpha.0":
+    dependencies:
+      "react": "^18.2.0"


### PR DESCRIPTION
### Before
```bash
➤ YN0000: ┌ Resolution step
➤ YN0002: │ uniforms-bridge-json-schema@npm:4.0.0-alpha.0 doesn't provide react (pd4a28), requested by uniforms
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 213ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: Done with warnings in 0s 631ms
```

### After
```bash
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 219ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 217ms
➤ YN0000: Done in 0s 741ms
```