### PR TITLE
Remove unused deprecated `inheritBydefault` Mojo annotation attribute

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
@@ -52,7 +52,6 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
  */
 @Mojo(
         name = "generate-kaoto-camel-catalog",
-        inheritByDefault = false,
         defaultPhase = LifecyclePhase.GENERATE_SOURCES,
         requiresDependencyResolution = ResolutionScope.COMPILE,
         threadSafe = true,


### PR DESCRIPTION
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/38d72574-2847-42f6-98f5-010f87714585)
