### PR TITLE
feat(SchemaSelector): Add SchemaSelector component

### DIFF
--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -26,9 +26,7 @@ export default {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   '\\\\node_modules\\\\'
-  // ],
+  coveragePathIgnorePatterns: ['\\\\node_modules\\\\', '<rootDir>/src/models', 'index.ts'],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: 'babel',
@@ -90,9 +88,9 @@ export default {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // moduleNameMapper: {},
   moduleNameMapper: {
-    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.ts',
+    '\\.(c|le|sc)ss$': '<rootDir>/src/__mocks__/styleMock.ts',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/__mocks__/fileMock.ts',
+      '<rootDir>/src/__mocks__/fileMock.ts',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "simple-zustand-devtools": "^1.1.0",
     "uniforms": "^4.0.0-alpha.0",
     "uniforms-bridge-json-schema": "^4.0.0-alpha.0",
+    "uuid": "^9.0.0",
     "zustand": "^4.3.9"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
     "build:lib": "tsc && vite build --config vite.config.lib.ts",
     "preview": "vite preview",
     "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "yarn eslint",
     "lint:fix": "yarn eslint \"src/**/*.{ts,tsx}\" --fix"
   },

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,13 +1,13 @@
 import { Outlet } from 'react-router-dom';
 import { Shell } from './layout/Shell';
-import { CatalogLoaderProvider as CatalogLoaderProvider } from './providers/catalog-loader.provider';
+import { CatalogSchemaLoaderProvider } from './providers/catalog-schema-loader.provider';
 
 function App() {
   return (
     <Shell>
-      <CatalogLoaderProvider>
+      <CatalogSchemaLoaderProvider>
         <Outlet />
-      </CatalogLoaderProvider>
+      </CatalogSchemaLoaderProvider>
     </Shell>
   );
 }

--- a/packages/ui/src/__mocks__/fileMock.ts
+++ b/packages/ui/src/__mocks__/fileMock.ts
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/packages/ui/src/__mocks__/styleMock.ts
+++ b/packages/ui/src/__mocks__/styleMock.ts
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -1,6 +1,5 @@
-import { camelComponentToTile, camelProcessorToTile, kameletToTile } from '.';
-import { ICamelComponentDefinition, CatalogKind, ICamelProcessorDefinition } from '../models';
-import { IKameletDefinition } from '../models/kamelets-catalog';
+import { camelComponentToTile, camelProcessorToTile, kameletToTile } from './camel-to-tile.adapter';
+import { ICamelComponentDefinition, CatalogKind, ICamelProcessorDefinition, IKameletDefinition } from '../models';
 
 describe('camelComponentToTile', () => {
   it('should return a tile with the correct type', () => {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -1,6 +1,5 @@
 import { ITile } from '../components/Catalog/Tile.models';
-import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition } from '../models';
-import { IKameletDefinition } from '../models/kamelets-catalog';
+import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition, IKameletDefinition } from '../models';
 
 export const camelComponentToTile = (componentDef: ICamelComponentDefinition): ITile => {
   const { name, title, description, supportLevel, label, version } = componentDef.component;

--- a/packages/ui/src/components/Catalog/Tile.test.tsx
+++ b/packages/ui/src/components/Catalog/Tile.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Tile } from './Tile';
+import { ITile } from './Tile.models';
+
+describe('Tile', () => {
+  const tile: ITile = {
+    type: 'tile-type',
+    name: 'tile-name',
+    title: 'tile-title',
+    description: 'tile-description',
+    tags: ['tag1', 'tag2'],
+    headerTags: ['header-tag1', 'header-tag2'],
+    rawObject: {},
+  };
+
+  it('renders correctly', () => {
+    const { container } = render(<Tile tile={tile} onClick={jest.fn()} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('calls onClick prop when clicked', () => {
+    const onClick = jest.fn();
+    const { getByRole } = render(<Tile tile={tile} onClick={onClick} />);
+
+    fireEvent.click(getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/Catalog/Tile.tsx
+++ b/packages/ui/src/components/Catalog/Tile.tsx
@@ -15,7 +15,15 @@ export const Tile: FunctionComponent<PropsWithChildren<TileProps>> = (props) => 
   }, [props]);
 
   return (
-    <Card className="tile" isClickable isCompact key={props.tile.name} id={props.tile.name} onClick={onTileClick}>
+    <Card
+      className="tile"
+      isClickable
+      isCompact
+      role="button"
+      key={props.tile.name}
+      id={props.tile.name}
+      onClick={onTileClick}
+    >
       <CardHeader
         selectableActions={{
           variant: 'single',

--- a/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tile renders correctly 1`] = `
+<div
+  class="pf-v5-c-card pf-m-compact pf-m-clickable tile"
+  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-type="PF5/Card"
+  data-ouia-safe="true"
+  id="tile-name"
+  role="button"
+>
+  <div
+    class="pf-v5-c-card__header"
+  >
+    <div
+      class="pf-v5-c-card__actions"
+    >
+      <div
+        class="pf-v5-c-card__selectable-actions"
+      >
+        <div
+          class="pf-v5-c-radio pf-m-standalone"
+        >
+          <input
+            aria-invalid="false"
+            aria-labelledby="Selectable tile-name"
+            class="pf-v5-c-radio__input pf-v5-screen-reader"
+            data-ouia-component-id="OUIA-Generated-Radio-1"
+            data-ouia-component-type="PF5/Radio"
+            data-ouia-safe="true"
+            id="tile-name"
+            name="tile-name"
+            type="radio"
+          />
+          <label
+            class="pf-v5-c-radio__label"
+            for="tile-name"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v5-c-card__header-main"
+    >
+      <div
+        class="tile__header"
+      >
+        <img
+          alt="Camel icon"
+          class="tile__icon"
+          src=""
+        />
+        <span
+          class="pf-v5-c-badge pf-m-read"
+        >
+          header-tag1
+        </span>
+        <span
+          class="pf-v5-c-badge pf-m-read"
+        >
+          header-tag2
+        </span>
+      </div>
+      <div
+        class="pf-v5-c-card__title"
+      >
+        <div
+          class="pf-v5-c-card__title-text tile__title"
+          id="tile-name-title"
+        >
+          <span>
+            tile-title
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="pf-v5-c-card__body tile__body"
+  >
+    tile-description
+  </div>
+  <div
+    class="pf-v5-c-card__footer tile__header"
+  >
+    <span
+      class="pf-v5-c-badge pf-m-read"
+    >
+      tag1
+    </span>
+    <span
+      class="pf-v5-c-badge pf-m-read"
+    >
+      tag2
+    </span>
+  </div>
+</div>
+`;

--- a/packages/ui/src/components/IconResolver/IconResolver.test.tsx
+++ b/packages/ui/src/components/IconResolver/IconResolver.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { IconResolver } from '.';
+import { CatalogKind } from '../../models';
+import { ITile } from '../Catalog';
+
+describe('IconResolver', () => {
+  const mockTile: ITile = {
+    type: CatalogKind.Component,
+    title: 'title',
+    description: 'description',
+    name: 'name',
+    tags: [],
+    rawObject: {},
+  };
+
+  it('should render default icon', () => {
+    const { container } = render(<IconResolver tile={mockTile} />);
+
+    expect(container.querySelector('img')).toHaveAttribute('alt', 'Camel icon');
+  });
+
+  it('should render icon from Kamelet', () => {
+    const kameletTile = {
+      ...mockTile,
+      type: CatalogKind.Kamelet,
+      rawObject: {
+        metadata: {
+          annotations: {
+            'camel.apache.org/kamelet.icon': 'kamelet-icon.svg',
+          },
+        },
+      },
+    };
+
+    const { container } = render(<IconResolver tile={kameletTile} />);
+
+    expect(container.querySelector('img')).toHaveAttribute('alt', 'Kamelet icon');
+    expect(container.querySelector('img')).toHaveAttribute('src', 'kamelet-icon.svg');
+  });
+});

--- a/packages/ui/src/components/IconResolver/IconResolver.tsx
+++ b/packages/ui/src/components/IconResolver/IconResolver.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
 import defaultCamelIcon from '../../assets/camel-logo.svg';
-import { CatalogKind } from '../../models';
-import { IKameletDefinition } from '../../models/kamelets-catalog';
+import { CatalogKind, IKameletDefinition } from '../../models';
 import { ITile } from '../Catalog/Tile.models';
 
 interface IconResolverProps {

--- a/packages/ui/src/components/InlineEdit/InlineEdit.scss
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.scss
@@ -1,0 +1,3 @@
+span[data-clickable='true'] {
+  cursor: pointer;
+}

--- a/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
@@ -1,0 +1,274 @@
+import { fireEvent } from '@testing-library/dom';
+import { act, render } from '@testing-library/react';
+import { InlineEdit } from './InlineEdit';
+import { minLengthValidator } from './min-length-validator';
+
+describe('InlineEdit', () => {
+  const DATA_TESTID = 'inline';
+
+  describe('Readonly mode', () => {
+    it('should render correctly', () => {
+      const wrapper = render(<InlineEdit value="My text" />);
+
+      const textField = wrapper.getByText('My text');
+      expect(textField).toBeInTheDocument();
+    });
+
+    it('should use an empty string as default value', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID)).toBeInTheDocument();
+      expect(wrapper.getByTestId(DATA_TESTID)).toHaveTextContent('');
+    });
+
+    it.each([
+      [() => {}, true],
+      [undefined, false],
+    ] as const)('should set data-clickable attribute according to onClick', (onClick, value) => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} onClick={onClick} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID)).toHaveAttribute('data-clickable', value.toString());
+    });
+
+    it('should render a pencil icon', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID + '--edit')).toBeInTheDocument();
+    });
+
+    it('should go to edit mode upon clicking on the pencil icon', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('should go to edit mode and stop click event propagation', () => {
+      const mouseEvent = new MouseEvent('click', { bubbles: true });
+      const stopPropagationSpy = jest.spyOn(mouseEvent, 'stopPropagation');
+
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent(editButton, mouseEvent);
+      });
+
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Editable mode', () => {
+    it('should set focus on input upon editing', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toHaveFocus();
+    });
+
+    it('should start with a default validation status', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('should set a default validation statuts if the change is the same as the original value', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} value="My text" />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+
+      act(() => {
+        fireEvent.change(input, { target: { value: 'edited text' } });
+        fireEvent.change(input, { target: { value: 'My text' } });
+      });
+
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('should use the validator if available', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} value="My text" validator={minLengthValidator} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      act(() => {
+        const errorMessage = wrapper.getByText(/Value must be at least 5 characters long/, {
+          exact: false,
+        });
+        expect(errorMessage).toBeInTheDocument();
+      });
+    });
+
+    it('should ignore the save action if the validation fails', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} value="My text" validator={minLengthValidator} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+      });
+
+      const saveButton = wrapper.getByTestId('inline--save');
+      act(() => {
+        fireEvent.click(saveButton);
+      });
+
+      expect(saveButton).toBeInTheDocument();
+      expect(saveButton).toBeDisabled();
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).not.toBeInTheDocument();
+    });
+
+    it('should call the onChange callback if the validation succeeds', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit data-testid={DATA_TESTID} value="My text" onChange={onChange} validator={minLengthValidator} />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'A new hope' } });
+      });
+
+      act(() => {
+        const saveButton = wrapper.getByTestId('inline--save');
+        fireEvent.click(saveButton);
+      });
+
+      expect(onChange).toHaveBeenCalledWith('A new hope');
+    });
+
+    it('should not call the onChange callback if the validation fails', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit data-testid={DATA_TESTID} value="My text" onChange={onChange} validator={minLengthValidator} />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should not call the onChange callback if the value did not change', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit data-testid={DATA_TESTID} value="My text" onChange={onChange} validator={minLengthValidator} />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should return to read mode when the user presses the Escape key', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.keyDown(input, { key: 'Escape' });
+      });
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).toBeInTheDocument();
+    });
+
+    it('should return to read mode and stop the event propagation when the user clicks on the cancel button', () => {
+      const mouseEvent = new MouseEvent('click', { bubbles: true });
+      const stopPropagationSpy = jest.spyOn(mouseEvent, 'stopPropagation');
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const cancelButton = wrapper.getByTestId('inline--cancel');
+        fireEvent(cancelButton, mouseEvent);
+      });
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).toBeInTheDocument();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should prevent the form submission', () => {
+      const submitEvent = new Event('submit', { bubbles: true });
+      const preventDefaultSpy = jest.spyOn(submitEvent, 'preventDefault');
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const form = wrapper.getByTestId('inline--form');
+        fireEvent(form, submitEvent);
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui/src/components/InlineEdit/InlineEdit.tsx
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.tsx
@@ -1,0 +1,191 @@
+import {
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { CheckIcon, ExclamationCircleIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
+import {
+  FormEventHandler,
+  FunctionComponent,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  useCallback,
+  useState,
+} from 'react';
+import { IDataTestID, ValidationResult, ValidationStatus } from '../../models';
+import './InlineEdit.scss';
+
+interface IInlineEdit extends IDataTestID {
+  value?: string;
+  validator?: (value: string) => ValidationResult;
+  onChange?: (value: string) => void;
+  onClick?: () => void;
+}
+
+export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
+  const [localValue, setLocalValue] = useState(props.value ?? '');
+  const [isReadOnly, setIsReadOnly] = useState(true);
+
+  const focusTextInput = useCallback((element: HTMLInputElement) => {
+    element?.focus();
+  }, []);
+
+  const [validationResult, setValidationResult] = useState<ValidationResult>({
+    status: ValidationStatus.Default,
+    errMessages: [],
+  });
+
+  const onEdit: MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
+    setIsReadOnly(false);
+    event.stopPropagation();
+  }, []);
+
+  const onChange = useCallback(
+    (_event: unknown, value: string) => {
+      setLocalValue(value);
+
+      if (value === props.value) {
+        setValidationResult({ status: ValidationStatus.Default, errMessages: [] });
+        return;
+      }
+
+      if (typeof props.validator === 'function') {
+        setValidationResult(props.validator(value));
+      }
+    },
+    [props],
+  );
+
+  const saveValue = useCallback(() => {
+    if (validationResult.status !== ValidationStatus.Default && validationResult.status !== ValidationStatus.Success)
+      return;
+
+    setIsReadOnly(true);
+    if (localValue !== props.value && typeof props.onChange === 'function') {
+      props.onChange(localValue);
+    }
+  }, [localValue, props, validationResult]);
+
+  const cancelValue = useCallback(() => {
+    setLocalValue(props.value ?? '');
+    setValidationResult({ status: ValidationStatus.Default, errMessages: [] });
+    setIsReadOnly(true);
+  }, [props.value]);
+
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      if (event.key === 'Enter') {
+        saveValue();
+      }
+      if (event.key === 'Escape') {
+        cancelValue();
+      }
+      event.stopPropagation();
+    },
+    [cancelValue, saveValue],
+  );
+
+  const onSave: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      saveValue();
+      event.stopPropagation();
+    },
+    [saveValue],
+  );
+
+  const onCancel: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      cancelValue();
+      event.stopPropagation();
+    },
+    [cancelValue],
+  );
+
+  const noop: FormEventHandler<HTMLFormElement> = useCallback((event) => {
+    event.preventDefault();
+  }, []);
+
+  return (
+    <>
+      {isReadOnly ? (
+        <>
+          <span
+            data-clickable={typeof props.onClick === 'function'}
+            data-testid={props['data-testid']}
+            onClick={props.onClick}
+          >
+            {props.value}
+          </span>
+          &nbsp;&nbsp;
+          <Button
+            variant="plain"
+            data-testid={props['data-testid'] + '--edit'}
+            onClick={onEdit}
+            icon={<PencilAltIcon />}
+          />
+        </>
+      ) : (
+        <Form onSubmit={noop} data-testid={props['data-testid'] + '--form'}>
+          <FormGroup type="text" fieldId="edit-value">
+            <InputGroup>
+              <InputGroupItem isFill>
+                <TextInput
+                  id="edit-value"
+                  name="edit-value"
+                  aria-label="edit-value"
+                  data-testid={props['data-testid'] + '--text-input'}
+                  type="text"
+                  ref={focusTextInput}
+                  onChange={onChange}
+                  value={localValue}
+                  aria-invalid={validationResult.status === ValidationStatus.Error}
+                  onKeyDown={onKeyDown}
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem
+                      variant={validationResult.status}
+                      {...(validationResult.status === ValidationStatus.Error && { icon: <ExclamationCircleIcon /> })}
+                    >
+                      {validationResult.errMessages[0]}
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </InputGroupItem>
+
+              <InputGroupItem>
+                <Button
+                  variant="plain"
+                  aria-label="save button for editing value"
+                  onClick={onSave}
+                  data-testid={props['data-testid'] + '--save'}
+                  aria-disabled={validationResult.status === ValidationStatus.Error}
+                  isDisabled={validationResult.status === ValidationStatus.Error}
+                >
+                  <CheckIcon />
+                </Button>
+              </InputGroupItem>
+
+              <InputGroupItem>
+                <Button
+                  variant="plain"
+                  aria-label="close button for editing value"
+                  data-testid={props['data-testid'] + '--cancel'}
+                  onClick={onCancel}
+                >
+                  <TimesIcon />
+                </Button>
+              </InputGroupItem>
+            </InputGroup>
+          </FormGroup>
+        </Form>
+      )}
+    </>
+  );
+};

--- a/packages/ui/src/components/InlineEdit/index.ts
+++ b/packages/ui/src/components/InlineEdit/index.ts
@@ -1,0 +1,1 @@
+export * from './InlineEdit';

--- a/packages/ui/src/components/InlineEdit/min-length-validator.test.ts
+++ b/packages/ui/src/components/InlineEdit/min-length-validator.test.ts
@@ -1,0 +1,20 @@
+import { ValidationStatus } from '../../models';
+import { minLengthValidator } from './min-length-validator';
+
+describe('min-length-validator', () => {
+  it('should return error if value is shorter than 5 characters', () => {
+    const result = minLengthValidator('1234');
+    expect(result).toEqual({
+      status: ValidationStatus.Error,
+      errMessages: ['Value must be at least 5 characters long'],
+    });
+  });
+
+  it('should return success if value is at least 5 characters', () => {
+    const result = minLengthValidator('12345');
+    expect(result).toEqual({
+      status: ValidationStatus.Success,
+      errMessages: [],
+    });
+  });
+});

--- a/packages/ui/src/components/InlineEdit/min-length-validator.ts
+++ b/packages/ui/src/components/InlineEdit/min-length-validator.ts
@@ -1,0 +1,15 @@
+import { ValidationResult, ValidationStatus } from '../../models';
+
+export const minLengthValidator = (value: string): ValidationResult => {
+  if (value.length < 5) {
+    return {
+      status: ValidationStatus.Error,
+      errMessages: ['Value must be at least 5 characters long'],
+    };
+  }
+
+  return {
+    status: ValidationStatus.Success,
+    errMessages: [],
+  };
+};

--- a/packages/ui/src/components/SchemaSelector/SchemaSelector.test.tsx
+++ b/packages/ui/src/components/SchemaSelector/SchemaSelector.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from '@testing-library/react';
+import { SchemaSelector } from './SchemaSelector';
+import userSchemaJson from '../../stubs/user-schema.json';
+
+describe('SchemaSelector', () => {
+  it('should render correctly', () => {
+    const props = {
+      schemas: [
+        {
+          name: 'name',
+          version: 'version',
+          schema: userSchemaJson,
+        },
+      ],
+    };
+
+    const { container } = render(<SchemaSelector {...props} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should call onClick when a tile is clicked', () => {
+    const props = {
+      schemas: [
+        {
+          name: 'name',
+          version: 'version',
+          schema: userSchemaJson,
+        },
+      ],
+      onClick: jest.fn(),
+    };
+
+    const { getByText } = render(<SchemaSelector {...props} />);
+
+    fireEvent.click(getByText('name'));
+
+    expect(props.onClick).toHaveBeenCalledWith(props.schemas[0].schema);
+  });
+});

--- a/packages/ui/src/components/SchemaSelector/SchemaSelector.tsx
+++ b/packages/ui/src/components/SchemaSelector/SchemaSelector.tsx
@@ -1,0 +1,38 @@
+import { FunctionComponent, PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { Schema } from '../../models';
+import { Catalog, ITile } from '../Catalog';
+
+const SCHEMA_INDEX_KEY = 'Schema';
+
+interface IconResolverProps {
+  schemas: Schema[];
+  onClick?: (schema: Schema) => void;
+}
+
+export const SchemaSelector: FunctionComponent<PropsWithChildren<IconResolverProps>> = (props) => {
+  const [tiles, setTiles] = useState<Record<string, ITile[]>>({});
+
+  useEffect(() => {
+    const tiles: ITile[] = props.schemas.map((schema) => {
+      return {
+        name: schema.name,
+        title: schema.name,
+        description: '',
+        tags: [schema.version],
+        type: SCHEMA_INDEX_KEY,
+        rawObject: schema.schema,
+      };
+    });
+
+    setTiles({ [SCHEMA_INDEX_KEY]: tiles });
+  }, [props.schemas]);
+
+  const onTileClick = useCallback(
+    (tile: ITile) => {
+      props.onClick?.(tile.rawObject as Schema);
+    },
+    [props],
+  );
+
+  return <Catalog tiles={tiles} onTileClick={onTileClick} />;
+};

--- a/packages/ui/src/components/SchemaSelector/__snapshots__/SchemaSelector.test.tsx.snap
+++ b/packages/ui/src/components/SchemaSelector/__snapshots__/SchemaSelector.test.tsx.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaSelector should render correctly 1`] = `
+<form
+  class="pf-v5-c-form catalog__filter"
+  novalidate=""
+>
+  <div
+    class="pf-v5-l-grid pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-v5-l-grid__item"
+    >
+      <div
+        class="pf-v5-c-form__group"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="search-term"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Search term
+            </span>
+          </label>
+           
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <div
+            class="pf-v5-c-text-input-group"
+          >
+            <div
+              class="pf-v5-c-text-input-group__main pf-m-icon"
+            >
+              <span
+                class="pf-v5-c-text-input-group__text"
+              >
+                <span
+                  class="pf-v5-c-text-input-group__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                    />
+                  </svg>
+                </span>
+                <input
+                  aria-label="Find by name or tag"
+                  class="pf-v5-c-text-input-group__text-input"
+                  placeholder="Find by name or tag"
+                  type="text"
+                  value=""
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v5-l-grid__item pf-v5-u-text-align-right"
+    >
+      <div
+        class="pf-v5-c-form__group"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="element-type"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Type
+            </span>
+          </label>
+           
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <div
+            aria-label="Select element type"
+            class="pf-v5-c-toggle-group"
+            role="group"
+          >
+            <div
+              class="pf-v5-c-toggle-group__item"
+              data-testid="Schema-catalog-tab"
+            >
+              <button
+                aria-pressed="true"
+                class="pf-v5-c-toggle-group__button pf-m-selected"
+                id="toggle-group-button-Schema"
+                type="button"
+              >
+                <span
+                  class="pf-v5-c-toggle-group__text"
+                >
+                  Schema
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;

--- a/packages/ui/src/components/SchemaSelector/index.ts
+++ b/packages/ui/src/components/SchemaSelector/index.ts
@@ -1,0 +1,1 @@
+export * from './SchemaSelector';

--- a/packages/ui/src/models/flow.ts
+++ b/packages/ui/src/models/flow.ts
@@ -1,0 +1,5 @@
+export interface FlowModel {
+  id: string;
+  type: string;
+  model: unknown;
+}

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -4,4 +4,6 @@ export * from './camel-processors-catalog';
 export * from './catalog-kind';
 export * from './flow';
 export * from './kamelets-catalog';
+export * from './react-component';
 export * from './schema';
+export * from './validation';

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -2,4 +2,6 @@ export * from './camel-catalog-index';
 export * from './camel-components-catalog';
 export * from './camel-processors-catalog';
 export * from './catalog-kind';
+export * from './flow';
 export * from './kamelets-catalog';
+export * from './schema';

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -2,3 +2,4 @@ export * from './camel-catalog-index';
 export * from './camel-components-catalog';
 export * from './camel-processors-catalog';
 export * from './catalog-kind';
+export * from './kamelets-catalog';

--- a/packages/ui/src/models/react-component.ts
+++ b/packages/ui/src/models/react-component.ts
@@ -1,0 +1,3 @@
+export interface IDataTestID {
+  'data-testid'?: string;
+}

--- a/packages/ui/src/models/schema.ts
+++ b/packages/ui/src/models/schema.ts
@@ -1,0 +1,5 @@
+export interface Schema {
+  name: string;
+  version: string;
+  schema: unknown;
+}

--- a/packages/ui/src/models/validation.ts
+++ b/packages/ui/src/models/validation.ts
@@ -1,0 +1,11 @@
+export interface ValidationResult {
+  status: ValidationStatus;
+  errMessages: string[];
+}
+
+export const enum ValidationStatus {
+  Default = 'default',
+  Warning = 'warning',
+  Success = 'success',
+  Error = 'error',
+}

--- a/packages/ui/src/store/flows.store.ts
+++ b/packages/ui/src/store/flows.store.ts
@@ -1,0 +1,20 @@
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { FlowModel } from '../models';
+
+interface FlowsState {
+  flows: FlowModel[];
+  addFlow: (flow: FlowModel) => void;
+}
+
+export const useFlowsStore = createWithEqualityFn<FlowsState>(
+  (set) => ({
+    flows: [],
+    addFlow: (flow: FlowModel) => {
+      set((state) => ({
+        flows: [...state.flows, flow],
+      }));
+    },
+  }),
+  shallow,
+);

--- a/packages/ui/src/store/index.ts
+++ b/packages/ui/src/store/index.ts
@@ -1,5 +1,7 @@
 import { mountStoreDevtool } from 'simple-zustand-devtools';
+import { useSchemasStore } from './schemas.store';
 import { useCatalogStore } from './catalog.store';
+import { useFlowsStore } from './flows.store';
 
 let isDevMode = true;
 try {
@@ -9,7 +11,11 @@ try {
 }
 
 if (isDevMode) {
-  mountStoreDevtool('CatalogStore', useCatalogStore);
+  mountStoreDevtool('Catalog Store', useCatalogStore);
+  mountStoreDevtool('Flows Store', useFlowsStore);
+  mountStoreDevtool('Schemas Store', useSchemasStore);
 }
 
 export * from './catalog.store';
+export * from './flows.store';
+export * from './schemas.store';

--- a/packages/ui/src/store/schemas.store.ts
+++ b/packages/ui/src/store/schemas.store.ts
@@ -1,0 +1,20 @@
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { Schema } from '../models';
+
+interface SchemasState {
+  schemas: Schema[];
+  setSchema: (schema: Schema) => void;
+}
+
+export const useSchemasStore = createWithEqualityFn<SchemasState>(
+  (set) => ({
+    schemas: [],
+    setSchema: (schema: Schema) => {
+      set((state) => ({
+        schemas: [...state.schemas, schema],
+      }));
+    },
+  }),
+  shallow,
+);

--- a/packages/ui/src/stubs/user-schema.json
+++ b/packages/ui/src/stubs/user-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "example-property": {
+      "title": "Example Property Title",
+      "description": "Example Property Description",
+      "defaultValue": "Example Property Default Value",
+      "type": "object",
+      "properties": {
+        "allowEmptyDirectory": {
+          "type": "boolean",
+          "description": "If the tar file has more than one entry, setting this option to true, allows to get the iterator even if the directory is empty",
+          "title": "Allow Empty Directory"
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of this node",
+          "title": "Id"
+        },
+        "maxDecompressedSize": {
+          "type": "number",
+          "description": "Set the maximum decompressed size of a tar file (in bytes). The default value if not specified corresponds to 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable setting a maximum decompressed size.",
+          "title": "Max Decompressed Size"
+        },
+        "preservePathElements": {
+          "type": "boolean",
+          "description": "If the file name contains path elements, setting this option to true, allows the path to be maintained in the tar file.",
+          "title": "Preserve Path Elements"
+        },
+        "usingIterator": {
+          "type": "boolean",
+          "description": "If the tar file has more than one entry, the setting this option to true, allows working with the splitter EIP, to split the data using an iterator in a streaming mode.",
+          "title": "Using Iterator"
+        }
+      }
+
+    }
+  }
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -18,7 +18,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Typings */
+    "types": [
+      "@testing-library/jest-dom",
+    ]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,6 +2145,7 @@ __metadata:
     typescript: ^5.0.2
     uniforms: ^4.0.0-alpha.0
     uniforms-bridge-json-schema: ^4.0.0-alpha.0
+    uuid: ^9.0.0
     vite: ^4.4.5
     vite-plugin-dts: ^3.5.1
     vite-plugin-static-copy: ^0.17.0
@@ -9771,6 +9772,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
In order to create flows, the user must select a Flow Type, i.e.:  `Route`, `Kamelet`, `KameletBinding`, etc...

### Changes
* Install UUID dependency for generating random `IDs` for the flows
* Add initial draft for loading available schemas from `@kaoto-next/camel-catalog`
* Add `SchemaSelector` component
* Bring `InlineEdit` component from `kaoto-ui `

### Notes
This pull request aims to fill some of the prerequisites for https://github.com/KaotoIO/kaoto-next/issues/34 and is not the final implementation.

For instance, the items being shown in the `SchemaSelector` for Camel are not correct, the first tile should read `Route` instead. This will be tackled in an upcoming pull request.

### Demo
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/6baec59f-be08-4931-8bc1-c005173f971d)
