### PR TITLE
chore: Refactor Camel Catalog index.json file

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/Index.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/Index.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-record Entry(String name, String version, String... files) {}
+record Entry(String name, String version, String file) {}
 
 public class Index {
     public static final String COMPONENTS = "components";
@@ -31,7 +31,6 @@ public class Index {
     private Map<String, Entry> catalogs = new HashMap<>();
 
     private List<Entry> schemas = new ArrayList<>();
-    private List<Entry> kamelets = new ArrayList<>();
 
     public Map<String, Entry> getCatalogs() {
         return catalogs;
@@ -39,8 +38,4 @@ public class Index {
     public List<Entry> getSchemas() {
         return schemas;
     }
-    public List<Entry> getKamelets() {
-        return kamelets;
-    }
 }
-

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
@@ -219,7 +219,7 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             jsonMapper.writerWithDefaultPrettyPrinter().writeValue(output.toFile(), schema);
             var displayName = crd.getSpec().getNames().getKind();
             var indexEntry = new Entry(
-                    "Camel K Custom Resource JSON schema for " + displayName,
+                    displayName,
                     camelKCRDVersion,
                     outputFileName);
             index.getSchemas().add(indexEntry);
@@ -251,7 +251,7 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
                     "Aggregated Kamelet definitions in JSON",
                     kameletsVersion,
                     outputFileName);
-            index.getKamelets().add(indexEntry);
+            index.getCatalogs().put(KAMELETS, indexEntry);
         } catch (Exception e) {
             getLog().error(e);
         }

--- a/packages/ui/src/camel-utils/camel-schemas-processor.test.ts
+++ b/packages/ui/src/camel-utils/camel-schemas-processor.test.ts
@@ -1,0 +1,74 @@
+import { CamelSchemasProcessor } from './camel-schemas-processor';
+import userSchemaJson from '../stubs/user-schema.json';
+
+describe('camel-schemas-processor', () => {
+  const camelSchema = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'array',
+    items: {
+      definitions: {
+        route: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      properties: {
+        route: { $ref: '#/definitions/route' },
+      },
+    },
+  };
+
+  const schemas = [
+    {
+      name: 'user-schema',
+      version: '3.2.0',
+      tags: [],
+      schema: userSchemaJson,
+    },
+  ];
+
+  it.each([
+    [null, false],
+    [undefined, false],
+    [{}, false],
+    [{ schema: null }, false],
+    [{ schema: {} }, false],
+    [{ schema: { items: {} } }, true],
+  ])('should return whether or not the provided schema is a Camel YAML schema: %s', (schema, expected) => {
+    const result = CamelSchemasProcessor.isCamelCatalog(schema);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return a list of schemas', () => {
+    const result = CamelSchemasProcessor.getSchemas(schemas);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual('user-schema');
+    expect(result[0].version).toEqual('3.2.0');
+    expect(result[0].tags).toEqual([]);
+    expect(result[0].schema).toEqual(userSchemaJson);
+  });
+
+  it.each([
+    [
+      'Beans',
+      { ...schemas[0], schema: { ...camelSchema, items: { ...camelSchema.items, properties: { beans: {} } } } },
+      [],
+    ],
+    ['userSchema', { ...schemas[0], schema: userSchemaJson }, []],
+    ['Route', { ...schemas[0], schema: camelSchema }, ['visualization']],
+    ['Integration', { ...schemas[0], name: 'Integration' }, ['visualization']],
+    ['Kamelet', { ...schemas[0], name: 'Kamelet' }, ['visualization']],
+    ['KameletBinding', { ...schemas[0], name: 'KameletBinding' }, ['visualization']],
+    ['Pipe', { ...schemas[0], name: 'Pipe' }, ['visualization']],
+  ])('should return a list of schemas with a tag property for: %s', (_name, schema, tags) => {
+    const result = CamelSchemasProcessor.getSchemas([schema]);
+
+    expect(result[0].tags).toEqual(tags);
+  });
+});

--- a/packages/ui/src/camel-utils/camel-schemas-processor.ts
+++ b/packages/ui/src/camel-utils/camel-schemas-processor.ts
@@ -1,0 +1,61 @@
+import { Schema } from '../models';
+
+export class CamelSchemasProcessor {
+  static readonly VISUAL_FLOWS = ['route', 'Integration', 'Kamelet', 'KameletBinding', 'Pipe'];
+
+  static getSchemas(schemas: Schema[]): Schema[] {
+    return schemas.reduce((acc, schema) => {
+      if (!this.isCamelCatalog(schema)) {
+        /** Standard JSON Schemas (Kamelets, KameletBindings & Pipes) */
+        const tags = [];
+        if (this.VISUAL_FLOWS.includes(schema.name)) {
+          tags.push('visualization');
+        }
+
+        acc.push({
+          ...schema,
+          name: schema.name,
+          tags,
+        });
+      } else {
+        /** Camel YAML DSL JSON Schemas */
+        Object.keys(schema.schema.items.properties).forEach((propertyRefName) => {
+          const propertyRef = schema.schema.items.properties[propertyRefName];
+          const tags = [];
+
+          if (this.VISUAL_FLOWS.includes(propertyRefName.toLowerCase())) {
+            tags.push('visualization');
+          }
+
+          acc.push({
+            name: propertyRefName,
+            version: schema.version,
+            tags,
+            schema: {
+              $schema: 'https://json-schema.org/draft-04/schema#',
+              type: 'object',
+              items: { definitions: schema.schema.items },
+              properties: {
+                [propertyRefName]: propertyRef,
+              },
+            },
+          });
+        });
+      }
+
+      return acc;
+    }, [] as Schema[]);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static isCamelCatalog(schema: any): schema is Schema & {
+    schema: { items: { definitions: Record<string, unknown>; properties: Record<string, unknown> } };
+  } {
+    return (
+      schema?.schema !== null &&
+      schema?.schema !== undefined &&
+      typeof schema.schema === 'object' &&
+      'items' in schema.schema
+    );
+  }
+}

--- a/packages/ui/src/camel-utils/index.ts
+++ b/packages/ui/src/camel-utils/index.ts
@@ -1,1 +1,2 @@
+export * from './camel-schemas-processor';
 export * from './camel-to-tile.adapter';

--- a/packages/ui/src/components/SchemaSelector/SchemaSelector.test.tsx
+++ b/packages/ui/src/components/SchemaSelector/SchemaSelector.test.tsx
@@ -3,34 +3,29 @@ import { SchemaSelector } from './SchemaSelector';
 import userSchemaJson from '../../stubs/user-schema.json';
 
 describe('SchemaSelector', () => {
-  it('should render correctly', () => {
-    const props = {
-      schemas: [
-        {
-          name: 'name',
-          version: 'version',
-          schema: userSchemaJson,
-        },
-      ],
-    };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
+  const props = {
+    schemas: [
+      {
+        name: 'name',
+        version: 'version',
+        tags: [],
+        schema: userSchemaJson,
+      },
+    ],
+    onClick: jest.fn(),
+  };
+
+  it('should render correctly', () => {
     const { container } = render(<SchemaSelector {...props} />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should call onClick when a tile is clicked', () => {
-    const props = {
-      schemas: [
-        {
-          name: 'name',
-          version: 'version',
-          schema: userSchemaJson,
-        },
-      ],
-      onClick: jest.fn(),
-    };
-
     const { getByText } = render(<SchemaSelector {...props} />);
 
     fireEvent.click(getByText('name'));

--- a/packages/ui/src/models/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel-catalog-index.ts
@@ -6,7 +6,6 @@ import { IKameletDefinition } from './kamelets-catalog';
 export interface CamelCatalogIndex {
   catalogs: Catalogs;
   schemas: CatalogEntry[];
-  kamelets: CatalogEntry[];
 }
 
 export interface Catalogs {
@@ -14,12 +13,13 @@ export interface Catalogs {
   components: CatalogEntry;
   languages: CatalogEntry;
   dataformats: CatalogEntry;
+  kamelets: CatalogEntry;
 }
 
 export interface CatalogEntry {
   name: string;
   version: string;
-  files: string[];
+  file: string;
 }
 
 export type ComponentTypes = ICamelComponentDefinition | ICamelProcessorDefinition | IKameletDefinition;

--- a/packages/ui/src/models/schema.ts
+++ b/packages/ui/src/models/schema.ts
@@ -1,5 +1,6 @@
 export interface Schema {
   name: string;
   version: string;
+  tags: string[];
   schema: unknown;
 }


### PR DESCRIPTION
### Changes
* Add missing tests
* Refactor the `files` property from the catalog into a dedicated `file` property
* Move the `Kamelets` property into the `catalog` section of the `index.json` file
