### PR TITLE
fix(gh-40): Make catalog filter case insensitive and use also title

### DIFF
--- a/packages/ui/src/components/Catalog/Catalog.tsx
+++ b/packages/ui/src/components/Catalog/Catalog.tsx
@@ -23,7 +23,12 @@ export const Catalog: FunctionComponent<PropsWithChildren<CatalogProps>> = (prop
   useEffect(() => {
     setFilteredTiles(
       props.tiles[activeGroup]?.filter((tile) => {
-        return tile.name.includes(searchTerm) || tile.tags.some((tag) => tag.includes(searchTerm));
+        return (
+          tile.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          tile.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          tile.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          tile.tags.some((tag) => tag.toLowerCase().includes(searchTerm.toLowerCase()))
+        );
       }),
     );
   }, [searchTerm, activeGroup, props.tiles]);

--- a/packages/ui/src/components/Catalog/Catalog.tsx
+++ b/packages/ui/src/components/Catalog/Catalog.tsx
@@ -26,7 +26,7 @@ export const Catalog: FunctionComponent<PropsWithChildren<CatalogProps>> = (prop
         return (
           tile.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
           tile.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          tile.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          tile.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
           tile.tags.some((tag) => tag.toLowerCase().includes(searchTerm.toLowerCase()))
         );
       }),

--- a/packages/ui/src/components/Catalog/CatalogFilter.tsx
+++ b/packages/ui/src/components/Catalog/CatalogFilter.tsx
@@ -23,8 +23,8 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
         <GridItem>
           <FormGroup label="Search term" fieldId="search-term">
             <SearchInput
-              aria-label="Find by name or tag"
-              placeholder="Find by name or tag"
+              aria-label="Find by name, description or tag"
+              placeholder="Find by name, description or tag"
               value={props.searchTerm}
               onChange={props.onChange}
               onClear={props.onChange}

--- a/packages/ui/src/components/Catalog/Tile.models.ts
+++ b/packages/ui/src/components/Catalog/Tile.models.ts
@@ -2,7 +2,7 @@ export interface ITile<T = unknown> {
   type: string;
   name: string;
   title: string;
-  description: string;
+  description?: string;
   headerTags?: string[];
   tags: string[];
   rawObject: T;

--- a/packages/ui/src/components/SchemaSelector/__snapshots__/SchemaSelector.test.tsx.snap
+++ b/packages/ui/src/components/SchemaSelector/__snapshots__/SchemaSelector.test.tsx.snap
@@ -59,9 +59,9 @@ exports[`SchemaSelector should render correctly 1`] = `
                   </svg>
                 </span>
                 <input
-                  aria-label="Find by name or tag"
+                  aria-label="Find by name, description or tag"
                   class="pf-v5-c-text-input-group__text-input"
-                  placeholder="Find by name or tag"
+                  placeholder="Find by name, description or tag"
                   type="text"
                   value=""
                 />

--- a/packages/ui/src/models/camel-components-catalog.ts
+++ b/packages/ui/src/models/camel-components-catalog.ts
@@ -11,7 +11,7 @@ export interface ICamelComponent {
   kind: CatalogKind.Component;
   name: string;
   title: string;
-  description: string;
+  description?: string;
   deprecated: boolean;
   firstVersion?: string;
   label: string;

--- a/packages/ui/src/models/camel-processors-catalog.ts
+++ b/packages/ui/src/models/camel-processors-catalog.ts
@@ -11,7 +11,7 @@ export interface ICamelProcessorModel {
   kind: CatalogKind.Processor;
   name: string;
   title: string;
-  description: string;
+  description?: string;
   deprecated: boolean;
   label: string;
   javaType?: string;

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -37,7 +37,7 @@ export interface IKameletSpec {
 
 export interface IKameletSpecDefinition {
   title: string;
-  description: string;
+  description?: string;
   type: string;
   properties?: Record<string, IKameletDefinition>;
   example?: string;


### PR DESCRIPTION
e.g.: ![image](https://github.com/KaotoIO/kaoto-next/assets/16251792/a7ae7d50-65e5-4271-a1d3-e584d0262804)

Matches: 
```
aws
AwS
aws2-ec2
aws elastic compute
SDK version 2.x.
sdk version 2.X
CLOUD
4.0.0
```