### PR TITLE
feat(viz): First iteration of the Visualization component

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -1,0 +1,45 @@
+import { FunctionComponent, PropsWithChildren, useEffect, useState } from 'react';
+import ReactFlow, { Background, Controls, Edge, Node, useReactFlow } from 'reactflow';
+import 'reactflow/dist/style.css';
+import { CamelRoute } from '../../../models/camel-entities';
+import { CanvasService } from './canvas.service';
+
+interface CanvasProps {
+  contextToolbar?: React.ReactNode;
+  entities: CamelRoute[];
+}
+
+export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+
+  /** Calculate graph */
+  useEffect(() => {
+    if (!Array.isArray(props.entities)) return;
+
+    const localNodes: Node[] = [];
+    const localEdges: Edge[] = [];
+
+    props.entities.forEach((entity) => {
+      const { nodes: childNodes, edges: childEdges } = CanvasService.getFlowChart(entity.toVizNode());
+      localNodes.push(...childNodes);
+      localEdges.push(...childEdges);
+    });
+
+    setNodes(localNodes);
+    setEdges(localEdges);
+
+    /** Find a better mechanism to update the canvas */
+    setTimeout(() => {
+      fitView();
+    }, 100);
+  }, []);
+
+  return (
+    <ReactFlow nodes={nodes} edges={edges}>
+      <Background />
+      <Controls />
+    </ReactFlow>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -1,0 +1,86 @@
+import Dagre from '@dagrejs/dagre';
+import { Edge, Node } from 'reactflow';
+import { VisualizationNode } from '../../../models/visualization';
+
+type NodesAndEdges = { nodes: Node[]; edges: Edge[] };
+
+export class CanvasService {
+  static nodes: Node[] = [];
+  static edges: Edge[] = [];
+  static visitedNodes: string[] = [];
+
+  static getFlowChart(vizNode: VisualizationNode): NodesAndEdges {
+    this.nodes = [];
+    this.edges = [];
+    this.visitedNodes = [];
+    this.getNodesAndEdges(vizNode);
+
+    console.log('this.nodes', this.nodes, vizNode);
+    console.log('this.edges', this.edges);
+    const positionedFlowChart = this.getLayoutedElements(this.nodes, this.edges);
+    return { nodes: positionedFlowChart.nodes, edges: positionedFlowChart.edges };
+  }
+
+  /** Method for iterating over all the VisualizationNode and its children using a depth-first algorithm */
+  static getNodesAndEdges(vizNodeParam: VisualizationNode) {
+    if (this.visitedNodes.includes(vizNodeParam.id)) {
+      return;
+    }
+
+    console.log('vizNodeParam', vizNodeParam.id, vizNodeParam.label);
+    const node = vizNodeParam.toNode();
+
+    /** Add node */
+    this.nodes.push(node);
+    this.visitedNodes.push(node.id);
+
+    /** Add edges */
+    this.edges.push(...vizNodeParam.getEdges());
+
+    /** Traverse the children nodes */
+    const children = vizNodeParam.getChildren();
+    if (children !== undefined) {
+      children.forEach((child) => {
+        this.getNodesAndEdges(child);
+      });
+    }
+
+    /** Traverse the next node */
+    const nextNode = vizNodeParam.getNextNode();
+    if (nextNode !== undefined) {
+      this.getNodesAndEdges(nextNode);
+    }
+  }
+
+  private static getLayoutedElements(nodes: Node[], edges: Edge[]): NodesAndEdges {
+    const graph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+    graph.setGraph({
+      rankdir: 'TB',
+    });
+
+    edges.forEach((edge) => graph.setEdge(edge.source, edge.target));
+    nodes.forEach((node) => {
+      graph.setNode(node.id, { width: node.style!.width, height: node.style!.height });
+    });
+
+    Dagre.layout(graph);
+
+    return {
+      nodes: nodes.map((node) => {
+        let { x, y } = graph.node(node.id);
+
+        /** Position child node relatively to its parent */
+        if (node.parentNode) {
+          const parentNode = graph.node(node.parentNode);
+          if (parentNode) {
+            x = x - parentNode.x;
+            y = y - parentNode.y;
+          }
+        }
+
+        return { ...node, position: { x, y } };
+      }),
+      edges,
+    };
+  }
+}

--- a/packages/ui/src/components/Visualization/Canvas/index.ts
+++ b/packages/ui/src/components/Visualization/Canvas/index.ts
@@ -1,0 +1,1 @@
+export * from './Canvas';

--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useState } from 'react';
+import { ReactFlowProvider } from 'reactflow';
+import { CamelRoute } from '../../models/camel-entities';
+import { camelRoute } from '../../stubs/camel-route';
+import { Canvas } from './Canvas';
 import './Visualization.scss';
 
 interface CanvasProps {
@@ -6,5 +10,13 @@ interface CanvasProps {
 }
 
 export const Visualization: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
-  return <div className={`canvasSurface ${props.className ?? ''}`}>Visualization</div>;
+  const [entities] = useState<CamelRoute[]>([camelRoute]);
+
+  return (
+    <div className={`canvasSurface ${props.className ?? ''}`}>
+      <ReactFlowProvider>
+        <Canvas entities={entities} />
+      </ReactFlowProvider>
+    </div>
+  );
 };


### PR DESCRIPTION
### Context
This is the first iteration of the Visualization component, there are still some rough edges but it will serve as an intermediate step to move forward.

### Pending issues
- [ ] Add tests for new classes

### Known issues
1. The icons are missing
2. Better node labeling is required
3. `when` and `otherwise` properties are nodes instead of simply tags in edges. This is because at some point, we would like to turn them into containers

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/005847fd-5a69-4a19-9601-45e67a5d2d03) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/28bac7a2-ef13-45c9-aaad-22c9b15e5e04) |

