### PR TITLE
feat(viz): Use @patternfly/react-topology to render a route

### DIFF
--- a/packages/ui/jest-setup.ts
+++ b/packages/ui/jest-setup.ts
@@ -1,2 +1,8 @@
 import '@testing-library/jest-dom';
 // import '@testing-library/jest-dom/extend-expect'
+
+beforeAll(() => {
+  jest
+    .spyOn(global, 'crypto', 'get')
+    .mockImplementation(() => ({ getRandomValues: () => [12345678] }) as unknown as Crypto);
+});

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -1,0 +1,94 @@
+import {
+  GRAPH_LAYOUT_END_EVENT,
+  Model,
+  SELECTION_EVENT,
+  TopologyControlBar,
+  TopologyView,
+  VisualizationProvider,
+  VisualizationSurface,
+  action,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+} from '@patternfly/react-topology';
+import { FunctionComponent, PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import { CamelRoute } from '../../../models/camel-entities';
+import { CanvasService } from './canvas.service';
+import { CanvasEdge, CanvasNode } from './canvas.models';
+
+interface CanvasProps {
+  contextToolbar?: React.ReactNode;
+  entities: CamelRoute[];
+}
+
+export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const controller = useMemo(() => {
+    const newController = CanvasService.createController();
+    newController.addEventListener(SELECTION_EVENT, setSelectedIds);
+    newController.addEventListener(GRAPH_LAYOUT_END_EVENT, () =>
+      /** TODO: Schedule the layouting in a better fashion */
+      setTimeout(() => {
+        newController.getGraph().fit(80);
+      }, 100),
+    );
+    return newController;
+  }, []);
+
+  /** Draw graph */
+  useEffect(() => {
+    if (!Array.isArray(props.entities)) return;
+
+    const nodes: CanvasNode[] = [];
+    const edges: CanvasEdge[] = [];
+
+    props.entities.forEach((entity) => {
+      const { nodes: childNodes, edges: childEdges } = CanvasService.getFlowDiagram(entity.toVizNode());
+      nodes.push(...childNodes);
+      edges.push(...childEdges);
+    });
+
+    const model: Model = {
+      nodes,
+      edges,
+      graph: {
+        id: 'g1',
+        type: 'graph',
+        layout: CanvasService.DEFAULT_LAYOUT,
+      },
+    };
+
+    controller.fromModel(model, false);
+  }, [controller, props.entities]);
+
+  return (
+    <TopologyView
+      contextToolbar={props.contextToolbar}
+      controlBar={
+        <TopologyControlBar
+          controlButtons={createTopologyControlButtons({
+            ...defaultControlButtonsOptions,
+            zoomInCallback: action(() => {
+              controller.getGraph().scaleBy(4 / 3);
+            }),
+            zoomOutCallback: action(() => {
+              controller.getGraph().scaleBy(0.75);
+            }),
+            fitToScreenCallback: action(() => {
+              controller.getGraph().fit(80);
+            }),
+            resetViewCallback: action(() => {
+              controller.getGraph().reset();
+              controller.getGraph().layout();
+            }),
+            legend: false,
+          })}
+        />
+      }
+    >
+      <VisualizationProvider controller={controller}>
+        <VisualizationSurface state={{ selectedIds }} />
+      </VisualizationProvider>
+    </TopologyView>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
@@ -1,0 +1,27 @@
+import { EdgeModel, NodeModel } from '@patternfly/react-topology';
+
+export const enum LayoutType {
+  BreadthFirst = 'BreadthFirst',
+  Cola = 'Cola',
+  ColaNoForce = 'ColaNoForce',
+  Concentric = 'Concentric',
+  Dagre = 'Dagre',
+  Force = 'Force',
+  Grid = 'Grid',
+  ColaGroups = 'ColaGroups',
+}
+
+/**
+ * The intention of these types is to isolate the usage of the
+ * underlying rendering library tokens
+ */
+export interface CanvasNode extends NodeModel {
+  parentNode?: string;
+}
+
+export interface CanvasEdge extends EdgeModel {
+  source: string;
+  target: string;
+}
+
+export type CanvasNodesAndEdges = { nodes: CanvasNode[]; edges: CanvasEdge[] };

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -1,0 +1,309 @@
+import {
+  BreadthFirstLayout,
+  ColaLayout,
+  ConcentricLayout,
+  DagreLayout,
+  DefaultEdge,
+  DefaultGroup,
+  DefaultNode,
+  EdgeAnimationSpeed,
+  EdgeStyle,
+  ForceLayout,
+  GraphComponent,
+  GridLayout,
+  ModelKind,
+  Visualization,
+} from '@patternfly/react-topology';
+import { VisualizationNode } from '../../../models/visualization';
+import { LayoutType } from './canvas.models';
+import { CanvasService } from './canvas.service';
+
+describe('CanvasService', () => {
+  const DEFAULT_NODE_PROPS = {
+    type: 'node',
+    data: undefined,
+    shape: CanvasService.DEFAULT_NODE_SHAPE,
+    width: CanvasService.DEFAULT_NODE_DIAMETER,
+    height: CanvasService.DEFAULT_NODE_DIAMETER,
+  };
+
+  const DEFAULT_EDGE_PROPS = {
+    type: 'edge',
+    edgeStyle: EdgeStyle.dashed,
+    animationSpeed: EdgeAnimationSpeed.medium,
+  };
+
+  it('should start with an empty nodes array', () => {
+    expect(CanvasService.nodes).toEqual([]);
+  });
+
+  it('should start with an empty edges array', () => {
+    expect(CanvasService.edges).toEqual([]);
+  });
+
+  it('should allow consumers to create a new controller and register its factories', () => {
+    const layoutFactorySpy = jest.spyOn(Visualization.prototype, 'registerLayoutFactory');
+    const componentFactorySpy = jest.spyOn(Visualization.prototype, 'registerComponentFactory');
+
+    const controller = CanvasService.createController();
+
+    expect(controller).toBeInstanceOf(Visualization);
+    expect(layoutFactorySpy).toHaveBeenCalledWith(CanvasService.baselineLayoutFactory);
+    expect(componentFactorySpy).toHaveBeenCalledWith(CanvasService.baselineComponentFactory);
+  });
+
+  describe('baselineComponentFactory', () => {
+    it('should return the correct component for a group', () => {
+      const component = CanvasService.baselineComponentFactory({} as ModelKind, 'group');
+
+      expect(component).toEqual(DefaultGroup);
+    });
+
+    it('should return the correct component for a graph', () => {
+      const component = CanvasService.baselineComponentFactory(ModelKind.graph, 'graph');
+
+      expect(component).toEqual(GraphComponent);
+    });
+
+    it('should return the correct component for a node', () => {
+      const component = CanvasService.baselineComponentFactory(ModelKind.node, 'node');
+
+      expect(component).toEqual(DefaultNode);
+    });
+
+    it('should return the correct component for an edge', () => {
+      const component = CanvasService.baselineComponentFactory(ModelKind.edge, 'edge');
+
+      expect(component).toEqual(DefaultEdge);
+    });
+
+    it('should return undefined for an unknown type', () => {
+      const component = CanvasService.baselineComponentFactory({} as ModelKind, 'unknown');
+
+      expect(component).toBeUndefined();
+    });
+  });
+
+  it.each([
+    [LayoutType.BreadthFirst, BreadthFirstLayout],
+    [LayoutType.Cola, ColaLayout],
+    [LayoutType.ColaNoForce, ColaLayout],
+    [LayoutType.ColaGroups, ColaLayout],
+    [LayoutType.Concentric, ConcentricLayout],
+    [LayoutType.Dagre, DagreLayout],
+    [LayoutType.Force, ForceLayout],
+    [LayoutType.Grid, GridLayout],
+    ['unknown' as LayoutType, ColaLayout],
+  ] as const)('baselineLayoutFactory [%s]', (type, layout) => {
+    const newController = CanvasService.createController();
+    newController.fromModel(
+      {
+        nodes: [],
+        edges: [],
+        graph: {
+          id: 'g1',
+          type: 'graph',
+          layout: CanvasService.DEFAULT_LAYOUT,
+        },
+      },
+      false,
+    );
+    const layoutFactory = CanvasService.baselineLayoutFactory(type, newController.getGraph());
+
+    expect(layoutFactory).toBeInstanceOf(layout);
+  });
+
+  describe('getFlowDiagram', () => {
+    it('should return nodes and edges for a simple VisualizationNode', () => {
+      const vizNode = new VisualizationNode('node');
+
+      const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
+
+      expect(nodes).toEqual([
+        {
+          id: 'node-1234',
+          label: 'node',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+      ]);
+      expect(edges).toEqual([]);
+    });
+
+    it('should return nodes and edges for a two-nodes VisualizationNode', () => {
+      const vizNode = new VisualizationNode('node');
+      const childNode = new VisualizationNode('child');
+      vizNode.addChild(childNode);
+
+      const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
+
+      expect(nodes).toEqual([
+        {
+          id: 'node-1234',
+          label: 'node',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'child-1234',
+          label: 'child',
+          parentNode: 'node-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+      ]);
+      expect(edges).toEqual([
+        {
+          id: 'node-1234-to-child-1234',
+          source: 'node-1234',
+          target: 'child-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+      ]);
+    });
+
+    it('should return nodes and edges for a multiple nodes VisualizationNode', () => {
+      const vizNode = new VisualizationNode('node');
+
+      const setHeaderNode = new VisualizationNode('set-header');
+      vizNode.setNextNode(setHeaderNode);
+      setHeaderNode.setPreviousNode(vizNode);
+
+      const choiceNode = new VisualizationNode('choice');
+      setHeaderNode.setNextNode(choiceNode);
+      choiceNode.setPreviousNode(setHeaderNode);
+
+      const directNode = new VisualizationNode('direct');
+      choiceNode.setNextNode(directNode);
+      directNode.setPreviousNode(choiceNode);
+
+      const whenNode = new VisualizationNode('when');
+      choiceNode.addChild(whenNode);
+
+      const otherwiseNode = new VisualizationNode('otherwise');
+      choiceNode.addChild(otherwiseNode);
+
+      const whenLeafNode = new VisualizationNode('when-leaf');
+      whenNode.addChild(whenLeafNode);
+
+      const processNode = new VisualizationNode('process');
+      otherwiseNode.addChild(processNode);
+      const logNode = new VisualizationNode('log');
+      processNode.addChild(logNode);
+
+      const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
+
+      expect(nodes).toEqual([
+        {
+          id: 'node-1234',
+          label: 'node',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'set-header-1234',
+          label: 'set-header',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'choice-1234',
+          label: 'choice',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'when-1234',
+          label: 'when',
+          parentNode: 'choice-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'when-leaf-1234',
+          label: 'when-leaf',
+          parentNode: 'when-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'otherwise-1234',
+          label: 'otherwise',
+          parentNode: 'choice-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'process-1234',
+          label: 'process',
+          parentNode: 'otherwise-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'log-1234',
+          label: 'log',
+          parentNode: 'process-1234',
+          ...DEFAULT_NODE_PROPS,
+        },
+        {
+          id: 'direct-1234',
+          label: 'direct',
+          parentNode: undefined,
+          ...DEFAULT_NODE_PROPS,
+        },
+      ]);
+      expect(edges).toEqual([
+        {
+          id: 'node-1234-to-set-header-1234',
+          source: 'node-1234',
+          target: 'set-header-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'set-header-1234-to-choice-1234',
+          source: 'set-header-1234',
+          target: 'choice-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'choice-1234-to-when-1234',
+          source: 'choice-1234',
+          target: 'when-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'when-1234-to-when-leaf-1234',
+          source: 'when-1234',
+          target: 'when-leaf-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'choice-1234-to-otherwise-1234',
+          source: 'choice-1234',
+          target: 'otherwise-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'otherwise-1234-to-process-1234',
+          source: 'otherwise-1234',
+          target: 'process-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'process-1234-to-log-1234',
+          source: 'process-1234',
+          target: 'log-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'when-leaf-1234-to-direct-1234',
+          source: 'when-leaf-1234',
+          target: 'direct-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+        {
+          id: 'log-1234-to-direct-1234',
+          source: 'log-1234',
+          target: 'direct-1234',
+          ...DEFAULT_EDGE_PROPS,
+        },
+      ]);
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -1,0 +1,184 @@
+import {
+  BreadthFirstLayout,
+  ColaGroupsLayout,
+  ColaLayout,
+  ConcentricLayout,
+  DagreLayout,
+  DefaultEdge,
+  DefaultGroup,
+  DefaultNode,
+  EdgeAnimationSpeed,
+  EdgeStyle,
+  ForceLayout,
+  Graph,
+  GraphComponent,
+  GridLayout,
+  Layout,
+  ModelKind,
+  NodeModel,
+  NodeShape,
+  Visualization,
+} from '@patternfly/react-topology';
+import { VisualizationNode } from '../../../models/visualization';
+import { CanvasEdge, CanvasNode, CanvasNodesAndEdges, LayoutType } from './canvas.models';
+
+export class CanvasService {
+  static readonly DEFAULT_LAYOUT = LayoutType.Dagre;
+  static readonly DEFAULT_NODE_SHAPE = NodeShape.ellipse;
+  static readonly DEFAULT_NODE_DIAMETER = 75;
+  static readonly DEFAULT_GROUP_PADDING = 50;
+
+  static nodes: NodeModel[] = [];
+  static edges: CanvasEdge[] = [];
+  private static visitedNodes: string[] = [];
+
+  static createController(): Visualization {
+    const newController = new Visualization();
+
+    newController.registerLayoutFactory(this.baselineLayoutFactory);
+    newController.registerComponentFactory(this.baselineComponentFactory);
+
+    return newController;
+  }
+
+  static baselineComponentFactory(kind: ModelKind, type: string) {
+    switch (type) {
+      case 'group':
+        return DefaultGroup;
+      default:
+        switch (kind) {
+          case ModelKind.graph:
+            return GraphComponent;
+          case ModelKind.node:
+            return DefaultNode;
+          case ModelKind.edge:
+            return DefaultEdge;
+          default:
+            return undefined;
+        }
+    }
+  }
+
+  static baselineLayoutFactory(type: string, graph: Graph): Layout | undefined {
+    switch (type) {
+      case LayoutType.BreadthFirst:
+        return new BreadthFirstLayout(graph);
+      case LayoutType.Cola:
+        return new ColaLayout(graph);
+      case LayoutType.ColaNoForce:
+        return new ColaLayout(graph, { layoutOnDrag: false });
+      case LayoutType.Concentric:
+        return new ConcentricLayout(graph);
+      case LayoutType.Dagre:
+        return new DagreLayout(graph, { rankdir: 'TB' });
+      case LayoutType.Force:
+        return new ForceLayout(graph);
+      case LayoutType.Grid:
+        return new GridLayout(graph);
+      case LayoutType.ColaGroups:
+        return new ColaGroupsLayout(graph, { layoutOnDrag: false });
+      default:
+        return new ColaLayout(graph, { layoutOnDrag: false });
+    }
+  }
+
+  static getFlowDiagram(vizNode: VisualizationNode): CanvasNodesAndEdges {
+    this.nodes = [];
+    this.edges = [];
+    this.visitedNodes = [];
+    this.appendNodesAndEdges(vizNode);
+
+    return { nodes: this.nodes, edges: this.edges };
+  }
+
+  /** Method for iterating over all the VisualizationNode and its children using a depth-first algorithm */
+  private static appendNodesAndEdges(vizNodeParam: VisualizationNode): void {
+    if (this.visitedNodes.includes(vizNodeParam.id)) {
+      return;
+    }
+
+    const node = this.getCanvasNode(vizNodeParam);
+
+    /** Add node */
+    this.nodes.push(node);
+    this.visitedNodes.push(node.id);
+
+    /** Add edges */
+    this.edges.push(...this.getEdgesFromVizNode(vizNodeParam));
+
+    /** Traverse the children nodes */
+    const children = vizNodeParam.getChildren();
+    if (children !== undefined) {
+      children.forEach((child) => {
+        this.appendNodesAndEdges(child);
+      });
+    }
+
+    /** Traverse the next node */
+    const nextNode = vizNodeParam.getNextNode();
+    if (nextNode !== undefined) {
+      this.appendNodesAndEdges(nextNode);
+    }
+  }
+
+  private static getCanvasNode(vizNodeParam: VisualizationNode): CanvasNode {
+    /** Join the parent if exist to form a group */
+    const parentNode =
+      vizNodeParam.getParentNode()?.getChildren() !== undefined ? vizNodeParam.getParentNode()?.id : undefined;
+
+    return this.getNode(vizNodeParam.id, { label: vizNodeParam.label, parentNode });
+  }
+
+  private static getEdgesFromVizNode(vizNodeParam: VisualizationNode): CanvasEdge[] {
+    const edges: CanvasEdge[] = [];
+
+    /** Connect to previous node if it doesn't have children */
+    if (vizNodeParam.getPreviousNode() !== undefined && vizNodeParam.getPreviousNode()?.getChildren() === undefined) {
+      edges.push(this.getEdge(vizNodeParam.getPreviousNode()!.id, vizNodeParam.id));
+    }
+
+    /** Connect to the parent if there is no previous node */
+    if (vizNodeParam.getParentNode() !== undefined && vizNodeParam.getPreviousNode() === undefined) {
+      edges.push(this.getEdge(vizNodeParam.getParentNode()!.id, vizNodeParam.id));
+    }
+
+    /** Connect to each leaf of the previous node */
+    if (vizNodeParam.getPreviousNode() !== undefined && vizNodeParam.getPreviousNode()?.getChildren() !== undefined) {
+      const leafNodesIds: string[] = [];
+      vizNodeParam.getPreviousNode()!.populateLeafNodesIds(leafNodesIds);
+
+      leafNodesIds.forEach((leafNodeId) => {
+        edges.push(this.getEdge(leafNodeId, vizNodeParam.id));
+      });
+    }
+
+    return edges;
+  }
+
+  private static getNode(
+    id: string,
+    options: { label?: string; parentNode?: string; data?: Record<string, string> } = {},
+  ): CanvasNode {
+    return {
+      id,
+      type: 'node',
+      label: options.label ?? id,
+      parentNode: options.parentNode,
+      data: options.data,
+      width: this.DEFAULT_NODE_DIAMETER,
+      height: this.DEFAULT_NODE_DIAMETER,
+      shape: this.DEFAULT_NODE_SHAPE,
+    };
+  }
+
+  private static getEdge(source: string, target: string): CanvasEdge {
+    return {
+      id: `${source}-to-${target}`,
+      type: 'edge',
+      source,
+      target,
+      edgeStyle: EdgeStyle.dashed,
+      animationSpeed: EdgeAnimationSpeed.medium,
+    };
+  }
+}

--- a/packages/ui/src/components/Visualization/Canvas/index.ts
+++ b/packages/ui/src/components/Visualization/Canvas/index.ts
@@ -1,0 +1,1 @@
+export * from './Canvas';

--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useState } from 'react';
+import { ReactFlowProvider } from 'reactflow';
+import { CamelRoute } from '../../models/camel-entities';
+import { camelRoute } from '../../stubs/camel-route';
+import { Canvas } from './Canvas';
 import './Visualization.scss';
 
 interface CanvasProps {
@@ -6,5 +10,13 @@ interface CanvasProps {
 }
 
 export const Visualization: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
-  return <div className={`canvasSurface ${props.className ?? ''}`}>Visualization</div>;
+  const [entities] = useState<CamelRoute[]>([camelRoute]);
+
+  return (
+    <div className={`canvasSurface ${props.className ?? ''}`}>
+      <ReactFlowProvider>
+        <Canvas entities={entities} />
+      </ReactFlowProvider>
+    </div>
+  );
 };

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -1,5 +1,4 @@
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
-import { Edge, Node } from 'reactflow';
 
 export class VisualizationNode<T = unknown> {
   readonly id: string;
@@ -23,7 +22,7 @@ export class VisualizationNode<T = unknown> {
     return this.parentNode;
   }
 
-  setParentNode(parentNode: VisualizationNode) {
+  setParentNode(parentNode?: VisualizationNode) {
     this.parentNode = parentNode;
   }
 
@@ -62,72 +61,12 @@ export class VisualizationNode<T = unknown> {
     const index = this.children?.findIndex((node) => node.id === child.id);
 
     if (index !== undefined && index > -1) {
+      this.children?.[index].setParentNode(undefined);
       this.children?.splice(index, 1);
     }
   }
 
-  toNode(): Node {
-    /** Check if it's the first node */
-    const type = this.parentNode === undefined && this.previousNode === undefined ? 'input' : 'default';
-
-    /** Join the parent if exist to form a group */
-    const parentNode = this.parentNode?.children !== undefined ? this.parentNode.toNode().id : undefined;
-
-    return {
-      id: this.id,
-      type,
-      parentNode,
-      data: { label: this.label },
-      position: { x: 0, y: 0 },
-      style: { borderRadius: '20px', padding: '10px', width: 150, height: 40 },
-    };
-  }
-
-  getEdges(): Edge[] {
-    const edges: Edge[] = [];
-
-    /** Connect to previous node if it doesn't have children */
-    if (this.previousNode !== undefined && this.previousNode.children === undefined) {
-      edges.push({
-        id: `${this.previousNode.id}-to-${this.id}`,
-        source: this.previousNode.id,
-        target: this.id,
-        type: 'smoothstep',
-        animated: true,
-      });
-    }
-
-    /** Connect to the parent if there is no previous node */
-    if (this.parentNode !== undefined && this.previousNode === undefined) {
-      edges.push({
-        id: `${this.parentNode.id}-to-${this.id}`,
-        source: this.parentNode.id,
-        target: this.id,
-        type: 'smoothstep',
-        animated: true,
-      });
-    }
-
-    /** Connect to each leaf of the previous node */
-    if (this.previousNode !== undefined && this.previousNode.children !== undefined) {
-      const leafNodesIds: string[] = [];
-      this.previousNode.populateLeafNodesIds(leafNodesIds);
-
-      leafNodesIds.forEach((leafNodeId) => {
-        edges.push({
-          id: `${leafNodeId}-to-${this.id}`,
-          source: leafNodeId,
-          target: this.id,
-          type: 'smoothstep',
-          animated: true,
-        });
-      });
-    }
-
-    return edges;
-  }
-
-  private populateLeafNodesIds(ids: string[]): void {
+  populateLeafNodesIds(ids: string[]): void {
     /** If this node doesn't have a next node neither children, it can be considered a leaf node */
     if (this.nextNode === undefined && this.children === undefined) {
       ids.push(this.id);


### PR DESCRIPTION
### Context
This pull request adds the first iteration of the Visualization component. It leverages [@patternfly/react-topology](https://www.patternfly.org/topology/getting-started) as an underlying rendering and layout library.

This pull request supersedes #63
Fixes: https://github.com/KaotoIO/kaoto-next/issues/34

### Known issues
Only `Camel Routes` are supported at this stage. In order to support other flow types, the transformation from said flow to `VisualizationNode` needs to be implemented.

### Next steps
1. Work on the Source Code editor component in order to allow multiple and different flows to test in-depth the `VisualizationComponent`.
2. Add the support for the remaining flows, f.i. `Integration`, `Kamelet`, `KameletBinding` and `Pipe`

### Screenshot
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/485267cd-2d15-425f-bd4d-f1332f6bb404)
