### PR TITLE
chore: Use 4.1.0-SNAPSHOT Camel YAML DSL schema

### DIFF
--- a/packages/camel-catalog/assembly/pom.xml
+++ b/packages/camel-catalog/assembly/pom.xml
@@ -7,7 +7,6 @@
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <groupId>io.kaoto</groupId>
   <artifactId>kaoto-camel-catalog</artifactId>
   <packaging>pom</packaging>
   <name>kaoto-camel-catalog</name>
@@ -58,54 +57,20 @@
               <outputDirectory>${inputDirectory}</outputDirectory>
               <includes>kamelets/*</includes>
             </artifactItem>
-            <!-- TODO: Uncomment when Camel K CRDs are available in Maven Central
-                 https://github.com/apache/camel-k/issues/4655
             <artifactItem>
               <groupId>org.apache.camel.k</groupId>
               <artifactId>camel-k-crds</artifactId>
               <version>${version.camel-k-crds}</version>
-              <outputDirectory>${inputDirectory}/camel-k</outputDirectory>
-              <includes>**/*.yaml</includes>
+              <outputDirectory>${inputDirectory}/crds</outputDirectory>
+              <includes>
+                camel.apache.org_integrations.yaml,
+                camel.apache.org_kameletbindings.yaml,
+                camel.apache.org_kamelets.yaml,
+                camel.apache.org_pipes.yaml
+              </includes>
             </artifactItem>
-            -->
           </artifactItems>
         </configuration>
-      </plugin>
-      <!-- TODO: A temporary workaround to download Camel K CRDs from GitHub
-           https://github.com/apache/camel-k/issues/4655 -->
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>${version.maven-antrun-plugin}</version>
-        <executions>
-          <execution>
-            <id>download-files</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <mkdir dir="${inputDirectory}/crds"/>
-                <get src="https://raw.githubusercontent.com/apache/camel-k/v2.0.0/config/crd/bases/camel.apache.org_integrations.yaml"
-                     dest="${inputDirectory}/crds/integration.yaml"
-                     verbose="true"
-                     usetimestamp="true"/>
-                <get src="https://raw.githubusercontent.com/apache/camel-k/v2.0.0/config/crd/bases/camel.apache.org_kameletbindings.yaml"
-                     dest="${inputDirectory}/crds/kameletbinding.yaml"
-                     verbose="true"
-                     usetimestamp="true"/>
-                <get src="https://raw.githubusercontent.com/apache/camel-k/v2.0.0/config/crd/bases/camel.apache.org_kamelets.yaml"
-                     dest="${inputDirectory}/crds/kamelet.yaml"
-                     verbose="true"
-                     usetimestamp="true"/>
-                <get src="https://raw.githubusercontent.com/apache/camel-k/v2.0.0/config/crd/bases/camel.apache.org_pipes.yaml"
-                     dest="${inputDirectory}/crds/pipe.yaml"
-                     verbose="true"
-                     usetimestamp="true"/>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.camel</groupId>
@@ -120,6 +85,7 @@
             </goals>
             <configuration>
               <kebabCase>false</kebabCase>
+              <additionalProperties>false</additionalProperties>
               <outputFile>${inputDirectory}/schema/camelYamlDsl.json</outputFile>
             </configuration>
           </execution>

--- a/packages/camel-catalog/pom.xml
+++ b/packages/camel-catalog/pom.xml
@@ -11,10 +11,37 @@
   </description>
   <url>https://kaoto.io</url>
 
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshots</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshots</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.camel>4.0.0</version.camel>
-    <version.camel-k-crds>2.0.0</version.camel-k-crds>
+    <version.camel>4.1.0-SNAPSHOT</version.camel>
+    <version.camel-k-crds>2.1.0-SNAPSHOT</version.camel-k-crds>
     <version.camel-kamelets>4.0.0-RC1</version.camel-kamelets>
     <version.jackson>2.15.2</version.jackson>
     <version.java>17</version.java>

--- a/packages/ui/src/models/camel-entities/flows/route.ts
+++ b/packages/ui/src/models/camel-entities/flows/route.ts
@@ -10,11 +10,11 @@ import { VisualizationNode } from '../../visualization';
 import { BaseCamelEntity, EntityType } from '../base-entity';
 import { CamelRouteStep } from './step';
 
-interface FromDefinition extends Exclude<CamelFromDefinition, 'steps'> {
+interface FromDefinition extends Omit<CamelFromDefinition, 'steps'> {
   steps: CamelRouteStep[];
 }
 
-interface RouteDefinition extends Exclude<CamelRouteDefinition, 'from'> {
+interface RouteDefinition extends Omit<CamelRouteDefinition, 'from'> {
   from: FromDefinition;
 }
 


### PR DESCRIPTION
Fixes: #93

Also use camel-k-crds maven artifact to get Camel K CRDs

Fixes: #69


I get some type error when building locally, looking into it
```
src/models/camel-entities/flows/route.ts(13,11): error TS2430: Interface 'FromDefinition' incorrectly extends interface 'import("/home/tomo/workspace/Kaoto/kaoto-next/packages/camel-catalog/dist/types/camelYamlDsl").FromDefinition'.
  Types of property 'steps' are incompatible.
    Type 'CamelRouteStep[]' is not assignable to type 'ProcessorDefinition[]'.
      Type 'CamelRouteStep' is not assignable to type 'ProcessorDefinition'.
        Type 'Step' has no properties in common with type 'ProcessorDefinition'.
src/models/camel-entities/flows/route.ts(17,11): error TS2430: Interface 'RouteDefinition' incorrectly extends interface 'import("/home/tomo/workspace/Kaoto/kaoto-next/packages/camel-catalog/dist/types/camelYamlDsl").RouteDefinition'.
  The types of 'from.steps' are incompatible between these types.
    Type 'CamelRouteStep[]' is not assignable to type 'ProcessorDefinition[]'
```