### PR TITLE
fix(build): Load camel catalog in GitHub pages

### DIFF
--- a/packages/ui/src/providers/catalog-schema-loader.provider.tsx
+++ b/packages/ui/src/providers/catalog-schema-loader.provider.tsx
@@ -46,7 +46,8 @@ export const CatalogSchemaLoaderProvider: FunctionComponent<PropsWithChildren> =
 };
 
 async function fetchCatalogFile(file: string) {
-  const response = await fetch(`${DEFAULT_CATALOG_PATH}/${file}`);
+  /** The `.` is required to support relative routes in GitHub pages */
+  const response = await fetch(`.${DEFAULT_CATALOG_PATH}/${file}`);
   return await response.json();
 }
 


### PR DESCRIPTION
### Context
Currently, `kaoto-next` is being deployed on GitHub pages under the following URL:

https://kaotoio.github.io/kaoto-next/

Since the `DEFAULT_CATALOG_PATH` is `/camel-catalog`, kaoto-next tries to load the catalog from:

https://kaotoio.github.io/

### Changes
The fix is to provide an initial `.` to instruct to download the catalog under the current location