### PR TITLE
fix(build): Build errors with node v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The next version of the UI for the Kaoto project.
 - [Camel Catalog and Supporting Schemas](#camel-catalog-and-supporting-schemas)
 
 ## Requirements
-- NodeJS (v18.x) [+info](https://nodejs.org/en)
+- NodeJS (v18.x or higher) [+info](https://nodejs.org/en)
 - Yarn (v3.x or higher) [+info](https://yarnpkg.com/getting-started/install)
 - OpenJDK (v17 or higher) [+info](https://developers.redhat.com/products/openjdk/download)
 

--- a/packages/camel-catalog/package.json
+++ b/packages/camel-catalog/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:mvn && yarn build:ts",
     "build:mvn": "./mvnw clean install",
-    "build:ts": "ts-node --esm ./src/json-schema-to-typescript.mts",
+    "build:ts": "node --loader ts-node/esm ./src/json-schema-to-typescript.mts",
     "clean": "yarn rimraf ./dist"
   },
   "devDependencies": {


### PR DESCRIPTION
### Context
Currently, there's a breaking change in node v20 that prevents ts-node to work as usual.

The workaround is to manually provide `ts-node/esm` as `custom loader` to node.

### Notes:
- [Node v20.0.0 release notes](https://nodejs.org/en/blog/release/v20.0.0)
- Related issue: https://github.com/TypeStrong/ts-node/issues/1997

fixes: https://github.com/KaotoIO/kaoto-next/issues/66