### PR TITLE
fix(build): Load Camel YAML schema in non root base path

### DIFF
--- a/packages/ui/src/components/SourceCode/SourceCode.tsx
+++ b/packages/ui/src/components/SourceCode/SourceCode.tsx
@@ -1,5 +1,4 @@
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
-import { editor } from 'monaco-editor';
+import { CodeEditor, CodeEditorProps, Language } from '@patternfly/react-code-editor';
 import { setDiagnosticsOptions } from 'monaco-yaml';
 import { FunctionComponent, Ref, useCallback, useEffect, useMemo, useRef } from 'react';
 import { EditorDidMount } from 'react-monaco-editor';
@@ -42,7 +41,7 @@ export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
     editor?.focus();
   }, []);
 
-  const options: Ref<editor.IStandaloneEditorConstructionOptions> = useRef({
+  const options: Ref<CodeEditorProps['options']> = useRef({
     selectOnLineNumbers: true,
     readOnly: false,
     scrollbar: {

--- a/packages/ui/src/providers/catalog-schema-loader.provider.tsx
+++ b/packages/ui/src/providers/catalog-schema-loader.provider.tsx
@@ -18,17 +18,17 @@ export const CatalogSchemaLoaderProvider: FunctionComponent<PropsWithChildren> =
     fetch(catalogIndex)
       .then((response) => response.json())
       .then((catalogIndex: CamelCatalogIndex) => {
-        const camelComponentsFiles = fetchCatalogFile(catalogIndex.catalogs.components.file);
-        const camelProcessorsFiles = fetchCatalogFile(catalogIndex.catalogs.models.file);
-        const kameletsFiles = fetchCatalogFile(catalogIndex.catalogs.kamelets.file);
+        const camelComponentsFiles = fetchFile(catalogIndex.catalogs.components.file);
+        const camelProcessorsFiles = fetchFile(catalogIndex.catalogs.models.file);
+        const kameletsFiles = fetchFile(catalogIndex.catalogs.kamelets.file);
 
         const schemaFiles = getSchemasFiles(catalogIndex.schemas);
 
         Promise.all([camelComponentsFiles, camelProcessorsFiles, kameletsFiles, Promise.all(schemaFiles)]).then(
           ([camelComponents, camelProcessors, kamelets, schemas]) => {
-            setCatalog(CatalogKind.Component, camelComponents);
-            setCatalog(CatalogKind.Processor, camelProcessors);
-            setCatalog(CatalogKind.Kamelet, kamelets);
+            setCatalog(CatalogKind.Component, camelComponents.body);
+            setCatalog(CatalogKind.Processor, camelProcessors.body);
+            setCatalog(CatalogKind.Kamelet, kamelets.body);
 
             CamelSchemasProcessor.getSchemas(schemas).forEach(setSchema);
 
@@ -45,22 +45,24 @@ export const CatalogSchemaLoaderProvider: FunctionComponent<PropsWithChildren> =
   );
 };
 
-async function fetchCatalogFile(file: string) {
+async function fetchFile(file: string) {
   /** The `.` is required to support relative routes in GitHub pages */
   const response = await fetch(`.${DEFAULT_CATALOG_PATH}/${file}`);
-  return await response.json();
+  const body = await response.json();
+
+  return { body, uri: response.url };
 }
 
 function getSchemasFiles(schemaFiles: CatalogEntry[]): Promise<Schema>[] {
   return schemaFiles.map(async (schemaDef) => {
-    const schema = await fetchCatalogFile(schemaDef.file);
+    const fetchedSchema = await fetchFile(schemaDef.file);
 
     return {
       name: schemaDef.name,
       tags: [],
       version: schemaDef.version,
-      uri: `${DEFAULT_CATALOG_PATH}/${schemaDef.file}`,
-      schema: schema,
+      uri: fetchedSchema.uri,
+      schema: fetchedSchema.body,
     };
   });
 }


### PR DESCRIPTION
### Context
`monaco-yaml` requires a valid `URI` to fetch the appropriate schema for the `monaco editor` and at the same time, it also uses it to determine the schema filename.

This commit uses the [resolved `URI` from the `fetch` call](https://github.com/KaotoIO/kaoto-next/pull/118/files#diff-77032d06eef9c517e8f18431ba19d26f52e6942d9e3a5a11133d07e999845e8eR53) when loading the schema to leverage relative paths when applicable, otherwise, deploying `kaoto-next` in environments like `GitHub Pages` in which the deployment is not at the root path, it will fail since it will use the wrong `URI`.

fixes: https://github.com/KaotoIO/kaoto-next/issues/109