### PR TITLE
chore: Expose internal components through dedicated entrypoint

### DIFF
--- a/packages/ui-tests/.storybook/main.ts
+++ b/packages/ui-tests/.storybook/main.ts
@@ -10,9 +10,10 @@ function getAbsolutePath(value: string): any {
   return dirname(require.resolve(join(value, 'package.json')));
 }
 const config: StorybookConfig = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: ['../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
     getAbsolutePath('@storybook/addon-links'),
+    getAbsolutePath('@storybook/addon-actions'),
     getAbsolutePath('@storybook/addon-essentials'),
     getAbsolutePath('@storybook/addon-onboarding'),
     getAbsolutePath('@storybook/addon-interactions'),

--- a/packages/ui-tests/stories/Navigation.stories.tsx
+++ b/packages/ui-tests/stories/Navigation.stories.tsx
@@ -1,4 +1,4 @@
-import { Navigation, Shell } from '@kaoto-next/ui';
+import { Navigation, Shell } from '@kaoto-next/ui/testing';
 import { StoryFn } from '@storybook/react';
 import { withRouter, reactRouterOutlet, reactRouterParameters } from 'storybook-addon-react-router-v6';
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
   "author": "The Kaoto Team",
   "license": "Apache License v2.0",
   "private": true,
+  "module": "./dist/lib/kaoto-next-ui.js",
   "main": "src/public-api.ts",
   "exports": {
     ".": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,10 +8,22 @@
   "license": "Apache License v2.0",
   "private": true,
   "main": "src/public-api.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/lib/kaoto-next-ui.js",
+      "require": "./dist/lib/kaoto-next-ui.umd.cjs"
+    },
+    "./testing": {
+      "import": "./dist/lib/kaoto-next-testing-ui.js",
+      "require": "./dist/lib/kaoto-next-testing-ui.umd.cjs"
+    }
+  },
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build --config vite.config.cjs",
-    "build:lib": "tsc && vite build --config vite.config.lib.ts",
+    "build:lib": "tsc && yarn build:public-lib && yarn build:testing-lib",
+    "build:public-lib": "vite build --config vite.config.lib.ts",
+    "build:testing-lib": "vite build --config vite.config.testing-lib.ts",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/ui/src/public-api.ts
+++ b/packages/ui/src/public-api.ts
@@ -2,4 +2,3 @@
 export * from './components/Catalog';
 export * from './components/PropertiesModal';
 export * from './components/Visualization';
-export * from './layout';

--- a/packages/ui/src/testing-api.ts
+++ b/packages/ui/src/testing-api.ts
@@ -1,0 +1,2 @@
+/** Internal components exported for testing only */
+export * from './layout';

--- a/packages/ui/vite.config.lib.ts
+++ b/packages/ui/vite.config.lib.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vite';
+import { UserConfig, defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export const getConfig = (): UserConfig => ({
   plugins: [react(), dts({ rollupTypes: true })],
   build: {
     outDir: './dist/lib',
@@ -25,3 +25,5 @@ export default defineConfig({
     },
   },
 });
+
+export default defineConfig(getConfig());

--- a/packages/ui/vite.config.testing-lib.ts
+++ b/packages/ui/vite.config.testing-lib.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import { getConfig } from './vite.config.lib';
+
+// https://vitejs.dev/config/
+const testingConfig = getConfig();
+testingConfig.build!.emptyOutDir = false;
+testingConfig.build!.lib = {
+  entry: './src/testing-api.ts',
+  name: '@kaoto-next/testing-ui',
+  fileName: 'kaoto-next-testing-ui',
+};
+
+export default defineConfig(testingConfig);


### PR DESCRIPTION
### Context
Currently, public and internal components are exposed through `@kaoto-next/ui` entrypoint, but this is not ideal, since there's no separation between components meant to be reused and components meant to be tested internally.

### Changes
Create a new entry point for `testing`

### Usage
1. For public components, the declaration should go in the `public-api.ts` file

2. For internal components that need to be exposed for testing, the `testing-api.ts` file should be used instead

The imports for testing components needs to be updated like the following:

```diff
- import { Navigation, Shell } from '@kaoto-next/ui';
+ import { Navigation, Shell } from '@kaoto-next/ui/testing';
```
