### PR TITLE
chore: remove reactflow

### DIFF
--- a/packages/ui-tests/.storybook/preview.ts
+++ b/packages/ui-tests/.storybook/preview.ts
@@ -5,7 +5,6 @@ import '@patternfly/patternfly/utilities/Display/display.css';
 import '@patternfly/patternfly/utilities/Flex/flex.css';
 import '@patternfly/patternfly/utilities/Sizing/sizing.css';
 import '@patternfly/patternfly/utilities/Spacing/spacing.css';
-import 'reactflow/dist/style.css';
 import '@kaoto-next/ui/testing-style.css';
 
 import type { Preview } from '@storybook/react';

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -49,7 +49,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
-    "reactflow": "^11.7.4",
     "start-server-and-test": "^2.0.0",
     "storybook-addon-react-router-v6": "^2.0.7",
     "storybook-fixtures": "0.12.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,6 @@
     "lint:fix": "yarn eslint \"src/**/*.{ts,tsx}\" --fix"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^1.0.2",
     "@kaoto-next/camel-catalog": "workspace:*",
     "@kie-tools/uniforms-patternfly": "^0.31.0",
     "@patternfly/patternfly": "^5.0.0",
@@ -52,7 +51,6 @@
     "react-dom": "^18.2.0",
     "react-monaco-editor": "^0.51.0",
     "react-router-dom": "^6.14.1",
-    "reactflow": "^11.8.3",
     "simple-zustand-devtools": "^1.1.0",
     "uniforms": "^4.0.0-alpha.0",
     "uniforms-bridge-json-schema": "^4.0.0-alpha.0",

--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { ReactFlowProvider } from 'reactflow';
 import { BaseVisualCamelEntity } from '../../models/camel-entities';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Canvas } from './Canvas';
@@ -15,9 +14,7 @@ export const Visualization: FunctionComponent<PropsWithChildren<CanvasProps>> = 
   return (
     <div className={`canvasSurface ${props.className ?? ''}`}>
       <ErrorBoundary fallback={<CanvasFallback />}>
-        <ReactFlowProvider>
-          <Canvas entities={props.entities} />
-        </ReactFlowProvider>
+        <Canvas entities={props.entities} />
       </ErrorBoundary>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,22 +1647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dagrejs/dagre@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@dagrejs/dagre@npm:1.0.2"
-  dependencies:
-    "@dagrejs/graphlib": 2.1.13
-  checksum: 6146ced6f8e946e83aeba8085967786c9c4e4fadbc94cfb2a6c48007cb8238e0c91e8a4385a7268bd4a5a55050fb2ac2f96d446ccd88de0f4d00a4970a9c2631
-  languageName: node
-  linkType: hard
-
-"@dagrejs/graphlib@npm:2.1.13":
-  version: 2.1.13
-  resolution: "@dagrejs/graphlib@npm:2.1.13"
-  checksum: 7d0732f78675ea1c25e54ad1fb2dcd3b8784705faba328bd44def6f372140197ccdf546d75c33db05555da9b288a00d67f34317215f64233b89e9e59bd79596a
-  languageName: node
-  linkType: hard
-
 "@discoveryjs/json-ext@npm:^0.5.3":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -2367,7 +2351,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-router-dom: ^6.14.1
-    reactflow: ^11.7.4
     start-server-and-test: ^2.0.0
     storybook: ^7.2.3
     storybook-addon-react-router-v6: ^2.0.7
@@ -2385,7 +2368,6 @@ __metadata:
     "@babel/preset-env": ^7.21.5
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
-    "@dagrejs/dagre": ^1.0.2
     "@kaoto-next/camel-catalog": "workspace:*"
     "@kie-tools/uniforms-patternfly": ^0.31.0
     "@patternfly/patternfly": ^5.0.0
@@ -2426,7 +2408,6 @@ __metadata:
     react-monaco-editor: ^0.51.0
     react-router-dom: ^6.14.1
     react-test-renderer: ^18.2.0
-    reactflow: ^11.8.3
     sass: ^1.63.6
     simple-zustand-devtools: ^1.1.0
     ts-node: ^10.9.1
@@ -3270,102 +3251,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
   checksum: aeec13b234a946052512d05239067d2d63422f9ec70bf2fe7acfd6b9196693fc33fbaf43c2667c167f777d90a095c6604eb487e0bce79e230b6df0f6cacd6a55
-  languageName: node
-  linkType: hard
-
-"@reactflow/background@npm:11.2.8":
-  version: 11.2.8
-  resolution: "@reactflow/background@npm:11.2.8"
-  dependencies:
-    "@reactflow/core": 11.8.3
-    classcat: ^5.0.3
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 85251e8e31bce5d984bda64475ebbd4ac256f40d85c1938dfd4af9fdf8814d1649e017026046d049772766bebe7a60fe9c6079d8708c62fd8434cf9af9ca728c
-  languageName: node
-  linkType: hard
-
-"@reactflow/controls@npm:11.1.19":
-  version: 11.1.19
-  resolution: "@reactflow/controls@npm:11.1.19"
-  dependencies:
-    "@reactflow/core": 11.8.3
-    classcat: ^5.0.3
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 0e2e94b5c329bf4764cff15c84aa4281ba5070ee57a0c93d0779d285be4bd7cf8904bb139e9c8120b8fe0f7a9beea60ceed9ed04e994b267bda5e3c25041d877
-  languageName: node
-  linkType: hard
-
-"@reactflow/core@npm:11.8.3":
-  version: 11.8.3
-  resolution: "@reactflow/core@npm:11.8.3"
-  dependencies:
-    "@types/d3": ^7.4.0
-    "@types/d3-drag": ^3.0.1
-    "@types/d3-selection": ^3.0.3
-    "@types/d3-zoom": ^3.0.1
-    classcat: ^5.0.3
-    d3-drag: ^3.0.0
-    d3-selection: ^3.0.0
-    d3-zoom: ^3.0.0
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 68b807a5866649e8f0799c7630579ce829127f9d4665e9507c29072ac78e29b4ad5a33c1d757e2b19dfdd9db82404fc10b858c6a047e91c9b567316ced89fb9f
-  languageName: node
-  linkType: hard
-
-"@reactflow/minimap@npm:11.6.3":
-  version: 11.6.3
-  resolution: "@reactflow/minimap@npm:11.6.3"
-  dependencies:
-    "@reactflow/core": 11.8.3
-    "@types/d3-selection": ^3.0.3
-    "@types/d3-zoom": ^3.0.1
-    classcat: ^5.0.3
-    d3-selection: ^3.0.0
-    d3-zoom: ^3.0.0
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 6364a9f40efbc7fcc0807febfa6ac21778bf67b8ab0d83775b50021dd872c9c3f7f1f4ac9acdb578fada5a207809e917c4b1e6e31348d21a6591f98b72b31e74
-  languageName: node
-  linkType: hard
-
-"@reactflow/node-resizer@npm:2.1.5":
-  version: 2.1.5
-  resolution: "@reactflow/node-resizer@npm:2.1.5"
-  dependencies:
-    "@reactflow/core": 11.8.3
-    classcat: ^5.0.4
-    d3-drag: ^3.0.0
-    d3-selection: ^3.0.0
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 58e366e979b746d620c919d2e3c84085f69ec6d94fef674e85737a43f226b90d2c3894d1eccdf969baf929b9965abde9ecee990125d713d1a1be1da5a5eac1ae
-  languageName: node
-  linkType: hard
-
-"@reactflow/node-toolbar@npm:1.2.7":
-  version: 1.2.7
-  resolution: "@reactflow/node-toolbar@npm:1.2.7"
-  dependencies:
-    "@reactflow/core": 11.8.3
-    classcat: ^5.0.3
-    zustand: ^4.4.1
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: c92e2cd8142375532522d755bf9bb2000e36509bb93e8b4c875b40a0237d50a2c6840179afb1f4007d803333e9bfe89f76ae3871a86e08cfbb5159af038b8339
   languageName: node
   linkType: hard
 
@@ -4886,7 +4771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-drag@npm:*, @types/d3-drag@npm:^3.0.1":
+"@types/d3-drag@npm:*":
   version: 3.0.3
   resolution: "@types/d3-drag@npm:3.0.3"
   dependencies:
@@ -5008,7 +4893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-selection@npm:*, @types/d3-selection@npm:^3.0.3":
+"@types/d3-selection@npm:*":
   version: 3.0.6
   resolution: "@types/d3-selection@npm:3.0.6"
   checksum: 01f9f3a41b98280947109911bcc6ebffff5c8c3e617695979c04ef9beef445a8cdc48a9fbdb3c9cff45a7345e83e8a5d6b346d7ceedca6ebc11dfd9717dbff6b
@@ -5054,7 +4939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-zoom@npm:*, @types/d3-zoom@npm:^3.0.1":
+"@types/d3-zoom@npm:*":
   version: 3.0.4
   resolution: "@types/d3-zoom@npm:3.0.4"
   dependencies:
@@ -6992,13 +6877,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classcat@npm:^5.0.3, classcat@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "classcat@npm:5.0.4"
-  checksum: 77373c58fa15ad2d4494b5c73c7ed2f859e7126227c357a3931e3f2a28e45dd9d8e779c1c8d3a8ba9ece833b21f14cd79160a7999973e28888d7e47f56c83170
-  languageName: node
-  linkType: hard
-
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -7576,7 +7454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-drag@npm:2 - 3, d3-drag@npm:3, d3-drag@npm:^3.0.0":
+"d3-drag@npm:2 - 3, d3-drag@npm:3":
   version: 3.0.0
   resolution: "d3-drag@npm:3.0.0"
   dependencies:
@@ -7741,7 +7619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-selection@npm:2 - 3, d3-selection@npm:3, d3-selection@npm:^3.0.0":
+"d3-selection@npm:2 - 3, d3-selection@npm:3":
   version: 3.0.0
   resolution: "d3-selection@npm:3.0.0"
   checksum: f4e60e133309115b99f5b36a79ae0a19d71ee6e2d5e3c7216ef3e75ebd2cb1e778c2ed2fa4c01bef35e0dcbd96c5428f5bd6ca2184fe2957ed582fde6841cbc5
@@ -7813,7 +7691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-zoom@npm:3, d3-zoom@npm:^3.0.0":
+"d3-zoom@npm:3":
   version: 3.0.0
   resolution: "d3-zoom@npm:3.0.0"
   dependencies:
@@ -13759,23 +13637,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reactflow@npm:^11.7.4, reactflow@npm:^11.8.3":
-  version: 11.8.3
-  resolution: "reactflow@npm:11.8.3"
-  dependencies:
-    "@reactflow/background": 11.2.8
-    "@reactflow/controls": 11.1.19
-    "@reactflow/core": 11.8.3
-    "@reactflow/minimap": 11.6.3
-    "@reactflow/node-resizer": 2.1.5
-    "@reactflow/node-toolbar": 1.2.7
-  peerDependencies:
-    react: ">=17"
-    react-dom: ">=17"
-  checksum: 805deb1ce920c17ca58fe5bb34dd3befe3a11476a496d3b71108488b6d702809a41a3802fcaa4148cd2b4998c5cccd4611b55a86f15437f0ccd7986ee1b8d970
-  languageName: node
-  linkType: hard
-
 "read-pkg-up@npm:^7.0.1":
   version: 7.0.1
   resolution: "read-pkg-up@npm:7.0.1"
@@ -16465,7 +16326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.3.9, zustand@npm:^4.4.1":
+"zustand@npm:^4.3.9":
   version: 4.4.1
   resolution: "zustand@npm:4.4.1"
   dependencies:


### PR DESCRIPTION
### Context
Since we're using `@patternfly/react-topology` for the `Visualization` component, there's no need to keep `reactflow` at the moment.