### PR TITLE
fix(gh-119) better way to refresh the Canvas component

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -22,17 +22,20 @@ interface CanvasProps {
 
 export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const controller = useMemo(() => CanvasService.createController(), []);
 
-  const controller = useMemo(() => {
-    const newController = CanvasService.createController();
-    newController.addEventListener(SELECTION_EVENT, setSelectedIds);
-    newController.addEventListener(GRAPH_LAYOUT_END_EVENT, () =>
-      /** TODO: Schedule the layouting in a better fashion */
-      setTimeout(() => {
-        newController.getGraph().fit(80);
-      }, 100),
-    );
-    return newController;
+  // Set up the controller one time
+  useEffect(() => {
+    const localController = controller;
+    const graphLayoutEndFn = () => {
+      localController.getGraph().fit(80);
+    };
+    localController.addEventListener(SELECTION_EVENT, setSelectedIds);
+    localController.addEventListener(GRAPH_LAYOUT_END_EVENT, graphLayoutEndFn);
+    return () => {
+      localController.removeEventListener(SELECTION_EVENT, setSelectedIds);
+      localController.removeEventListener(GRAPH_LAYOUT_END_EVENT, graphLayoutEndFn);
+    };
   }, []);
 
   /** Draw graph */
@@ -72,7 +75,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props)
               controller.getGraph().scaleBy(4 / 3);
             }),
             zoomOutCallback: action(() => {
-              controller.getGraph().scaleBy(0.75);
+              controller.getGraph().scaleBy(3 / 4);
             }),
             fitToScreenCallback: action(() => {
               controller.getGraph().fit(80);

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -14,6 +14,7 @@ import {
   GraphComponent,
   GridLayout,
   Layout,
+  Model,
   ModelKind,
   NodeModel,
   NodeShape,
@@ -37,6 +38,15 @@ export class CanvasService {
 
     newController.registerLayoutFactory(this.baselineLayoutFactory);
     newController.registerComponentFactory(this.baselineComponentFactory);
+
+    const defaultModel: Model = {
+      graph: {
+        id: 'default',
+        type: 'graph',
+      },
+    };
+
+    newController.fromModel(defaultModel, false);
 
     return newController;
   }


### PR DESCRIPTION
Fix for https://github.com/KaotoIO/kaoto-next/issues/119

Updated the way the diagram controller is created. The way the diagram is loaded now:

![Peek 2023-09-19 08-40](https://github.com/KaotoIO/kaoto-next/assets/4180208/cdba03f3-1ca7-4e9f-a5f3-8b067b9b06db)
