### PR TITLE
fix: Let UI use maven generated YAML DSL sub schema

### DIFF
--- a/packages/camel-catalog/assembly/src/test/java/io/kaoto/camelcatalog/IndexTest.java
+++ b/packages/camel-catalog/assembly/src/test/java/io/kaoto/camelcatalog/IndexTest.java
@@ -21,33 +21,26 @@ public class IndexTest extends CamelCatalogTestSupport {
         assertTrue(catalogs.has("dataformats"));
         assertTrue(index.has("schemas"));
         var schemas = index.withArray("/schemas");
-        List<String> props = new ArrayList<>();
-        List<String> crds = new ArrayList<>();
-        schemas.forEach(schema -> {
-            var tokens = schema.get("file").asText().split("-");
-            if ("camelYamlDsl".equals(tokens[0]) && !tokens[1].matches("^\\d+.*")) {
-                props.add(tokens[1]);
-            } else if ("crd".equals(tokens[0])) {
-                crds.add(tokens[2]);
-            }
-        });
-        assertTrue(props.contains("beans"));
-        assertTrue(props.contains("errorHandler"));
-        assertTrue(props.contains("from"));
-        assertTrue(props.contains("intercept"));
-        assertTrue(props.contains("interceptFrom"));
-        assertTrue(props.contains("interceptSendToEndpoint"));
-        assertTrue(props.contains("onCompletion"));
-        assertTrue(props.contains("onException"));
-        assertTrue(props.contains("rest"));
-        assertTrue(props.contains("restConfiguration"));
-        assertTrue(props.contains("route"));
-        assertTrue(props.contains("routeConfiguration"));
-        assertTrue(props.contains("routeTemplate"));
-        assertTrue(props.contains("templatedRoute"));
-        assertTrue(crds.contains("integrations"));
-        assertTrue(crds.contains("kamelets"));
-        assertTrue(crds.contains("kameletbindings"));
-        assertTrue(crds.contains("pipes"));
+        List<String> names = new ArrayList<>();
+        schemas.forEach(schema -> names.add(schema.get("name").asText()));
+        assertTrue(names.contains("camelYamlDsl"));
+        assertTrue(names.contains("beans"));
+        assertTrue(names.contains("errorHandler"));
+        assertTrue(names.contains("from"));
+        assertTrue(names.contains("intercept"));
+        assertTrue(names.contains("interceptFrom"));
+        assertTrue(names.contains("interceptSendToEndpoint"));
+        assertTrue(names.contains("onCompletion"));
+        assertTrue(names.contains("onException"));
+        assertTrue(names.contains("rest"));
+        assertTrue(names.contains("restConfiguration"));
+        assertTrue(names.contains("route"));
+        assertTrue(names.contains("routeConfiguration"));
+        assertTrue(names.contains("routeTemplate"));
+        assertTrue(names.contains("templatedRoute"));
+        assertTrue(names.contains("Integration"));
+        assertTrue(names.contains("Kamelet"));
+        assertTrue(names.contains("KameletBinding"));
+        assertTrue(names.contains("Pipe"));
     }
 }

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/Index.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/Index.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-record Entry(String name, String version, String file) {}
+record Entry(String name, String description, String version, String file) {}
 
 public class Index {
     public static final String COMPONENTS = "components";

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/KaotoCamelCatalogMojo.java
@@ -129,7 +129,11 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             getLog().error(e);
             return;
         }
-        var indexEntry = new Entry("Camel YAML DSL JSON schema", camelVersion, outputFileName);
+        var indexEntry = new Entry(
+                "camelYamlDsl",
+                "Camel YAML DSL JSON schema",
+                camelVersion,
+                outputFileName);
         index.getSchemas().add(indexEntry);
 
         try {
@@ -177,7 +181,11 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             var writer = new FileWriter(output.toFile());
             JsonGenerator gen = jsonFactory.createGenerator(writer).useDefaultPrettyPrinter();
             jsonMapper.writeTree(gen, answer);
-            var indexEntry = new Entry("Camel YAML DSL JSON schema: " + propName, camelVersion, outputFileName);
+            var indexEntry = new Entry(
+                    propName,
+                    "Camel YAML DSL JSON schema: " + propName,
+                    camelVersion,
+                    outputFileName);
             index.getSchemas().add(indexEntry);
         } catch (Exception e) {
             getLog().error(e);
@@ -242,7 +250,11 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             var writer = new FileWriter(output.toFile());
             var jsonGenerator = jsonFactory.createGenerator(writer).useDefaultPrettyPrinter();
             jsonMapper.writeTree(jsonGenerator, targetObject);
-            var indexEntry = new Entry("Aggregated Camel catalog for " + categoryName, camelVersion, outputFileName);
+            var indexEntry = new Entry(
+                    categoryName,
+                    "Aggregated Camel catalog for " + categoryName,
+                    camelVersion,
+                    outputFileName);
             index.getCatalogs().put(categoryName, indexEntry);
         } catch (Exception e) {
             getLog().error(e);
@@ -307,9 +319,11 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             var crd = yamlMapper.readValue(file.toFile(), CustomResourceDefinition.class);
             var schema = crd.getSpec().getVersions().get(0).getSchema().getOpenAPIV3Schema();
             jsonMapper.writerWithDefaultPrettyPrinter().writeValue(output.toFile(), schema);
-            var displayName = crd.getSpec().getNames().getKind();
+            var name = crd.getSpec().getNames().getKind();
+            var description = name;
             var indexEntry = new Entry(
-                    displayName,
+                    name,
+                    description,
                     camelKCRDVersion,
                     outputFileName);
             index.getSchemas().add(indexEntry);
@@ -338,6 +352,7 @@ public class KaotoCamelCatalogMojo extends AbstractMojo {
             var jsonGenerator = jsonFactory.createGenerator(writer).useDefaultPrettyPrinter();
             jsonMapper.writeTree(jsonGenerator, root);
             var indexEntry = new Entry(
+                    KAMELETS,
                     "Aggregated Kamelet definitions in JSON",
                     kameletsVersion,
                     outputFileName);

--- a/packages/ui/src/camel-utils/camel-schemas-processor.test.ts
+++ b/packages/ui/src/camel-utils/camel-schemas-processor.test.ts
@@ -32,20 +32,6 @@ describe('camel-schemas-processor', () => {
     },
   ];
 
-  it.each([
-    [null, false],
-    [undefined, false],
-    [{}, false],
-    [{ schema: null }, false],
-    [{ schema: {} }, false],
-    [{ schema: { items: {} } }, false],
-    [{ name: "Camel YAML DSL JSON schema" }, true],
-  ])('should return whether or not the provided schema is a Camel YAML schema: %s', (schema, expected) => {
-    const result = CamelSchemasProcessor.isCamelCatalog(schema);
-
-    expect(result).toEqual(expected);
-  });
-
   it('should return a list of schemas', () => {
     const result = CamelSchemasProcessor.getSchemas(schemas);
 
@@ -86,20 +72,6 @@ describe('camel-schemas-processor', () => {
         tags: [],
         uri: 'https://camel.apache.org/schema/user-schema.json',
         version: '3.2.0',
-      },
-      {
-        name: 'route',
-        version: '3.2.0',
-        tags: ['visualization'],
-        uri: 'https://camel.apache.org/schema/user-schema.json',
-        schema: {
-          $schema: 'https://json-schema.org/draft-04/schema#',
-          type: 'object',
-          items: { definitions: camelSchema.items.definitions },
-          properties: {
-            route: camelSchema.items.properties.route,
-          },
-        },
       },
     ];
 

--- a/packages/ui/src/camel-utils/camel-schemas-processor.ts
+++ b/packages/ui/src/camel-utils/camel-schemas-processor.ts
@@ -19,43 +19,8 @@ export class CamelSchemasProcessor {
         tags,
       });
 
-      /** Camel YAML DSL JSON Schemas */
-      if (this.isCamelCatalog(schema)) {
-        Object.keys(schema.schema.items.properties).forEach((propertyRefName) => {
-          const propertyRef = schema.schema.items.properties[propertyRefName];
-          const tags = [];
-
-          if (this.VISUAL_FLOWS.includes(propertyRefName.toLowerCase())) {
-            tags.push('visualization');
-          }
-
-          acc.push({
-            name: propertyRefName,
-            version: schema.version,
-            tags,
-            uri: schema.uri,
-            schema: {
-              $schema: 'https://json-schema.org/draft-04/schema#',
-              type: 'object',
-              items: {
-                definitions: schema.schema.items.definitions,
-              },
-              properties: {
-                [propertyRefName]: propertyRef,
-              },
-            },
-          });
-        });
-      }
-
       return acc;
     }, [] as Schema[]);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static isCamelCatalog(schema: any): schema is Schema & {
-    schema: { items: { definitions: Record<string, unknown>; properties: Record<string, unknown> } };
-  } {
-    return schema?.name === `Camel YAML DSL JSON schema`;
-  }
 }

--- a/packages/ui/src/components/SourceCode/SourceCode.tsx
+++ b/packages/ui/src/components/SourceCode/SourceCode.tsx
@@ -15,6 +15,7 @@ interface SourceCodeProps {
 export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
   const editorRef = useRef<Parameters<EditorDidMount>[0] | null>(null);
   const schemas = useSchemasStore((state) => state.schemas);
+  const camelYamlDslSchema = schemas.find(s => s.name === 'camelYamlDsl');
 
   useEffect(() => {
     setDiagnosticsOptions({
@@ -26,8 +27,8 @@ export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
       schemas: [
         {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          schema: schemas[0].schema as any,
-          uri: schemas[0].uri,
+          schema: camelYamlDslSchema!.schema as any,
+          uri: camelYamlDslSchema!.uri,
           fileMatch: ['*'],
         },
       ],


### PR DESCRIPTION
Fixes: #147

ATM sub schemas are not used by UI. We'll soon use for Beans editor (#8) and will be easier to identify the sub schema by its name being same as the property name - for example, `beans` to be a name for the beans sub schema. The old verbose name were moved as `description` in the index.json. We might want to generate an enum of these sub schema names and put in .d.ts.