### PR TITLE
chore(ui): Remove direct catalog usage

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,6 @@
     "lint:fix": "yarn eslint \"src/**/*.{ts,tsx}\" --fix"
   },
   "dependencies": {
-    "@kaoto-next/camel-catalog": "workspace:*",
     "@kaoto-next/uniforms-patternfly": "workspace:*",
     "@patternfly/patternfly": "^5.0.0",
     "@patternfly/react-code-editor": "^5.0.0",
@@ -65,6 +64,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
+    "@kaoto-next/camel-catalog": "workspace:*",
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/packages/ui/src/providers/catalog-schema-loader.provider.tsx
+++ b/packages/ui/src/providers/catalog-schema-loader.provider.tsx
@@ -1,4 +1,3 @@
-import catalogIndex from '@kaoto-next/camel-catalog/index.json?url';
 import { FunctionComponent, PropsWithChildren, createContext, useEffect, useState } from 'react';
 import { CamelSchemasProcessor, DEFAULT_CATALOG_PATH } from '../camel-utils';
 import { CamelCatalogIndex, CatalogEntry, CatalogKind, ComponentsCatalog, Schema } from '../models';
@@ -15,7 +14,7 @@ export const CatalogSchemaLoaderProvider: FunctionComponent<PropsWithChildren> =
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    fetch(catalogIndex)
+    fetch(`.${DEFAULT_CATALOG_PATH}/index.json`)
       .then((response) => response.json())
       .then((catalogIndex: CamelCatalogIndex) => {
         const camelComponentsFiles = fetchFile(catalogIndex.catalogs.components.file);


### PR DESCRIPTION
### Context
Currently, we're using the catalog at runtime by:

```typescript
import catalogIndex from '@kaoto-next/camel-catalog/index.json?url';
```

While it works, the problem with this approach is that we're tying the @kaoto-next/camel-catalog dependency at runtime.

### Changes
The change is to leverage the vite build step in which the catalog is copied to the `assets` folder.

```typescript
    fetch(`.${DEFAULT_CATALOG_PATH}/index.json`)
```

Relates to: https://github.com/KaotoIO/kaoto-next/issues/131