### PR TITLE
fix(lerna-lite) Provide @lerna-lite/cli as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": "18.x"
   },
   "devDependencies": {
+    "@lerna-lite/cli": "^2.5.0",
     "@lerna-lite/publish": "^2.5.0",
     "@lerna-lite/version": "^2.5.0",
     "husky": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,7 +2459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna-lite/cli@npm:2.5.1":
+"@lerna-lite/cli@npm:2.5.1, @lerna-lite/cli@npm:^2.5.0":
   version: 2.5.1
   resolution: "@lerna-lite/cli@npm:2.5.1"
   dependencies:
@@ -13012,6 +13012,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kaoto-next@workspace:."
   dependencies:
+    "@lerna-lite/cli": ^2.5.0
     "@lerna-lite/publish": ^2.5.0
     "@lerna-lite/version": ^2.5.0
     husky: ^8.0.3


### PR DESCRIPTION
### Context
When executing the `publish` action, `lerna` is used instead, as [it is already provided in the runner nodes](https://github.com/actions/runner-images/blob/ubuntu22/20230924.1/images/linux/Ubuntu2204-Readme.md#project-management)

### Changes
Provide `@lerna-lite/cli` dependency to signal which CLI we want to use.