### PR TITLE
feat(version): Create a pull request for the release process

### DIFF
--- a/.github/workflows/create-pre-release-pr.yml
+++ b/.github/workflows/create-pre-release-pr.yml
@@ -1,4 +1,4 @@
-name: 🏷️ Trigger Version and publish npm Package
+name: ↗️ Create a Pull request for a new release
 # Event for the workflow
 on:
   workflow_dispatch:
@@ -8,12 +8,12 @@ concurrency:
   group: "publish"
   cancel-in-progress: true
 
-jobs:
-  trigger-version-and-publish:
-    if: github.repository == 'KaotoIO/kaoto-next' && github.actor != 'renovate[bot]'
 
+jobs:
+  create-pre-release-pr:
     permissions:
       contents: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
     steps:
@@ -50,9 +50,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Version and publish
-      - name: "Version and publish"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.KAOTO_NEXT_NPM_TOKEN }}
-        run: yarn publish
+      - name: Version
+        run: yarn version
+
+      - name: Get version
+        id: get_version
+        run: |
+          echo "TITLE=$(git --no-pager log --format=%s -n 1)" >> $GITHUB_OUTPUT
+        # echo "BODY='$(git --no-pager log --format=%B -n 1)'" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: release"
+          title: ${{ steps.get_version.outputs.TITLE }}
+          body: ${{ steps.get_version.outputs.BODY }}
+          branch: chore/pre-release
+          base: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-branch: true
+          labels: release

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,55 @@
+name: 🏷️ Release and publish a new version of the package
+on:
+  # Run on pull request merged from a `pre-release` branch into the `main` branch\
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - 'packages/**/CHANGELOG.md'
+
+jobs:
+  release-and-publish:
+    permissions:
+      contents: write
+
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@kaoto-next'
+          cache: 'yarn'
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: 🔧 Install dependencies
+        run: yarn
+
+      # Build lib
+      - name: Build @kaoto-next/ui package in lib mode
+        run: yarn workspace @kaoto-next/ui run build:lib
+
+      # Version and publish
+      - name: 'Version and publish'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.KAOTO_NEXT_NPM_TOKEN }}
+        run: yarn publish
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1.13.0
+        with:
+          draft: true
+          commit: ${{ github.event.pull_request.head.sha }}
+          tag: ${{ github.event.pull_request.head.ref }}

--- a/lerna.json
+++ b/lerna.json
@@ -9,14 +9,16 @@
   "conventionalCommits": true,
   "changelog": true,
   "message": "chore(release): publish",
-  "createRelease": "github",
+  "loglevel": "debug",
   "command": {
+    "version": {
+      "tag": false,
+      "push": false,
+      "yes": true
+    },
     "publish": {
-      "tag": true,
-      "push": true,
-      "pushArgs": [
-        "--follow-tags"
-      ],
+      "tag": false,
+      "push": false,
       "yes": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "postinstall": "yarn workspace @kaoto-next/camel-catalog run build",
-    "publish": "lerna publish"
+    "version": "lerna version",
+    "publish": "lerna publish from-package"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
### Context
This workflow consists of 2 steps:

1. The create-pre-release-pr.yaml workflow triggers a lerna-lite version command and creates a pull request with the changes

2. Once the pull request is done, the release-and-publish.yml workflow publishes the changed packages by using the lerna-lite publish from-package command, and later on it creates a release. The latter is not working due to a lack of permissions to create the release.

Fixes: https://github.com/KaotoIO/kaoto-next/issues/77