### PR TITLE
fix(publishing): Set access:public for @kaoto-next/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/KaotoIO/kaoto-next",
   "repositoryDirectory": "packages/ui",
   "author": "The Kaoto Team",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache License v2.0",
   "types": "./lib/esm/public-api.d.ts",
   "module": "./lib/esm/public-api.js",


### PR DESCRIPTION
### Context
In order for lerna-lite to be able to publish a package, we need to set the access to public.

Relates to: https://github.com/KaotoIO/kaoto-next/issues/77