### PR TITLE
chore(viznode): Remove usage of the VisualizationNode class

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import { JSONSchemaType } from 'ajv';
-import { VisualizationNode } from '../../../models/visualization';
-import { VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
+import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import { CanvasForm } from './CanvasForm';
 import { CanvasNode } from './canvas.models';
@@ -29,7 +28,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-        } as VisualizationNode,
+        } as IVisualizationNode,
       },
     };
 
@@ -49,7 +48,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => undefined,
-        } as VisualizationNode,
+        } as IVisualizationNode,
       },
     };
 
@@ -75,7 +74,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-        } as VisualizationNode,
+        } as IVisualizationNode,
       },
     };
 

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -13,7 +13,7 @@ import {
   ModelKind,
   Visualization,
 } from '@patternfly/react-topology';
-import { VisualizationNode } from '../../../models/visualization';
+import { createVisualizationNode } from '../../../models/visualization';
 import { LayoutType } from './canvas.models';
 import { CanvasService } from './canvas.service';
 
@@ -114,7 +114,7 @@ describe('CanvasService', () => {
 
   describe('getFlowDiagram', () => {
     it('should return nodes and edges for a simple VisualizationNode', () => {
-      const vizNode = new VisualizationNode('node');
+      const vizNode = createVisualizationNode('node');
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
 
@@ -131,8 +131,8 @@ describe('CanvasService', () => {
     });
 
     it('should return nodes and edges for a two-nodes VisualizationNode', () => {
-      const vizNode = new VisualizationNode('node');
-      const childNode = new VisualizationNode('child');
+      const vizNode = createVisualizationNode('node');
+      const childNode = createVisualizationNode('child');
       vizNode.addChild(childNode);
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
@@ -164,32 +164,32 @@ describe('CanvasService', () => {
     });
 
     it('should return nodes and edges for a multiple nodes VisualizationNode', () => {
-      const vizNode = new VisualizationNode('node');
+      const vizNode = createVisualizationNode('node');
 
-      const setHeaderNode = new VisualizationNode('set-header');
+      const setHeaderNode = createVisualizationNode('set-header');
       vizNode.setNextNode(setHeaderNode);
       setHeaderNode.setPreviousNode(vizNode);
 
-      const choiceNode = new VisualizationNode('choice');
+      const choiceNode = createVisualizationNode('choice');
       setHeaderNode.setNextNode(choiceNode);
       choiceNode.setPreviousNode(setHeaderNode);
 
-      const directNode = new VisualizationNode('direct');
+      const directNode = createVisualizationNode('direct');
       choiceNode.setNextNode(directNode);
       directNode.setPreviousNode(choiceNode);
 
-      const whenNode = new VisualizationNode('when');
+      const whenNode = createVisualizationNode('when');
       choiceNode.addChild(whenNode);
 
-      const otherwiseNode = new VisualizationNode('otherwise');
+      const otherwiseNode = createVisualizationNode('otherwise');
       choiceNode.addChild(otherwiseNode);
 
-      const whenLeafNode = new VisualizationNode('when-leaf');
+      const whenLeafNode = createVisualizationNode('when-leaf');
       whenNode.addChild(whenLeafNode);
 
-      const processNode = new VisualizationNode('process');
+      const processNode = createVisualizationNode('process');
       otherwiseNode.addChild(processNode);
-      const logNode = new VisualizationNode('log');
+      const logNode = createVisualizationNode('log');
       processNode.addChild(logNode);
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
@@ -207,7 +207,7 @@ describe('CanvasService', () => {
           id: 'set-header-1234',
           label: 'set-header',
           parentNode: undefined,
-          data: { vizNode: setHeaderNode }
+          data: { vizNode: setHeaderNode },
         },
         {
           ...DEFAULT_NODE_PROPS,

--- a/packages/ui/src/models/visualization/flows/kamelet-binding.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-binding.ts
@@ -1,11 +1,11 @@
+import { KameletBinding as KameletBindingModel } from '@kaoto-next/camel-catalog/types';
 import get from 'lodash.get';
 import set from 'lodash.set';
-import { KameletBinding as KameletBindingModel } from '@kaoto-next/camel-catalog/types';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType } from '../../camel-entities';
 import { KameletBindingStep, KameletBindingSteps } from '../../camel-entities/kamelet-binding-overrides';
-import { BaseVisualCamelEntity, VisualComponentSchema } from '../base-visual-entity';
-import { VisualizationNode } from '../visualization-node';
+import { BaseVisualCamelEntity, IVisualizationNode, VisualComponentSchema } from '../base-visual-entity';
+import { createVisualizationNode } from '../visualization-node';
 import { KameletSchemaService } from './kamelet-schema.service';
 
 export class KameletBinding implements BaseVisualCamelEntity {
@@ -48,7 +48,7 @@ export class KameletBinding implements BaseVisualCamelEntity {
     return allSteps;
   }
 
-  toVizNode(): VisualizationNode {
+  toVizNode(): IVisualizationNode {
     const rootNode = this.getVizNodeFromStep(this.route.spec?.source, 'source');
     const stepNodes = this.route.spec?.steps && this.getVizNodesFromSteps(this.route.spec?.steps);
     const sinkNode = this.getVizNodeFromStep(this.route.spec?.sink, 'sink');
@@ -75,9 +75,9 @@ export class KameletBinding implements BaseVisualCamelEntity {
     return rootNode;
   }
 
-  private getVizNodesFromSteps(steps: Array<KameletBindingStep>): VisualizationNode[] {
+  private getVizNodesFromSteps(steps: Array<KameletBindingStep>): IVisualizationNode[] {
     if (!Array.isArray(steps)) {
-      return [] as VisualizationNode[];
+      return [] as IVisualizationNode[];
     }
     return steps?.reduce((acc, camelRouteStep) => {
       const previousVizNode = acc[acc.length - 1];
@@ -89,12 +89,12 @@ export class KameletBinding implements BaseVisualCamelEntity {
       }
       acc.push(vizNode);
       return acc;
-    }, [] as VisualizationNode[]);
+    }, [] as IVisualizationNode[]);
   }
 
-  private getVizNodeFromStep(step: KameletBindingStep, path: string): VisualizationNode {
+  private getVizNodeFromStep(step: KameletBindingStep, path: string): IVisualizationNode {
     const stepName = step?.ref?.name;
-    const answer = new VisualizationNode(stepName!, this);
+    const answer = createVisualizationNode(stepName!, this);
     answer.path = path;
     const kameletDefinition = KameletSchemaService.getKameletDefinition(step);
     answer.iconData = kameletDefinition?.metadata.annotations['camel.apache.org/kamelet.icon'];

--- a/packages/ui/src/models/visualization/flows/route.ts
+++ b/packages/ui/src/models/visualization/flows/route.ts
@@ -5,7 +5,7 @@ import set from 'lodash.set';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { EntityType } from '../../camel-entities/base-entity';
 import { BaseVisualCamelEntity, IVisualizationNode, VisualComponentSchema } from '../base-visual-entity';
-import { VisualizationNode } from '../visualization-node';
+import { createVisualizationNode } from '../visualization-node';
 import { CamelComponentSchemaService } from './camel-component-schema.service';
 
 export class CamelRoute implements BaseVisualCamelEntity {
@@ -46,7 +46,7 @@ export class CamelRoute implements BaseVisualCamelEntity {
   }
 
   toVizNode(): IVisualizationNode {
-    const rootNode = new VisualizationNode((this.route.from?.uri as string) ?? '', this);
+    const rootNode = createVisualizationNode((this.route.from?.uri as string) ?? '', this);
     rootNode.path = 'from';
     const vizNodes = this.getVizNodesFromSteps(this.getSteps(), `${rootNode.path}.steps`);
 
@@ -76,7 +76,7 @@ export class CamelRoute implements BaseVisualCamelEntity {
 
   private getVizNodeFromStep(processor: ProcessorDefinition, path: string): IVisualizationNode {
     const processorName = Object.keys(processor)[0];
-    const parentStep = new VisualizationNode(processorName);
+    const parentStep = createVisualizationNode(processorName);
     parentStep.path = `${path}.${processorName}`;
 
     switch (processorName) {
@@ -113,7 +113,7 @@ export class CamelRoute implements BaseVisualCamelEntity {
   }
 
   private getChildren(label: string, steps: ProcessorDefinition[], path: string): IVisualizationNode {
-    const node = new VisualizationNode(label);
+    const node = createVisualizationNode(label);
     node.path = path;
     const children = this.getVizNodesFromSteps(steps, path);
     node.setChildren(children);

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -1,11 +1,11 @@
-import { BaseVisualCamelEntity } from './base-visual-entity';
-import { VisualizationNode } from './visualization-node';
+import { BaseVisualCamelEntity, IVisualizationNode } from './base-visual-entity';
+import { createVisualizationNode } from './visualization-node';
 
 describe('VisualizationNode', () => {
-  let node: VisualizationNode;
+  let node: IVisualizationNode;
 
   beforeEach(() => {
-    node = new VisualizationNode('test');
+    node = createVisualizationNode('test');
   });
 
   it('should create a node with a random id', () => {
@@ -14,7 +14,7 @@ describe('VisualizationNode', () => {
 
   it('should return the base visual entity', () => {
     const visualEntity = {} as BaseVisualCamelEntity;
-    node = new VisualizationNode('test', visualEntity);
+    node = createVisualizationNode('test', visualEntity);
 
     expect(node.getBaseEntity()).toEqual(visualEntity);
   });
@@ -25,7 +25,7 @@ describe('VisualizationNode', () => {
       getComponentSchema: getComponentSchemaSpy,
     } as unknown as BaseVisualCamelEntity;
 
-    node = new VisualizationNode('test', visualEntity);
+    node = createVisualizationNode('test', visualEntity);
     node.path = 'test-path';
     node.getComponentSchema();
 
@@ -39,7 +39,7 @@ describe('VisualizationNode', () => {
       getComponentSchema: getComponentSchemaSpy,
     } as unknown as BaseVisualCamelEntity;
 
-    const rootNode = new VisualizationNode('test', visualEntity);
+    const rootNode = createVisualizationNode('test', visualEntity);
     rootNode.path = 'test-path';
     node.setParentNode(rootNode);
 
@@ -57,7 +57,7 @@ describe('VisualizationNode', () => {
         updateModel: updateModelSpy,
       } as unknown as BaseVisualCamelEntity;
 
-      node = new VisualizationNode('test', visualEntity);
+      node = createVisualizationNode('test', visualEntity);
       node.path = 'test-path';
       node.updateModel('test-value');
 
@@ -71,7 +71,7 @@ describe('VisualizationNode', () => {
         updateModel: updateModelSpy,
       } as unknown as BaseVisualCamelEntity;
 
-      const rootNode = new VisualizationNode('test', visualEntity);
+      const rootNode = createVisualizationNode('test', visualEntity);
       rootNode.path = 'test-path';
       node.setParentNode(rootNode);
 
@@ -84,35 +84,35 @@ describe('VisualizationNode', () => {
   });
 
   it('should set the parent node', () => {
-    const parentNode = new VisualizationNode('parent');
+    const parentNode = createVisualizationNode('parent');
     node.setParentNode(parentNode);
 
     expect(node.getParentNode()).toEqual(parentNode);
   });
 
   it('should set the previous node', () => {
-    const previousNode = new VisualizationNode('previous');
+    const previousNode = createVisualizationNode('previous');
     node.setPreviousNode(previousNode);
 
     expect(node.getPreviousNode()).toEqual(previousNode);
   });
 
   it('should set the next node', () => {
-    const nextNode = new VisualizationNode('next');
+    const nextNode = createVisualizationNode('next');
     node.setNextNode(nextNode);
 
     expect(node.getNextNode()).toEqual(nextNode);
   });
 
   it('should set the children', () => {
-    const children = [new VisualizationNode('child')];
+    const children = [createVisualizationNode('child')];
     node.setChildren(children);
 
     expect(node.getChildren()).toEqual(children);
   });
 
   it('should add a child', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.addChild(child);
 
     expect(node.getChildren()).toEqual([child]);
@@ -120,7 +120,7 @@ describe('VisualizationNode', () => {
   });
 
   it('should add a child to an existing children array', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.setChildren([child]);
 
     expect(node.getChildren()).toEqual([child]);
@@ -128,7 +128,7 @@ describe('VisualizationNode', () => {
   });
 
   it('should remove a child', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.addChild(child);
     node.removeChild(child);
 
@@ -137,7 +137,7 @@ describe('VisualizationNode', () => {
   });
 
   it('should remove a child from an existing children array', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.setChildren([child]);
     node.removeChild(child);
 
@@ -146,7 +146,7 @@ describe('VisualizationNode', () => {
   });
 
   it('should not error when removing a non-existing child', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.removeChild(child);
 
     expect(node.getChildren()).toBeUndefined();
@@ -154,10 +154,10 @@ describe('VisualizationNode', () => {
   });
 
   it('should populate the leaf nodes ids - simple relationship', () => {
-    const child = new VisualizationNode('child');
+    const child = createVisualizationNode('child');
     node.addChild(child);
 
-    const leafNode = new VisualizationNode('leaf');
+    const leafNode = createVisualizationNode('leaf');
     child.addChild(leafNode);
 
     const ids: string[] = [];
@@ -167,21 +167,21 @@ describe('VisualizationNode', () => {
   });
 
   it('should populate the leaf nodes ids - complex relationship', () => {
-    const choiceNode = new VisualizationNode('choice');
+    const choiceNode = createVisualizationNode('choice');
     node.addChild(choiceNode);
 
-    const whenNode = new VisualizationNode('when');
+    const whenNode = createVisualizationNode('when');
     choiceNode.addChild(whenNode);
 
-    const otherwiseNode = new VisualizationNode('otherwise');
+    const otherwiseNode = createVisualizationNode('otherwise');
     choiceNode.addChild(otherwiseNode);
 
-    const whenLeafNode = new VisualizationNode('when-leaf');
+    const whenLeafNode = createVisualizationNode('when-leaf');
     whenNode.addChild(whenLeafNode);
 
-    const processNode = new VisualizationNode('process');
+    const processNode = createVisualizationNode('process');
     otherwiseNode.addChild(processNode);
-    const logNode = new VisualizationNode('log');
+    const logNode = createVisualizationNode('log');
     processNode.addChild(logNode);
 
     const ids: string[] = [];

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -1,7 +1,16 @@
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { BaseVisualCamelEntity, IVisualizationNode, VisualComponentSchema } from './base-visual-entity';
 
-export class VisualizationNode implements IVisualizationNode {
+export const createVisualizationNode: (
+  ...args: ConstructorParameters<typeof VisualizationNode>
+) => IVisualizationNode = (...args): IVisualizationNode => new VisualizationNode(...args);
+
+/**
+ * VisualizationNode
+ * This class is used to represent a node in the visualization tree.
+ * It shouldn't be used directly, but rather through the IVisualizationNode interface.
+ */
+class VisualizationNode implements IVisualizationNode {
   readonly id: string;
   private parentNode: IVisualizationNode | undefined = undefined;
   private previousNode: IVisualizationNode | undefined = undefined;


### PR DESCRIPTION
### Context
In some cases, we're using the VisualizationNode class directly to create a new node as `new VisualizationNode(...)`.

This is not a problem itself, but tying entity classes like `KameletBinding` with the `VisualizationNode` class is not ok, as it allows to implement functionality directly on the implementation class that other entities won't leverage.

### Changes
This commit encompasses:

* Remove the usage of `new VisualizationClass(...)`
* Create a new function that returns an instance of `VisualizationNode` but using the `IVisualizationNode` type instead