### PR TITLE
chore(tile): Make rawObject optional and deprecated

### DIFF
--- a/packages/ui/src/components/Catalog/Catalog.models.ts
+++ b/packages/ui/src/components/Catalog/Catalog.models.ts
@@ -1,4 +1,4 @@
-export interface ITile<T = unknown> {
+export interface ITile {
   type: string;
   name: string;
   title: string;
@@ -6,7 +6,8 @@ export interface ITile<T = unknown> {
   headerTags?: string[];
   tags: string[];
   version?: string;
-  rawObject: T;
+  /** @deprecated Please relay on name property instead */
+  rawObject?: unknown;
 }
 
 export const enum CatalogLayout {


### PR DESCRIPTION
### Context
Initially, the `ITile` interface had a `rawObject` property for holding raw information about the underlying `Tile` object.

This property is now optional and deprecated as it's better to rely on the `name` property to identify the selected `Tile` to have better isolation of concerns between the `Tile` object and its consumers.