### PR TITLE
feat: Improve component's icon visualization

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
@@ -1,20 +1,30 @@
-import { CubeIcon } from '@patternfly/react-icons';
 import { DefaultNode, Node, WithSelectionProps, withSelection } from '@patternfly/react-topology';
 import { FunctionComponent } from 'react';
+import defaultCamelIcon from '../../../assets/camel-logo.svg';
 import { CanvasNode } from '../Canvas/canvas.models';
+import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 
 interface CustomNodeProps extends WithSelectionProps {
   element: Node<CanvasNode, CanvasNode['data']>;
 }
 
+function getIcon(data: IVisualizationNode | undefined) {
+  const iconRadius = 20;
+  const cx = 25 / 2;
+  const cy = 25 / 2;
+
+  const icon = data?.iconData ?? defaultCamelIcon;
+  return (
+    <image xlinkHref={icon} x={cx - iconRadius} y={cy - iconRadius} width={iconRadius * 2} height={iconRadius * 2} />
+  );
+}
+
 const CustomNode: FunctionComponent<CustomNodeProps> = ({ element, ...rest }) => {
-  // const vizNode = element.getData()?.vizNode;
+  const data = element.getData()?.vizNode;
 
   return (
     <DefaultNode element={element} showStatusDecorator {...rest}>
-      <g transform={`translate(25, 25)`}>
-        <CubeIcon style={{ color: '#393F44' }} width={25} height={25} />
-      </g>
+      <g transform={`translate(25, 25)`}>{getIcon(data)}</g>
     </DefaultNode>
   );
 };


### PR DESCRIPTION
relates to https://github.com/KaotoIO/kaoto-next/issues/76

Initial work on icon resolving for the `CustomNode`. 
This for now just specifies the KB icon or selects the default icon for every other flow type.

Will add the handling for EIP icons, from [here](https://camel.apache.org/components/4.0.x/eips/enterprise-integration-patterns.html#_eip_icons)
The canvas sidebar also needs to display the selected node icon and we also need to  need to add handling for custom icons.