### PR TITLE
feat: sidebar icon handling and EIP POC

### DIFF
--- a/packages/ui/src/assets/question-mark.svg
+++ b/packages/ui/src/assets/question-mark.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="135.70801mm"
+   height="174.76601mm"
+   viewBox="0 0 135.70801 174.76601"
+   version="1.1"
+   id="svg5"
+   inkscape:export-filename="bitmap.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   sodipodi:docname="svg_2.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.638672"
+     inkscape:cx="176.0572"
+     inkscape:cy="255.69486"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-28.618387,14.834599)">
+    <g
+       class="layer"
+       id="g79"
+       transform="matrix(0.26458333,0,0,0.26458333,49.728699,8.3096165)">
+      <title
+         id="title75">Layer 1</title>
+      <g
+         class="layer"
+         id="svg_2"
+         transform="translate(-24.500628,-23.97814)">
+        <path
+           d="M 202.02,0 C 122.2,0 70.5,32.7 29.91,91.03 c -7.36,10.58 -5.09,25.08 5.18,32.87 l 43.14,32.71 c 10.37,7.86 25.13,6.03 33.25,-4.15 25.05,-31.38 43.63,-49.45 82.76,-49.45 30.76,0 68.82,19.8 68.82,49.63 0,22.56 -18.62,34.14 -49,51.17 -35.42,19.86 -82.3,44.57 -82.3,106.4 V 320 c 0,13.25 10.75,24 24,24 h 72.48 c 13.25,0 24,-10.75 24,-24 v -5.77 C 252.24,271.37 377.5,269.58 377.5,153.6 377.5,66.26 286.9,0 202.02,0 Z M 192,373.46 c -38.2,0 -69.27,31.07 -69.27,69.27 0,38.2 31.07,69.27 69.27,69.27 38.2,0 69.27,-31.07 69.27,-69.27 0,-38.2 -31.07,-69.27 -69.27,-69.27 z"
+           id="svg_1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.scss
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.scss
@@ -1,0 +1,3 @@
+img[class^='sidebar-icon-'] {
+    max-height: 40px;
+}

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
@@ -1,10 +1,11 @@
-import { Button, Card, CardBody, CardTitle } from '@patternfly/react-core';
+import { Button, Card, CardBody, Grid, CardTitle, GridItem, CardHeader } from '@patternfly/react-core';
 import { TopologySideBar } from '@patternfly/react-topology';
 import { FunctionComponent } from 'react';
 import { CanvasForm } from './CanvasForm';
 import { CanvasNode } from './canvas.models';
 import { TimesIcon } from '@patternfly/react-icons';
 import { ErrorBoundary } from '../../ErrorBoundary';
+import './CanvasSideBar.scss';
 
 interface CanvasSideBarProps {
   selectedNode: CanvasNode | undefined;
@@ -19,17 +20,23 @@ export const CanvasSideBar: FunctionComponent<CanvasSideBarProps> = (props) => {
      */
     <TopologySideBar show={props.selectedNode !== undefined}>
       <Card>
-        <CardTitle>
-          {props.selectedNode?.label}{' '}
-          <Button
-            variant="plain"
-            icon={<TimesIcon />}
-            onClick={() => {
-              props.onClose();
-            }}
-          />
-        </CardTitle>
-
+        <CardHeader>
+          <Grid hasGutter>
+            <GridItem span={2}>
+              <img
+                className={'sidebar-icon-' + props.selectedNode?.label}
+                src={props.selectedNode?.data?.vizNode?.getIconData()}
+                alt="icon"
+              />
+            </GridItem>
+            <GridItem span={9}>
+              <CardTitle>{props.selectedNode?.label}</CardTitle>
+            </GridItem>
+            <GridItem span={1}>
+              <Button variant="plain" icon={<TimesIcon />} onClick={props.onClose} />
+            </GridItem>
+          </Grid>
+        </CardHeader>
         <CardBody>
           {props.selectedNode === undefined ? null : (
             <ErrorBoundary fallback={<p>Something didn't work as expected</p>}>

--- a/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
@@ -11,7 +11,6 @@ import {
   withSelection,
 } from '@patternfly/react-topology';
 import { FunctionComponent, useCallback, useContext } from 'react';
-import defaultCamelIcon from '../../../assets/camel-logo.svg';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import { CanvasNode } from '../Canvas/canvas.models';
 import { CanvasService } from '../Canvas/canvas.service';
@@ -23,7 +22,7 @@ interface CustomNodeProps extends WithSelectionProps {
 
 const CustomNode: FunctionComponent<CustomNodeProps> = ({ element, ...rest }) => {
   const data = element.getData()?.vizNode;
-  const icon = data?.iconData ?? defaultCamelIcon;
+  const icon = data?.getIconData();
 
   return (
     <DefaultNode element={element} showStatusDecorator {...rest}>

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -6,7 +6,7 @@ import { BaseCamelEntity, EntityType } from '../camel/entities';
  *
  * This interface is used to represent a visual Camel entity.
  * f.i. Camel Route, Kamelet, KameletBinding, etc.
- * All dedicated Camel code would implemented using this interface.
+ * All dedicated Camel code should be implemented using this interface.
  */
 export interface BaseVisualCamelEntity extends BaseCamelEntity {
   id: string;
@@ -42,7 +42,6 @@ export interface IVisualizationNode {
   id: string;
   path: string | undefined;
   label: string;
-  iconData: string | undefined;
 
   /** This property is only set on the root node */
   getBaseEntity(): BaseVisualCamelEntity | undefined;
@@ -74,6 +73,10 @@ export interface IVisualizationNode {
   removeChild(child: IVisualizationNode): void;
 
   populateLeafNodesIds(ids: string[]): void;
+
+  setIconData(iconData: string | undefined): void;
+
+  getIconData(): string | undefined;
 }
 
 /**

--- a/packages/ui/src/models/visualization/flows/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-component-schema.service.ts
@@ -4,6 +4,7 @@ import { ICamelProcessorProperty } from '../../camel-processors-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { VisualComponentSchema } from '../base-visual-entity';
 import { ICamelComponentProperty } from '../../camel-components-catalog';
+import { isDefined } from '../../../utils';
 
 interface ICamelElementLookupResult {
   processorName: string;
@@ -21,7 +22,7 @@ export class CamelComponentSchemaService {
     };
   }
 
-  private static getCamelComponentLookup(path: string, definition: any): ICamelElementLookupResult {
+  static getCamelComponentLookup(path: string, definition: any): ICamelElementLookupResult {
     const splitPath = path.split('.');
     const lastPathSegment = splitPath[splitPath.length - 1];
     const pathAsIndex = Number.parseInt(lastPathSegment, 10);
@@ -88,7 +89,10 @@ export class CamelComponentSchemaService {
    * An URI is composed by a component name and query parameters, separated by a colon
    * For instance: `timer:tick?period=1000`
    */
-  private static getComponentNameFromUri(uri: string): string {
+  private static getComponentNameFromUri(uri: string): string | undefined {
+    if (!uri) {
+      return undefined;
+    }
     const uriParts = uri.split(':');
 
     return uriParts[0];
@@ -118,6 +122,23 @@ export class CamelComponentSchemaService {
     }
 
     return schema;
+  }
+
+  static getIconName(camelElementLookup: ICamelElementLookupResult): string | undefined {
+    if (
+      isDefined(camelElementLookup.componentName) &&
+      isDefined(useCatalogStore.getState().catalogs[CatalogKind.Component]?.[camelElementLookup.componentName])
+    ) {
+      return camelElementLookup.componentName;
+    }
+    if (
+      isDefined(camelElementLookup.processorName) &&
+      !isDefined(camelElementLookup.componentName) &&
+      isDefined(useCatalogStore.getState().catalogs[CatalogKind.Processor]?.[camelElementLookup.processorName])
+    ) {
+      return camelElementLookup.processorName;
+    }
+    return '';
   }
 
   /**

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -6,6 +6,7 @@ import { PipeSink, PipeSource, PipeStep, PipeSteps } from '../../camel/entities/
 import { BaseVisualCamelEntity, IVisualizationNode, VisualComponentSchema } from '../base-visual-entity';
 import { createVisualizationNode } from '../visualization-node';
 import { KameletSchemaService } from './kamelet-schema.service';
+import { NodeIconResolver } from '../../../utils/node-icon-resolver';
 
 type PipeFlow = {
   source: PipeSource;
@@ -137,7 +138,9 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
     const answer = createVisualizationNode(stepName!, this);
     answer.path = path;
     const kameletDefinition = KameletSchemaService.getKameletDefinition(step);
-    answer.iconData = kameletDefinition?.metadata.annotations['camel.apache.org/kamelet.icon'];
+    answer.setIconData(
+      kameletDefinition?.metadata.annotations['camel.apache.org/kamelet.icon'] ?? NodeIconResolver.getUnknownIcon(),
+    );
     return answer;
   }
 }

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -16,8 +16,8 @@ class VisualizationNode implements IVisualizationNode {
   private previousNode: IVisualizationNode | undefined = undefined;
   private nextNode: IVisualizationNode | undefined = undefined;
   private children: IVisualizationNode[] | undefined;
+  private iconData: string | undefined;
   path: string | undefined;
-  iconData: string | undefined;
 
   constructor(
     public label: string,
@@ -107,5 +107,13 @@ class VisualizationNode implements IVisualizationNode {
 
     /** If this node has children, populate the leaf nodes ids of each child */
     this.children?.forEach((child) => child.populateLeafNodesIds(ids));
+  }
+
+  setIconData(iconData: string | undefined) {
+    this.iconData = iconData;
+  }
+
+  getIconData(): string | undefined {
+    return this.iconData;
   }
 }

--- a/packages/ui/src/utils/node-icon-resolver.ts
+++ b/packages/ui/src/utils/node-icon-resolver.ts
@@ -1,0 +1,25 @@
+//POC - extend to include icons for all the EIP's
+import defaultCamelIcon from '../assets/camel-logo.svg';
+import questionIcon from '../assets/question-mark.svg';
+
+export class NodeIconResolver {
+  static getIcon = (iconName: string | undefined): string => {
+    switch (iconName) {
+      case 'choice':
+        return 'data:image/gif;base64,R0lGODlhVgA2AKIAAP///8z/mYCAgAAAAP4BAgAAAAAAAAAAACH5BAQUAP8ALAAAAABWADYAAAP/OLrc/jDKSRm4oOrN+8PZEIxkaZ5oqq5sq4BKK890nSpCHtp875c4XexHLLKCgp1xyRwhlc3l4vccRosNX1V0JXq4pm3Xm+2Jx7zhVDvIJa1oGTwANreF9bhqLr2/83phgExngYJ6hYZ0g1eJiIxdjmN8j25Qk5BxkoSZlXiRnYGbVKGGozQxlHalN36XaWt9sTabX6xHHiinLmVGvbSuqjMMUbPAlsLDt6hkyMuKfc7Q04vS1Iq7103Z2tGf3Z5/4OGv48XBz+ao6OqY1u1Aybjv8IvG6/TtX7rs9U7EdvLBu4fvmz8nzQwexNJvIUOBDmE5s0WxYoeJFjNqfGAJKYObjyBDihxJsqTJkyJBoFzJsqXLlB5fypxJsyOImzhz6tzJs6fPnwkAADs=';
+      case 'log':
+        return 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pg0KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE2LjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPg0KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCINCgkgd2lkdGg9IjUxMnB4IiBoZWlnaHQ9IjUxMnB4IiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNTEyIDUxMjsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPGc+DQoJPHBhdGggZD0iTTQ0OCwwSDY0QzQ2LjMyOCwwLDMyLDE0LjMxMywzMiwzMnY0NDhjMCwxNy42ODgsMTQuMzI4LDMyLDMyLDMyaDM4NGMxNy42ODgsMCwzMi0xNC4zMTIsMzItMzJWMzINCgkJQzQ4MCwxNC4zMTMsNDY1LjY4OCwwLDQ0OCwweiBNNjQsNDgwVjEyOGg4MHY2NEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY0OEg5NnYxNmg0OHY4MEg2NHogTTQ0OCw0ODBIMTYwdi04MGgyNTZ2LTE2DQoJCUgxNjB2LTQ4aDI1NnYtMTZIMTYwdi00OGgyNTZ2LTE2SDE2MHYtNDhoMjU2di0xNkgxNjB2LTY0aDI4OFY0ODB6Ii8+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8L3N2Zz4NCg==';
+      case '':
+        return this.getUnknownIcon();
+      default:
+        return this.getDefaultCamelIcon();
+    }
+  };
+
+  static getUnknownIcon = (): string => {
+    return questionIcon;
+  };
+  static getDefaultCamelIcon = (): string => {
+    return defaultCamelIcon;
+  };
+}


### PR DESCRIPTION
Added the questionmark icon - ATM only for "unknown" KameletBindings - can add this also to Camel Route.

For EIP's - there is only a log and choice ATM, for other steps there is a placeholder icon.

The current state for Camel Routes:
![Screenshot from 2023-10-12 08-13-29](https://github.com/KaotoIO/kaoto-next/assets/4180208/6ccdec70-4367-4464-8933-4099a7849bd0)

KameletBindings:

![Screenshot from 2023-10-12 08-14-08](https://github.com/KaotoIO/kaoto-next/assets/4180208/419d22f1-f3f4-431e-abd1-16d38f834973)
