### PR TITLE
feat: Support configuring Camel K CR metadata and Pipe errorHandler

### DIFF
--- a/packages/camel-catalog/assembly/pom.xml
+++ b/packages/camel-catalog/assembly/pom.xml
@@ -93,6 +93,27 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Download Kubernetes API OpenAPI v3 Specification</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <get src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/v3/api__v1_openapi.json"
+                     dest="${inputDirectory}/schema/kubernetes-api-v1-openapi.json"
+                     verbose="true"
+                     usetimestamp="true"
+                />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-maven-plugin</artifactId>
         <executions>
@@ -107,6 +128,26 @@
               <kebabCase>false</kebabCase>
               <additionalProperties>false</additionalProperties>
               <outputFile>${inputDirectory}/schema/camelYamlDsl.json</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Copy additional schema files</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${inputDirectory}/schema</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/resources</directory>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
@@ -133,6 +174,17 @@
               <camelVersion>${version.camel}</camelVersion>
               <camelKCRDVersion>${version.camel-k-crds}</camelKCRDVersion>
               <kameletsVersion>${version.camel-kamelets}</kameletsVersion>
+              <kubernetesDefinitions>
+                <kubernetesDefinition>io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta</kubernetesDefinition>
+                <kubernetesDefinition>io.k8s.api.core.v1.ObjectReference</kubernetesDefinition>
+              </kubernetesDefinitions>
+              <additionalSchemas>
+                <!--
+                     ATM Camel K doesn't provide schema for Pipe ErrorHandler.
+                     so we create a custom one and hold it here for now.
+                -->
+                <additionalSchema>${inputDirectory}/schema/PipeErrorHandler.json</additionalSchema>
+              </additionalSchemas>
             </configuration>
           </execution>
         </executions>

--- a/packages/camel-catalog/assembly/src/main/resources/PipeErrorHandler.json
+++ b/packages/camel-catalog/assembly/src/main/resources/PipeErrorHandler.json
@@ -1,0 +1,100 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "additionalProperties" : false,
+  "description": "Camel K Pipe ErrorHandler. See https://camel.apache.org/camel-k/latest/pipe-step.html#_error_handler for more details.",
+  "oneOf" : [ {
+    "properties" : {
+      "none" : {
+        "type" : "null"
+      }
+    },
+    "required" : [ "none" ]
+  }, {
+    "properties" : {
+      "log": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "maximumRedeliveries": {
+                "type": "number"
+              },
+              "redeliveryDelay": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "required" : [ "log" ]
+  }, {
+    "properties" : {
+      "sink": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "endpoint": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "apiVersion": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [ "kind", "apiVersion", "name" ]
+              },
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "maximumRedeliveries": {
+                "type": "number"
+              },
+              "redeliveryDelay": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "required" : [ "sink" ]
+  }],
+  "properties": {
+    "none": {},
+    "log": {},
+    "sink": {}
+  }
+}

--- a/packages/camel-catalog/src/json-schema-to-typescript.mts
+++ b/packages/camel-catalog/src/json-schema-to-typescript.mts
@@ -53,7 +53,16 @@ async function main() {
   const exportedFiles: string[] = [];
 
   console.log('---');
-  const targetSchemaNames = ['camelYamlDsl', 'Integration', 'Kamelet', 'KameletBinding', 'Pipe'];
+  const targetSchemaNames = [
+    'camelYamlDsl',
+    'Integration',
+    'Kamelet',
+    'KameletBinding',
+    'Pipe',
+    'ObjectMeta',
+    'ObjectReference',
+    'PipeErrorHandler',
+  ];
   const schemaPromises = Object.entries(index.schemas).map(async ([name, schema]) => {
     if (!targetSchemaNames.includes(name)) {
       return;

--- a/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
+++ b/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
@@ -59,11 +59,12 @@ export const MetadataEditor: FunctionComponent<PropsWithChildren<MetadataEditorP
   }
 
   function getFormModel() {
-    const targetModel = preparedModel != null ? preparedModel : props.metadata?.slice();
     if (isTopmostArray()) {
+      const targetModel = preparedModel != null ? preparedModel : props.metadata?.slice();
       return targetModel && selected !== -1 ? targetModel[selected] : undefined;
+    } else {
+      return preparedModel != null ? preparedModel : { ...props.metadata };
     }
-    return targetModel;
   }
 
   function onChangeFormModel(model: any) {

--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -68,5 +68,7 @@ const navElements: NavElements = [
   },
   { title: 'Beans', to: Links.Beans },
   { title: 'Rest', to: Links.Rest },
+  { title: 'Metadata', to: Links.Metadata },
+  { title: 'Pipe ErrorHandler', to: Links.PipeErrorHandler },
   { title: 'Catalog', to: Links.Catalog },
 ];

--- a/packages/ui/src/models/camel/entities/base-entity.ts
+++ b/packages/ui/src/models/camel/entities/base-entity.ts
@@ -9,6 +9,7 @@ export const enum EntityType {
   RestConfiguration = 'restConfiguration',
   Beans = 'beans',
   Metadata = 'metadata',
+  ErrorHandler = 'errorHandler',
 }
 
 export interface BaseCamelEntity {

--- a/packages/ui/src/models/camel/entities/pipe-overrides.ts
+++ b/packages/ui/src/models/camel/entities/pipe-overrides.ts
@@ -1,5 +1,6 @@
 import { Pipe } from '@kaoto-next/camel-catalog/types';
 
+export type PipeSpec = NonNullable<Pipe['spec']>;
 export type PipeSource = NonNullable<Pipe['spec']>['source'];
 export type PipeSink = NonNullable<Pipe['spec']>['sink'];
 export type PipeSteps = NonNullable<Pipe['spec']>['steps'];

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -3,9 +3,14 @@ import { BaseCamelEntity } from './entities';
 import { PipeVisualEntity } from '../visualization/flows';
 import { Pipe as PipeType } from '@kaoto-next/camel-catalog/types';
 import { SourceSchemaType } from './source-schema-type';
+import { MetadataEntity } from '../visualization/metadata';
+import { PipeErrorHandlerEntity } from '../visualization/metadata/pipeErrorHandlerEntity';
 
 export class PipeResource implements CamelResource {
   protected pipe: PipeType;
+  private flow?: PipeVisualEntity;
+  private metadata?: MetadataEntity;
+  private errorHandler?: PipeErrorHandlerEntity;
 
   constructor(json: unknown) {
     if (!json) {
@@ -16,10 +21,20 @@ export class PipeResource implements CamelResource {
       return;
     }
     this.pipe = json as PipeType;
+    this.flow = new PipeVisualEntity(this.pipe.spec);
+    this.metadata = new MetadataEntity(this.pipe.metadata);
+    this.errorHandler = new PipeErrorHandlerEntity(this.pipe.spec?.errorHandler);
   }
 
   getEntities(): BaseCamelEntity[] {
-    return []; // TODO [new MetadataEntity(this.pipe.metadata), new ErrorHandlerEntity(this.pipe.spec?.errorHandler)];
+    const answer = [];
+    if (this.metadata?.metadata) {
+      answer.push(this.metadata);
+    }
+    if (this.errorHandler?.errorHandler) {
+      answer.push(this.errorHandler);
+    }
+    return answer;
   }
 
   getType(): SourceSchemaType {
@@ -27,7 +42,7 @@ export class PipeResource implements CamelResource {
   }
 
   getVisualEntities(): PipeVisualEntity[] {
-    return [new PipeVisualEntity(this.pipe.spec?.source, this.pipe.spec?.steps, this.pipe.spec?.sink)];
+    return this.flow ? [this.flow] : [];
   }
 
   supportsMultipleVisualEntities(): boolean {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -2,33 +2,20 @@ import get from 'lodash.get';
 import set from 'lodash.set';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType } from '../../camel/entities';
-import { PipeSink, PipeSource, PipeStep, PipeSteps } from '../../camel/entities/pipe-overrides';
+import { PipeSpec, PipeStep, PipeSteps } from '../../camel/entities/pipe-overrides';
 import { BaseVisualCamelEntity, IVisualizationNode, VisualComponentSchema } from '../base-visual-entity';
 import { createVisualizationNode } from '../visualization-node';
 import { KameletSchemaService } from './kamelet-schema.service';
 
-type PipeFlow = {
-  source: PipeSource;
-  steps: PipeSteps;
-  sink: PipeSink;
-};
-
 export class PipeVisualEntity implements BaseVisualCamelEntity {
   readonly id = uuidv4();
   type = EntityType.Pipe;
-  flow: PipeFlow;
 
-  constructor(
-    public source: PipeSource,
-    public steps: PipeSteps,
-    public sink: PipeSink,
-  ) {
-    this.flow = { source, steps, sink };
-  }
+  constructor(private flow: PipeSpec) {}
 
   /** Internal API methods */
   getId(): string {
-    return '';
+    return this.id;
   }
 
   getComponentSchema(path?: string): VisualComponentSchema | undefined {

--- a/packages/ui/src/models/visualization/metadata/index.ts
+++ b/packages/ui/src/models/visualization/metadata/index.ts
@@ -1,1 +1,2 @@
 export * from './beansEntity';
+export * from './metadataEntity';

--- a/packages/ui/src/models/visualization/metadata/metadataEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/metadataEntity.ts
@@ -1,0 +1,18 @@
+import { ObjectMeta as MetadataModel } from '@kaoto-next/camel-catalog/types';
+import { v4 as uuidv4 } from 'uuid';
+import { EntityType, BaseCamelEntity } from '../../camel/entities';
+
+export class MetadataEntity implements BaseCamelEntity {
+  readonly id = uuidv4();
+  type = EntityType.Metadata;
+
+  constructor(public metadata: Partial<MetadataModel> = {}) {}
+
+  toJSON() {
+    return { metadata: this.metadata };
+  }
+
+  updateModel(): void {
+    return;
+  }
+}

--- a/packages/ui/src/models/visualization/metadata/pipeErrorHandlerEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/pipeErrorHandlerEntity.ts
@@ -1,0 +1,18 @@
+import { BaseCamelEntity, EntityType } from '../../camel/entities';
+import { v4 as uuidv4 } from 'uuid';
+import { PipeErrorHandler as PipeErrorHandlerModel } from '@kaoto-next/camel-catalog/types';
+
+export class PipeErrorHandlerEntity implements BaseCamelEntity {
+  readonly id = uuidv4();
+  type = EntityType.ErrorHandler;
+
+  constructor(public errorHandler: Partial<PipeErrorHandlerModel> = {}) {}
+
+  toJSON() {
+    return { errorHandler: this.errorHandler };
+  }
+
+  updateModel(): void {
+    return;
+  }
+}

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -1,0 +1,58 @@
+import { Title } from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useContext } from 'react';
+import { MetadataEditor } from '../../components/MetadataEditor';
+import { useSchemasStore } from '../../store';
+import { EntitiesContext } from '../../providers/entities.provider';
+import { ObjectMeta } from '@kaoto-next/camel-catalog/types';
+import { EntityType } from '../../models/camel/entities';
+import { MetadataEntity } from '../../models/visualization/metadata';
+
+export const MetadataPage: FunctionComponent = () => {
+  const schemaMap = useSchemasStore((state) => state.schemas);
+  const entitiesContext = useContext(EntitiesContext);
+  const entities = entitiesContext?.entities ?? [];
+
+  const findMetadata = useCallback(() => {
+    return entities.find((item) => item.type === EntityType.Metadata) as { metadata: ObjectMeta } | undefined;
+  }, [entities]);
+
+  const getMetadata = useCallback(() => {
+    const found = findMetadata();
+    return found ? found.metadata : {};
+  }, [findMetadata]);
+
+  const onChangeModel = useCallback(
+    (model: ObjectMeta) => {
+      const metadata = findMetadata();
+      if (Object.keys(model).length > 0) {
+        if (!metadata) {
+          entities.push(new MetadataEntity(model));
+        } else {
+          Object.keys(metadata.metadata).forEach((key) => {
+            if (!(key in model)) {
+              delete metadata.metadata[key];
+            }
+          });
+          Object.assign(metadata.metadata, model);
+        }
+      } else if (metadata) {
+        const index = entities.indexOf(metadata as MetadataEntity);
+        entities.splice(index, 1);
+      }
+      entitiesContext?.updateCodeFromEntities();
+    },
+    [entities, entitiesContext, findMetadata],
+  );
+
+  return (
+    <>
+      <Title headingLevel="h1">Metadata Configuration</Title>
+      <MetadataEditor
+        name="Metadata"
+        schema={schemaMap.ObjectMeta.schema}
+        metadata={getMetadata()}
+        onChangeModel={onChangeModel}
+      />
+    </>
+  );
+};

--- a/packages/ui/src/pages/Metadata/index.ts
+++ b/packages/ui/src/pages/Metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/packages/ui/src/pages/Metadata/router-exports.tsx
+++ b/packages/ui/src/pages/Metadata/router-exports.tsx
@@ -1,0 +1,3 @@
+import { MetadataPage } from './MetadataPage';
+
+export const element = <MetadataPage />;

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -1,0 +1,61 @@
+import { Title } from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useContext } from 'react';
+import { MetadataEditor } from '../../components/MetadataEditor';
+import { useSchemasStore } from '../../store';
+import { EntitiesContext } from '../../providers/entities.provider';
+import { ObjectMeta } from '@kaoto-next/camel-catalog/types';
+import { EntityType } from '../../models/camel/entities';
+import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto/camel-catalog/types';
+import { PipeErrorHandlerEntity } from '../../models/visualization/metadata/pipeErrorHandlerEntity';
+
+export const PipeErrorHandlerPage: FunctionComponent = () => {
+  const schemaMap = useSchemasStore((state) => state.schemas);
+  const entitiesContext = useContext(EntitiesContext);
+  const entities = entitiesContext?.entities ?? [];
+
+  const findErrorHandler = useCallback(() => {
+    return entities.find((item) => item.type === EntityType.ErrorHandler) as
+      | { errorHandler: PipeErrorHandlerType }
+      | undefined;
+  }, [entities]);
+
+  const getErrorHandler = useCallback(() => {
+    const found = findErrorHandler();
+    return found ? found.errorHandler : {};
+  }, [findErrorHandler]);
+
+  const onChangeModel = useCallback(
+    (model: ObjectMeta) => {
+      const errorHandler = findErrorHandler();
+      if (Object.keys(model).length > 0) {
+        if (!errorHandler) {
+          entities.push(new PipeErrorHandlerEntity(model));
+        } else {
+          Object.keys(errorHandler.errorHandler).forEach((key) => {
+            if (!(key in model)) {
+              delete errorHandler?.errorHandler[key];
+            }
+          });
+          Object.assign(errorHandler.errorHandler, model);
+        }
+      } else if (errorHandler) {
+        const index = entities.indexOf(errorHandler as PipeErrorHandlerEntity);
+        entities.splice(index, 1);
+      }
+      entitiesContext?.updateCodeFromEntities();
+    },
+    [entities, entitiesContext, findErrorHandler],
+  );
+
+  return (
+    <>
+      <Title headingLevel="h1">Pipe ErrorHandler Configuration</Title>
+      <MetadataEditor
+        name="ErrorHandler"
+        schema={schemaMap['PipeErrorHandler'].schema}
+        metadata={getErrorHandler()}
+        onChangeModel={onChangeModel}
+      />
+    </>
+  );
+};

--- a/packages/ui/src/pages/PipeErrorHandler/index.ts
+++ b/packages/ui/src/pages/PipeErrorHandler/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/packages/ui/src/pages/PipeErrorHandler/router-exports.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/router-exports.tsx
@@ -1,0 +1,3 @@
+import { PipeErrorHandlerPage } from './PipeErrorHandlerPage';
+
+export const element = <PipeErrorHandlerPage />;

--- a/packages/ui/src/router.tsx
+++ b/packages/ui/src/router.tsx
@@ -25,6 +25,14 @@ export const router = createHashRouter([
         path: Links.Beans,
         lazy: async () => import('./pages/Beans'),
       },
+      {
+        path: Links.Metadata,
+        lazy: async () => import('./pages/Metadata'),
+      },
+      {
+        path: Links.PipeErrorHandler,
+        lazy: async () => import('./pages/PipeErrorHandler'),
+      },
     ],
   },
 ]);

--- a/packages/ui/src/router/links.models.ts
+++ b/packages/ui/src/router/links.models.ts
@@ -3,6 +3,8 @@ export const enum Links {
   SourceCode = '/code', // Flows source code
   Beans = '/beans',
   Rest = '/rest',
+  Metadata = '/metadata',
+  PipeErrorHandler = '/pipe-error-handler',
   Catalog = '/catalog',
 }
 

--- a/packages/ui/src/stubs/kamelet-binding-route.ts
+++ b/packages/ui/src/stubs/kamelet-binding-route.ts
@@ -9,7 +9,24 @@ apiVersion: camel.apache.org/v1
 kind: KameletBinding
 metadata:
   name: webhook-binding
+  annotations:
+    sco1237896.github.com/catalog.group: "messaging"
+    sco1237896.github.com/catalog.id: "http"
+    sco1237896.github.com/connector.description: "Send data to a HTTP endpoint."
+    sco1237896.github.com/connector.group: "messaging"
+    sco1237896.github.com/connector.id: "http_sink_v1"
+    sco1237896.github.com/connector.title: "HTTP sink"
+    sco1237896.github.com/connector.version: "v1"
+    trait.camel.apache.org/container.request-cpu: "0.20"
+    trait.camel.apache.org/container.request-memory: "128M"
+    trait.camel.apache.org/deployment.progress-deadline-seconds: "30"
+    trait.camel.apache.org/container.image: "quay.io/sco1237896/connector-http:camel-4-1046a96"
 spec:
+  errorHandler:
+    log:
+      parameters:
+        maximumRedeliveries: 3
+        redeliveryDelay: 2000
   source:
     ref:
       kind: Kamelet
@@ -35,8 +52,29 @@ export const kameletBindingJson = {
   kind: 'KameletBinding',
   metadata: {
     name: 'webhook-binding',
+    annotations: {
+      'sco1237896.github.com/catalog.group': 'messaging',
+      'sco1237896.github.com/catalog.id': 'http',
+      'sco1237896.github.com/connector.description': 'Send data to a HTTP endpoint.',
+      'sco1237896.github.com/connector.group': 'messaging',
+      'sco1237896.github.com/connector.id': 'http_sink_v1',
+      'sco1237896.github.com/connector.title': 'HTTP sink',
+      'sco1237896.github.com/connector.version': 'v1',
+      'trait.camel.apache.org/container.request-cpu': '0.20',
+      'trait.camel.apache.org/container.request-memory': '128M',
+      'trait.camel.apache.org/deployment.progress-deadline-seconds': '30',
+      'trait.camel.apache.org/container.image': 'quay.io/sco1237896/connector-http:camel-4-1046a96',
+    },
   },
   spec: {
+    errorHandler: {
+      log: {
+        parameters: {
+          maximumRedeliveries: 3,
+          redeliveryDelay: 2000,
+        },
+      },
+    },
     source: {
       ref: {
         kind: 'Kamelet',
@@ -56,7 +94,7 @@ export const kameletBindingJson = {
     sink: {
       ref: {
         kind: 'Kamelet',
-        apiVersion: 'camel.apache.org/v1alpha1',
+        apiVersion: 'camel.apache.org/v1',
         name: 'log-sink',
       },
     },

--- a/packages/ui/src/stubs/pipe.ts
+++ b/packages/ui/src/stubs/pipe.ts
@@ -7,28 +7,20 @@ export const pipeYaml = `
     source:
       ref:
         apiVersion: camel.apache.org/v1
-        name: timer-source
+        name: log-action
         kind: Kamelet
         properties:
-          period: "10000"
-          message: Hello
-    steps:
-      - ref:
-          apiVersion: camel.apache.org/v1
-          name: log-action
-          kind: Kamelet
-          properties:
-            showHeaders: "true"
-    sink:
-      ref:
-        apiVersion: camel.apache.org/v1
-        name: kafka-sink
-        kind: Kamelet
-        properties:
-          topic: myTopic
-          bootstrapServers: 192.168.0.1
-          user: test2
-          password: test
+          showHeaders: "true"
+  sink:
+    ref:
+      apiVersion: camel.apache.org/v1
+      name: kafka-sink
+      kind: Kamelet
+      properties:
+        topic: myTopic
+        bootstrapServers: 192.168.0.1
+        user: test2
+        password: test
 
 `;
 


### PR DESCRIPTION
Fixes: #181

Adding primitive k8s `metadata` and Pipe `errorHandler` configuration. We'll eventually need more user friendliness by focusing on CamelK usage of k8s `metadata`, for example showing a dropdown for available Camel K traits in `metadata.annotations`, etc.
Also uniforms doesn't well understand the schema composition (oneOf), causes it doesn't render a form for `errorHandler` configuration.
Adding them to the left menu just because it's the only place to add something ATM. It should be easy to move anywhere else once we decide.

https://github.com/KaotoIO/kaoto-next/assets/265462/aede10f8-01f5-48e0-8e51-ea662c8ab84e

