### PR TITLE
fix(catalog): Wait until the catalog is downloaded

### DIFF
--- a/packages/ui/src/providers/catalog-schema-loader.provider.tsx
+++ b/packages/ui/src/providers/catalog-schema-loader.provider.tsx
@@ -18,12 +18,12 @@ export const CatalogSchemaLoaderProvider: FunctionComponent<PropsWithChildren> =
   useEffect(() => {
     fetch(`.${DEFAULT_CATALOG_PATH}/index.json`)
       .then((response) => response.json())
-      .then((catalogIndex: CamelCatalogIndex) => {
+      .then(async (catalogIndex: CamelCatalogIndex) => {
         const camelComponentsFiles = fetchFile(catalogIndex.catalogs.components.file);
         const camelProcessorsFiles = fetchFile(catalogIndex.catalogs.models.file);
         const kameletsFiles = fetchFile(catalogIndex.catalogs.kamelets.file);
 
-        Promise.all([camelComponentsFiles, camelProcessorsFiles, kameletsFiles]).then(
+        await Promise.all([camelComponentsFiles, camelProcessorsFiles, kameletsFiles]).then(
           ([camelComponents, camelProcessors, kamelets]) => {
             setCatalog(CatalogKind.Component, camelComponents.body);
             setCatalog(CatalogKind.Processor, camelProcessors.body);


### PR DESCRIPTION
### Context
Currently, when downloading the Camel Catalog, we're not waiting until the process is completed, which leads to the rendering flows without icons.

The fix is to wait until the catalog is processed before rendering the content