### PR TITLE
feat(catalog): Minify Camel Catalog

### DIFF
--- a/packages/camel-catalog/src/json-schema-to-typescript.mts
+++ b/packages/camel-catalog/src/json-schema-to-typescript.mts
@@ -40,7 +40,7 @@ const addTitleToDefinitions = (schema: JSONSchema) => {
     }
 
     const title = key.split('.').slice(-1).join('');
-    console.log(`Adding title to ${key}: ${title}`);
+    console.log(`\tAdding title to ${key}: ${title}`);
 
     value.title = title;
   });

--- a/packages/ui/vite.config.cjs
+++ b/packages/ui/vite.config.cjs
@@ -50,12 +50,20 @@ function copyKaotoCamelCatalog() {
     throw new Error(message.join('\n\n'));
   }
 
+  /** List all the JSON files in the Camel Catalog folder */
+  const jsonFiles = fs
+    .readdirSync(camelCatalogPath)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => path.join(camelCatalogPath, file));
+
   return viteStaticCopy({
     targets: [
       {
-        src: camelCatalogPath,
-        dest: '.',
-        rename: 'camel-catalog',
+        src: jsonFiles,
+        dest: 'camel-catalog',
+        transform: (content, filename) => {
+          return JSON.stringify(JSON.parse(content));
+        },
       },
     ],
   });


### PR DESCRIPTION
### Context
Currently, we're generating the Camel Catalog at build time, in a pretty fashion.

The issue with this approach is the file size increase.

This pull request minifies those files at the UI build time, but preserves them in a pretty fashion in the `dist` folder, so it can be analyzed locally for devs.

#### Before
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/dc5e350b-be50-4aa2-88f4-1ab460391a87)

#### After
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/ba9284d5-5c06-4720-a6ca-f22904dbf560)


Fixes: https://github.com/KaotoIO/kaoto-next/issues/131