### PR TITLE
feat(viz): Add Loading component

### DIFF
--- a/packages/ui/src/components/Loading/Loading.test.tsx
+++ b/packages/ui/src/components/Loading/Loading.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Loading } from './Loading';
+
+describe('Loading component', () => {
+  it('renders a spinner', () => {
+    const { getByRole } = render(<Loading />);
+    const spinner = getByRole('progressbar');
+
+    expect(spinner).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Loading/Loading.tsx
+++ b/packages/ui/src/components/Loading/Loading.tsx
@@ -1,0 +1,10 @@
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+export const Loading: FunctionComponent<PropsWithChildren> = (props) => {
+  return (
+    <Bullseye>
+      <Spinner size="lg" aria-label="Loading" /> {props.children}
+    </Bullseye>
+  );
+};

--- a/packages/ui/src/components/Loading/index.ts
+++ b/packages/ui/src/components/Loading/index.ts
@@ -1,0 +1,1 @@
+export * from './Loading';


### PR DESCRIPTION
### Context
Adding a `Loading` distractor component to use it when loading `kaoto-next`

### Screenshot
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/350b0e89-4d05-4838-8cad-d1dbed604f19)
