### PR TITLE
chore: Hide new route

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -13,7 +13,7 @@ export const ContextToolbar: FunctionComponent = () => {
         {sourceSchemaConfig.config[currentSchemaType].name || 'None'}
       </Chip>
     </ToolbarItem>,
-    <ToolbarItem key={'toolbar-new-route'}>
+    <ToolbarItem style={{ display: 'none' }} key={'toolbar-new-route'}>
       <NewFlow />
     </ToolbarItem>,
     <ToolbarItem key={'toolbar-flows-list'}>


### PR DESCRIPTION
### Context
While the **New Route** functionality was ported from Kaoto, it's not yet fully wired up.

### Changes
Temporarily hide the **New Route** drop-down until is completely functional.

### Before
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/bc8e03ba-a59f-40dc-a3dd-b78216176ebd)

### After
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/ca025f20-edbe-428f-99da-4a1baaaab683)
