### PR TITLE
feat(viz): Implement `New Route` and `Remove` route 

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
@@ -7,14 +7,11 @@ import { Schema } from '../../../../models';
 import { EntitiesContextResult } from '../../../../hooks';
 
 const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Integration].schema = { schema: { name: 'Integration', description: 'desc' } } as Schema;
-config.config[SourceSchemaType.Pipe].schema = { schema: { name: 'Pipe', description: 'desc' } } as Schema;
-config.config[SourceSchemaType.Kamelet].schema = { schema: { name: 'Kamelet', description: 'desc' } } as Schema;
-config.config[SourceSchemaType.KameletBinding].schema = {
-  name: 'kameletBinding',
-  schema: { description: 'desc' },
+config.config[SourceSchemaType.Pipe].schema = { name: 'Pipe', schema: { name: 'Pipe', description: 'desc' } } as Schema;
+config.config[SourceSchemaType.Route].schema = {
+  name: 'route',
+  schema: { name: 'route', description: 'desc' },
 } as Schema;
-config.config[SourceSchemaType.Route].schema = { schema: { name: 'route', description: 'desc' } } as Schema;
 
 const onSelect = jest.fn();
 const FlowTypeSelectorWithContext: React.FunctionComponent<{ currentSchemaType?: SourceSchemaType }> = ({
@@ -24,7 +21,7 @@ const FlowTypeSelectorWithContext: React.FunctionComponent<{ currentSchemaType?:
     <EntitiesContext.Provider
       value={
         {
-          currentSchemaType: currentSchemaType ?? SourceSchemaType.Integration,
+          currentSchemaType: currentSchemaType ?? SourceSchemaType.Route,
           visualEntities: [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity],
         } as unknown as EntitiesContextResult
       }
@@ -73,7 +70,7 @@ describe('FlowTypeSelector.tsx', () => {
       fireEvent.click(toggle);
     });
 
-    const element = wrapper.getByText('Integration');
+    const element = wrapper.getByText('Camel Route');
     expect(element).toBeInTheDocument();
 
     /** Close Select */
@@ -93,12 +90,12 @@ describe('FlowTypeSelector.tsx', () => {
       fireEvent.click(toggle);
     });
 
-    const element = await wrapper.findByText('Integration');
+    const element = await wrapper.findByText('Camel Route');
     expect(element).toBeInTheDocument();
   });
 
   test('should disable a SelectOption if is already selected and does not support multiple flows', async () => {
-    const wrapper = render(<FlowTypeSelectorWithContext currentSchemaType={SourceSchemaType.KameletBinding} />);
+    const wrapper = render(<FlowTypeSelectorWithContext currentSchemaType={SourceSchemaType.Pipe} />);
     const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
@@ -106,10 +103,10 @@ describe('FlowTypeSelector.tsx', () => {
       fireEvent.click(toggle);
     });
 
-    const element = await wrapper.findByText('Kamelet Binding (single route only)');
+    const element = await wrapper.findByText('Pipe (single route only)');
     expect(element).toBeInTheDocument();
 
-    const option = await wrapper.findByTestId('dsl-kameletBinding');
+    const option = await wrapper.findByTestId('dsl-Pipe');
     expect(option).toHaveClass('pf-m-disabled');
   });
 
@@ -124,7 +121,7 @@ describe('FlowTypeSelector.tsx', () => {
 
     /** Click on first element */
     act(() => {
-      const element = wrapper.getByText('Integration');
+      const element = wrapper.getByText('Camel Route');
       fireEvent.click(element);
     });
 
@@ -135,7 +132,7 @@ describe('FlowTypeSelector.tsx', () => {
 
     const element = await wrapper.findByRole('option', { selected: true });
     expect(element).toBeInTheDocument();
-    expect(element).toHaveTextContent('Integration');
+    expect(element).toHaveTextContent('Camel Route');
   });
 
   test('should not have anything selected if "isStatic=true"', async () => {
@@ -149,7 +146,7 @@ describe('FlowTypeSelector.tsx', () => {
 
     /** Click on first element */
     act(() => {
-      const element = wrapper.getByText('Integration');
+      const element = wrapper.getByText('Camel Route');
       fireEvent.click(element);
     });
 
@@ -176,7 +173,7 @@ describe('FlowTypeSelector.tsx', () => {
     waitFor(() => {
       const element = wrapper.queryByRole('option', { selected: true });
       expect(element).toBeInTheDocument();
-      expect(element).toHaveTextContent('Kamelet');
+      expect(element).toHaveTextContent('Pipe');
     });
   });
 
@@ -204,7 +201,7 @@ describe('FlowTypeSelector.tsx', () => {
     waitFor(() => {
       const element = wrapper.queryByRole('option', { selected: true });
       expect(element).toBeInTheDocument();
-      expect(element).toHaveTextContent('Integration');
+      expect(element).toHaveTextContent('Camel Route');
     });
   });
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
@@ -21,7 +21,6 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
   const totalFlowsCount = visualEntities.length;
   const currentFlowType: ISourceSchema = sourceSchemaConfig.config[currentSchemaType];
   const [isOpen, setIsOpen] = useState(false);
-  const [selected, setSelected] = useState<SourceSchemaType | undefined>(currentSchemaType);
 
   /** Toggle the DSL dropdown */
   const onToggleClick = () => {
@@ -30,17 +29,13 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
 
   /** Selecting a DSL checking the the existing flows */
   const onSelect = useCallback(
-    (_event: MouseEvent | undefined, selectedDslName: string | number | undefined) => {
-      if (selectedDslName) {
-        const dsl = sourceSchemaConfig.config[selectedDslName as SourceSchemaType];
-
-        if (!props.isStatic) {
-          setSelected(selectedDslName as SourceSchemaType);
-        }
+    (_event: MouseEvent | undefined, flowType: string | number | undefined) => {
+      if (flowType) {
+        const dsl = sourceSchemaConfig.config[flowType as SourceSchemaType];
 
         setIsOpen(false);
         if (typeof props.onSelect === 'function' && dsl !== undefined) {
-          props.onSelect(selectedDslName as SourceSchemaType);
+          props.onSelect(flowType as SourceSchemaType);
         }
       }
     },
@@ -93,7 +88,7 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
     <Select
       id="dsl-list-select"
       isOpen={isOpen}
-      selected={selected}
+      selected={currentSchemaType}
       onSelect={onSelect}
       onOpenChange={(isOpen) => {
         setIsOpen(isOpen);
@@ -101,7 +96,10 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
       toggle={toggle}
     >
       <SelectList>
-        {Object.entries(sourceSchemaConfig.config).map((obj, index) => {
+        {Object.entries({
+          [SourceSchemaType.Route]: sourceSchemaConfig.config[SourceSchemaType.Route],
+          [SourceSchemaType.Pipe]: sourceSchemaConfig.config[SourceSchemaType.Pipe],
+        }).map((obj, index) => {
           const sourceType = obj[0] as SourceSchemaType;
           const sourceSchema = obj[1] as ISourceSchema;
           const isOptionDisabled =

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
@@ -45,8 +45,8 @@ describe('NewFlow.tsx', () => {
       fireEvent.click(trigger);
     });
 
-    for (const s of Object.values(sourceSchemaConfig.config)) {
-      const element = await wrapper.findByText(s.name);
+    for (const name of ['Pipe', 'Camel Route']) {
+      const element = await wrapper.findByText(name);
       expect(element).toBeInTheDocument();
     }
   });
@@ -62,7 +62,7 @@ describe('NewFlow.tsx', () => {
 
     /** Select an option */
     act(() => {
-      const element = wrapper.getByText('Kamelet');
+      const element = wrapper.getByText('Pipe');
       fireEvent.click(element);
     });
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
@@ -14,7 +14,6 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
 
   const checkBeforeAddNewFlow = useCallback(
     (flowType: SourceSchemaType) => {
-      //  console.log('selected new flow', flowType);
       const isSameSourceType = entitiesContext.currentSchemaType === flowType;
 
       if (isSameSourceType) {

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -14,19 +14,10 @@ interface IFlowsList {
 }
 
 export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
-  const { visualEntities } = useContext(EntitiesContext)!;
+  const { visualEntities, camelResource, updateCodeFromEntities } = useContext(EntitiesContext)!;
   const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
 
-  const { isListEmpty, flows, setFlowName, deleteFlow } = {
-    isListEmpty: visualEntities.length === 0,
-    flows: visualEntities,
-    setFlowName: (id: string, name: string) => {
-      console.log('setting the name ', id, name);
-    },
-    deleteFlow: (id: string) => {
-      console.log('delete flow ', id);
-    },
-  };
+  const isListEmpty = visualEntities.length === 0;
 
   const columnNames = useRef({
     id: 'Route Id',
@@ -55,7 +46,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
         </Tr>
       </Thead>
       <Tbody>
-        {flows.map((flow: BaseVisualCamelEntity) => (
+        {visualEntities.map((flow: BaseVisualCamelEntity) => (
           <Tr key={flow.id} data-testid={`flows-list-row-${flow.id}`}>
             <Td dataLabel={columnNames.current.id}>
               <InlineEdit
@@ -65,9 +56,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 onClick={() => {
                   onSelectFlow(flow.id);
                 }}
-                onChange={(name) => {
-                  setFlowName(flow.id, name);
-                }}
+                onChange={(_name) => {}}
               />
               {/*TODO add description*/}
             </Td>
@@ -101,7 +90,8 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 icon={<TrashIcon />}
                 variant="plain"
                 onClick={(event) => {
-                  deleteFlow(flow.id);
+                  camelResource.removeEntity(flow.id);
+                  updateCodeFromEntities();
                   /** Required to avoid closing the Dropdown after clicking in the icon */
                   event.stopPropagation();
                 }}

--- a/packages/ui/src/hooks/entities.ts
+++ b/packages/ui/src/hooks/entities.ts
@@ -67,7 +67,7 @@ export const useEntities = (): EntitiesContextResult => {
       currentSchemaType: camelResource?.getType(),
       setCurrentSchemaType: setCurrentSchemaType(),
       visualEntities: camelResource.getVisualEntities(),
-      flowTemplateService: flowTemplateService,
+      flowTemplateService,
       camelResource,
       updateCodeFromEntities,
       eventNotifier,

--- a/packages/ui/src/hooks/entities.ts
+++ b/packages/ui/src/hooks/entities.ts
@@ -4,6 +4,7 @@ import { CamelResource, SourceSchemaType, createCamelResource } from '../models/
 import { BaseCamelEntity } from '../models/camel/entities';
 import { BaseVisualCamelEntity } from '../models/visualization/base-visual-entity';
 import { EventNotifier } from '../utils';
+import { FlowTemplateService, flowTemplateService } from '../models/visualization/flows/flow-templates-service';
 
 export interface EntitiesContextResult {
   code: string;
@@ -12,6 +13,7 @@ export interface EntitiesContextResult {
   currentSchemaType: SourceSchemaType;
   setCurrentSchemaType: (entity: SourceSchemaType) => void;
   visualEntities: BaseVisualCamelEntity[];
+  flowTemplateService: FlowTemplateService;
   camelResource: CamelResource;
   updateCodeFromEntities: () => void;
   eventNotifier: EventNotifier;
@@ -65,10 +67,19 @@ export const useEntities = (): EntitiesContextResult => {
       currentSchemaType: camelResource?.getType(),
       setCurrentSchemaType: setCurrentSchemaType(),
       visualEntities: camelResource.getVisualEntities(),
+      flowTemplateService: flowTemplateService,
       camelResource,
       updateCodeFromEntities,
       eventNotifier,
     }),
-    [sourceCode, setCode, setCurrentSchemaType, camelResource, updateCodeFromEntities, eventNotifier],
+    [
+      sourceCode,
+      setCode,
+      setCurrentSchemaType,
+      camelResource,
+      updateCodeFromEntities,
+      eventNotifier,
+      flowTemplateService,
+    ],
   );
 };

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -37,6 +37,7 @@ export abstract class CamelKResource implements CamelResource {
     this.metadata = this.resource.metadata && new MetadataEntity(this.resource!);
   }
 
+  removeEntity(_id?: string) {}
   createMetadataEntity() {
     this.resource.metadata = {};
     this.metadata = new MetadataEntity(this.resource!);
@@ -67,4 +68,8 @@ export abstract class CamelKResource implements CamelResource {
   abstract supportsMultipleVisualEntities(): boolean;
 
   abstract toJSON(): unknown;
+
+  addNewEntity(): string {
+    return '';
+  }
 }

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -17,6 +17,8 @@ import {
 export interface CamelResource {
   getVisualEntities(): BaseVisualCamelEntity[];
   getEntities(): BaseCamelEntity[];
+  addNewEntity(entity?: unknown): string;
+  removeEntity(id?: string): void;
   supportsMultipleVisualEntities(): boolean;
   toJSON(): unknown;
   getType(): SourceSchemaType;

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -4,6 +4,8 @@ import { CamelRouteVisualEntity, isCamelRoute } from '../visualization/flows';
 import { BeansEntity, isBeans } from '../visualization/metadata';
 import { SourceSchemaType } from './source-schema-type';
 import { isDefined } from '../../utils';
+import { flowTemplateService } from '../visualization/flows/flow-templates-service';
+import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
 
 export class CamelRouteResource implements CamelResource, BeansAwareResource {
   private entities: BaseCamelEntity[] = [];
@@ -18,6 +20,15 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
       }
       return acc;
     }, [] as BaseCamelEntity[]);
+  }
+
+  addNewEntity(_entity?: unknown): string {
+    const template = flowTemplateService.getFlowTemplate(this.getType());
+    const route = template[0].route as Partial<RouteDefinition>;
+    const visualEntity = new CamelRouteVisualEntity(route);
+    this.entities.push(visualEntity);
+
+    return visualEntity.id;
   }
 
   getEntity(rawItem: unknown): BaseCamelEntity | undefined {
@@ -63,6 +74,18 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
     const index = this.entities.findIndex((e) => e === entity);
     if (index !== -1) {
       this.entities.splice(index, 1);
+    }
+  }
+
+  removeEntity(id?: string): void {
+    const index: number = this.entities.findIndex((e) => e.id === id);
+
+    if (index !== -1) {
+      this.entities.splice(index, 1);
+    }
+    // we don't want to end up with clean entities, so we're adding default one if the list if empty
+    if (this.entities.length === 0) {
+      this.addNewEntity();
     }
   }
 }

--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -37,4 +37,9 @@ export class IntegrationResource extends CamelKResource {
   toJSON(): IntegrationType {
     return this.integration;
   }
+
+  addNewEntity(): string {
+    //TODO
+    return '';
+  }
 }

--- a/packages/ui/src/models/camel/kamelet-binding-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.ts
@@ -22,4 +22,9 @@ export class KameletBindingResource extends PipeResource {
   getType(): SourceSchemaType {
     return SourceSchemaType.KameletBinding;
   }
+
+  addNewEntity(): string {
+    //TODO
+    return '';
+  }
 }

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -37,4 +37,10 @@ export class KameletResource extends CamelKResource {
   toJSON(): KameletType {
     return this.kamelet;
   }
+
+  addNewEntity(): string {
+    //TODO
+    console.log('Replacing Kamelet visual entity');
+    return '';
+  }
 }

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -4,6 +4,7 @@ import { Pipe as PipeType } from '@kaoto-next/camel-catalog/types';
 import { SourceSchemaType } from './source-schema-type';
 import { PipeErrorHandlerEntity } from '../visualization/metadata/pipeErrorHandlerEntity';
 import { CamelKResource } from './camel-k-resource';
+import { flowTemplateService } from '../visualization/flows/flow-templates-service';
 
 export class PipeResource extends CamelKResource {
   protected pipe: PipeType;
@@ -25,7 +26,12 @@ export class PipeResource extends CamelKResource {
     this.errorHandler =
       this.pipe.spec.errorHandler && new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler);
   }
-
+  removeEntity(_id?: string): void {
+    super.removeEntity();
+    const flowTemplate = flowTemplateService.getFlowTemplate(this.getType())!;
+    this.pipe.spec = flowTemplate.spec;
+    this.flow = new PipeVisualEntity(flowTemplate.spec);
+  }
   getEntities(): BaseCamelEntity[] {
     const answer = super.getEntities();
     if (this.pipe.spec!.errorHandler && this.errorHandler) {
@@ -63,5 +69,10 @@ export class PipeResource extends CamelKResource {
   deleteErrorHandlerEntity() {
     this.pipe.spec!.errorHandler = undefined;
     this.errorHandler = undefined;
+  }
+
+  addNewEntity(): string {
+    //not supported
+    return '';
   }
 }

--- a/packages/ui/src/models/visualization/flows/flow-templates-service.ts
+++ b/packages/ui/src/models/visualization/flows/flow-templates-service.ts
@@ -1,0 +1,40 @@
+import { SourceSchemaType } from '../../camel/source-schema-type';
+import { parse } from 'yaml';
+
+export class FlowTemplateService {
+  getFlowTemplate = (type: SourceSchemaType) => {
+    return parse(this.getFlowYamlTemplate(type));
+  };
+
+  getFlowYamlTemplate = (type: SourceSchemaType): string => {
+    switch (type) {
+      case SourceSchemaType.Pipe:
+        return `apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: webhook-binding
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: timer-source
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink`;
+        break;
+      case SourceSchemaType.Route:
+        return `- route:
+    from:
+      uri: timer:template
+      steps:
+        - to:
+            uri: log:template`;
+      default:
+        return '';
+    }
+  };
+}
+export const flowTemplateService = new FlowTemplateService();

--- a/packages/ui/src/models/visualization/flows/flow-templates-service.ts
+++ b/packages/ui/src/models/visualization/flows/flow-templates-service.ts
@@ -12,13 +12,15 @@ export class FlowTemplateService {
         return `apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: webhook-binding
+  name: new-pipe-template
 spec:
   source:
     ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1
       name: timer-source
+      properties:
+        message: hello
   sink:
     ref:
       kind: Kamelet
@@ -29,9 +31,11 @@ spec:
         return `- route:
     from:
       uri: timer:template
+      parameters:
+        period: "1000"
       steps:
-        - to:
-            uri: log:template`;
+        - log:
+            message: template message`;
       default:
         return '';
     }

--- a/packages/ui/src/models/visualization/flows/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/flows-visibility.ts
@@ -95,7 +95,7 @@ export class VisualFlowsApi {
   }
 
   toggleFlowVisible(flowId: string, isVisible?: boolean) {
-    this.dispatch({ type: 'toggleFlowVisible', flowId: flowId, isVisible: isVisible });
+    this.dispatch({ type: 'toggleFlowVisible', flowId, isVisible });
   }
 
   showAllFlows() {
@@ -109,6 +109,7 @@ export class VisualFlowsApi {
   setVisibleFlows(flows: string[]) {
     this.dispatch({ type: 'setVisibleFlows', flows: flows });
   }
+
   clearFlows() {
     this.dispatch({ type: 'clearFlows' });
   }

--- a/packages/ui/src/models/visualization/flows/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/flows-visibility.ts
@@ -33,28 +33,19 @@ export function getVisibleFlowsInformation(visibleFlows: IVisibleFlows): IVisibl
   };
 }
 
-type ToggleFlowVisible = {
-  type: 'toggleFlowVisible';
-  flowId: string;
-  isVisible?: boolean;
-};
-type ShowAllFlows = {
-  type: 'showAllFlows';
-};
+type VisibleFlowAction =
+  | {
+      type: 'toggleFlowVisible';
+      flowId: string;
+      isVisible?: boolean;
+    }
+  | { type: 'showAllFlows' }
+  | { type: 'hideAllFlows' }
+  | { type: 'clearFlows' }
+  | { type: 'setVisibleFlows'; flows: string[] }
+  | { type: 'initVisibleFlows'; visibleFlows: IVisibleFlows };
 
-type HideAllFlows = {
-  type: 'hideAllFlows';
-};
-
-type SetVisibleFlows = {
-  type: 'setVisibleFlows';
-  flows: string[];
-};
-
-export function VisibleFlowsReducer(
-  state: IVisibleFlows,
-  action: ToggleFlowVisible | ShowAllFlows | HideAllFlows | SetVisibleFlows,
-) {
+export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAction) {
   let visibleFlows;
   switch (action.type) {
     case 'toggleFlowVisible':
@@ -84,24 +75,27 @@ export function VisibleFlowsReducer(
            * otherwise, we set the first flow to visible
            * and the rest to invisible
            */
-          [flow]: state[flow] ?? index === 0,
+          [flow]: acc[flow] ?? index === 0,
         }),
         {} as IVisibleFlows,
       );
       return { ...state, ...visibleFlows };
+    case 'clearFlows':
+      return {};
+    case 'initVisibleFlows':
+      return { ...action.visibleFlows };
   }
 }
 
 export class VisualFlowsApi {
-  private dispatch: React.Dispatch<ToggleFlowVisible | ShowAllFlows | HideAllFlows | SetVisibleFlows>;
+  private dispatch: React.Dispatch<VisibleFlowAction>;
 
-  constructor(dispatch: React.Dispatch<ToggleFlowVisible | ShowAllFlows | HideAllFlows | SetVisibleFlows>) {
+  constructor(dispatch: React.Dispatch<VisibleFlowAction>) {
     this.dispatch = dispatch;
   }
 
   toggleFlowVisible(flowId: string, isVisible?: boolean) {
-    const t: ToggleFlowVisible = { type: 'toggleFlowVisible', flowId: flowId, isVisible: isVisible };
-    this.dispatch(t);
+    this.dispatch({ type: 'toggleFlowVisible', flowId: flowId, isVisible: isVisible });
   }
 
   showAllFlows() {
@@ -109,10 +103,17 @@ export class VisualFlowsApi {
   }
 
   hideAllFlows() {
-    this.dispatch({ type: 'hideAllFlows' } as HideAllFlows);
+    this.dispatch({ type: 'hideAllFlows' });
   }
 
   setVisibleFlows(flows: string[]) {
     this.dispatch({ type: 'setVisibleFlows', flows: flows });
+  }
+  clearFlows() {
+    this.dispatch({ type: 'clearFlows' });
+  }
+
+  initVisibleFlows(visibleFlows: IVisibleFlows) {
+    this.dispatch({ type: 'initVisibleFlows', visibleFlows: visibleFlows });
   }
 }

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -20,7 +20,7 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
     const flows: IVisibleFlows = {};
 
     entitiesContext?.visualEntities.forEach((visualEntity) => (flows[visualEntity.id] = visibleFlows[visualEntity.id]));
-    const hiddenAll = Object.values(flows).reduce((acc, current) => acc && !current, true);
+    const hiddenAll = Object.values(flows).every((visible) => !visible);
     if (hiddenAll) {
       flows[entitiesContext!.visualEntities[0].id] = true;
     }

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -17,8 +17,15 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
   }, [dispatch]);
 
   useEffect(() => {
-    const flows = entitiesContext?.visualEntities.map((visualEntity) => visualEntity.id) ?? [];
-    visualFlowsApi.setVisibleFlows(flows);
+    const flows: IVisibleFlows = {};
+
+    entitiesContext?.visualEntities.forEach((visualEntity) => (flows[visualEntity.id] = visibleFlows[visualEntity.id]));
+    const hiddenAll = Object.values(flows).reduce((acc, current) => acc && !current, true);
+    if (hiddenAll) {
+      flows[entitiesContext!.visualEntities[0].id] = true;
+    }
+
+    visualFlowsApi.initVisibleFlows(flows);
   }, [entitiesContext, visualFlowsApi]);
 
   const value = useMemo(() => {


### PR DESCRIPTION
Make `New Route` and Remove route functional. Also I refactored  VisibleFlowsReducer to be more readable and fixed wrong numbers. 
This PR also introduces flowTemplateService which in the future should be use to provide default yaml templates when adding new flows. 
