### PR TITLE
feat(viz): Enable zoom and scroll for the canvas

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -8,7 +8,6 @@ import {
   EdgeAnimationSpeed,
   EdgeStyle,
   ForceLayout,
-  GraphComponent,
   GridLayout,
   ModelKind,
   Visualization,
@@ -66,7 +65,7 @@ describe('CanvasService', () => {
     it('should return the correct component for a graph', () => {
       const component = CanvasService.baselineComponentFactory(ModelKind.graph, 'graph');
 
-      expect(component).toBe(GraphComponent);
+      expect(component).toBeDefined();
     });
 
     it('should return the correct component for a node', () => {

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -18,6 +18,7 @@ import {
   ModelKind,
   NodeShape,
   Visualization,
+  withPanZoom,
 } from '@patternfly/react-topology';
 import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 import { CustomNodeWithSelection } from '../Custom/CustomNode';
@@ -58,7 +59,7 @@ export class CanvasService {
       default:
         switch (kind) {
           case ModelKind.graph:
-            return GraphComponent;
+            return withPanZoom()(GraphComponent);
           case ModelKind.node:
             return CustomNodeWithSelection;
           case ModelKind.edge:


### PR DESCRIPTION
### Context
Currently, there's no mechanism to alter the canvas view port.

### Changes
This pull request enables the Zoom and Pane functionality from `@patternfly/react-topology`

### Demo
[Screencast from 2023-10-30 17-05-03.webm](https://github.com/KaotoIO/kaoto-next/assets/16512618/171cdbf2-cae4-475e-bcd7-8a182733ed86)
