### PR TITLE
fix(viz): Fix broken Camel Route representation

### DIFF
--- a/packages/ui/src/models/visualization/flows/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-component-schema.service.ts
@@ -44,12 +44,12 @@ export class CamelComponentSchemaService {
 
   static getProcessorStepsProperties(
     processorName: string,
-  ): { name: string; type: 'processor' | 'list' | 'expression-list' }[] {
+  ): { name: string; type: 'single-processor' | 'steps-list' | 'expression-list' }[] {
     switch (processorName) {
       case 'choice':
         return [
           { name: 'when', type: 'expression-list' },
-          { name: 'otherwise', type: 'processor' },
+          { name: 'otherwise', type: 'single-processor' },
         ];
 
       case 'aggregate':
@@ -61,7 +61,7 @@ export class CamelComponentSchemaService {
       case 'from':
       case 'when':
       case 'otherwise':
-        return [{ name: 'steps', type: 'list' }];
+        return [{ name: 'steps', type: 'steps-list' }];
 
       default:
         return [];

--- a/packages/ui/src/models/visualization/flows/support/camel-component-types.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-types.ts
@@ -1,0 +1,26 @@
+import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { IVisualizationNodeData } from '../../base-visual-entity';
+
+export interface ICamelElementLookupResult {
+  processorName: keyof ProcessorDefinition;
+  componentName?: string;
+}
+
+export type CamelRouteVisualEntityData = IVisualizationNodeData & ICamelElementLookupResult;
+
+/**
+ * Interface to shape the properties from Processors that can be filled
+ * with nested Camel Processors.
+ */
+export interface CamelProcessorStepsProperties {
+  /** Property name, f.i., `steps` */
+  name: string;
+
+  /**
+   * Property handling type
+   * processor: the property can have a single processor
+   * list: the property have a list of `processors`, f.i. `steps`
+   * expression-list: the property can have a list of `processors`, usually in the shape of `expression`, f.i. `when` and `doCatch`
+   */
+  type: 'single-processor' | 'steps-list' | 'expression-list';
+}


### PR DESCRIPTION
### Context
Currently, the Camel Route representation is broken due to the children are not placed correctly

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/b3bb431b-92eb-413f-8f9f-116e18a6a656) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/77102fee-e32c-49c9-9cf3-72a56f646b7c) |


### Notes
Kudos to @pprosser-redhat for providing an example route that helped to identify the issue