### PR TITLE
feat(viz) Replace Camel Route steps

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -43,6 +43,19 @@ describe('camelComponentToTile', () => {
     expect(tile.tags).toEqual(['label1', 'label2']);
     expect(tile.version).toEqual('4.0.0');
   });
+
+  it('should populate tags with `consumerOnly` and `producerOnly` when applicable', () => {
+    const componentDef = {
+      component: {
+        consumerOnly: true,
+        producerOnly: true,
+      },
+    } as ICamelComponentDefinition;
+
+    const tile = camelComponentToTile(componentDef);
+
+    expect(tile.tags).toEqual(['consumerOnly', 'producerOnly']);
+  });
 });
 
 describe('camelProcessorToTile', () => {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -12,6 +12,12 @@ export const camelComponentToTile = (componentDef: ICamelComponentDefinition): I
   if (label) {
     tags.push(...label.split(','));
   }
+  if (componentDef.component.consumerOnly) {
+    tags.push('consumerOnly');
+  }
+  if (componentDef.component.producerOnly) {
+    tags.push('producerOnly');
+  }
 
   return {
     type: CatalogKind.Component,

--- a/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
@@ -24,7 +24,6 @@ export const ItemReplaceNode: FunctionComponent<IDataTestID> = (props) => {
 
     /** Open Catalog modal, filtering the compatible nodes */
     const definedComponent = await catalogModalContext?.getNewComponent(compatibleNodes);
-    console.log(definedComponent);
     if (!definedComponent) return;
 
     /** Add new node to the entities */

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -234,11 +234,11 @@ describe('Camel Route', () => {
       expect(vizNode.data.label).toEqual('timer:tutorial');
     });
 
-    it('should set an empty label if the uri is not available', () => {
+    it('should set a default label if the uri is not available', () => {
       camelEntity = new CamelRouteVisualEntity({ from: {} } as RouteDefinition);
       const vizNode = camelEntity.toVizNode();
 
-      expect(vizNode.data.label).toEqual('');
+      expect(vizNode.data.label).toEqual('from: Unknown');
     });
 
     it('should populate the viz node chain with the steps', () => {

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -211,14 +211,11 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
       (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
     );
-    const catalogFilter = CamelComponentSchemaService.getCompatibleComponents(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
-    );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
       (data as CamelRouteVisualEntityData).processorName,
     );
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
-    const canHaveSpecialChildren = Object.keys(catalogFilter).length > 0;
+    const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
 
     return {
       canHavePreviousStep,

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -232,6 +232,11 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
     const rootNode = this.getVizNodeFromProcessor('from', { processorName: 'from' as keyof ProcessorDefinition });
     rootNode.data.entity = this;
 
+    if (!this.route.from?.uri) {
+      rootNode.data.label = 'from: Unknown';
+      rootNode.data.icon = NodeIconResolver.getPlaceholderIcon();
+    }
+
     return rootNode;
   }
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -11,6 +11,17 @@ import { CatalogKind } from '../../../catalog-kind';
  */
 export class CamelComponentDefaultService {
   /**
+   * Get the default definition for the `from` component
+   */
+  static getDefaultFromDefinitionValue(definedComponent: DefinedComponent): ProcessorDefinition {
+    return parse(`
+      id: ${getCamelRandomId('from')}
+      uri: "${definedComponent.name}"
+      parameters: {}
+    `);
+  }
+
+  /**
    * Get the default value for a given component and property
    */
   static getDefaultNodeDefinitionValue(definedComponent: DefinedComponent): ProcessorDefinition {
@@ -27,14 +38,12 @@ export class CamelComponentDefaultService {
   }
 
   private static getDefaultValueFromComponent(componentName: string): object {
-    switch (componentName) {
-      default:
-        return parse(`
-          to:
-            uri: "${componentName}"
-            id: ${getCamelRandomId('to')}
-        `);
-    }
+    return parse(`
+      to:
+        id: ${getCamelRandomId('to')}
+        uri: "${componentName}"
+        parameters: {}
+    `);
   }
 
   private static getDefaultValueFromKamelet(kameletName: string): object {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -3,7 +3,6 @@ import type { JSONSchemaType } from 'ajv';
 import { isDefined } from '../../../../utils';
 import { ICamelComponentProperty } from '../../../camel-components-catalog';
 import { ICamelProcessorProperty } from '../../../camel-processors-catalog';
-import { CatalogFilter } from '../../../catalog-filter';
 import { CatalogKind } from '../../../catalog-kind';
 import { VisualComponentSchema } from '../../base-visual-entity';
 import { CamelCatalogService } from '../camel-catalog.service';
@@ -75,25 +74,6 @@ export class CamelComponentSchemaService {
 
   static canHavePreviousStep(processorName: keyof ProcessorDefinition): boolean {
     return !this.DISABLED_SIBLING_STEPS.includes(processorName);
-  }
-
-  static getCompatibleComponents(processorName: keyof ProcessorDefinition): CatalogFilter {
-    switch (processorName) {
-      case 'choice':
-        return {
-          kinds: [CatalogKind.Processor],
-          names: ['when', 'otherwise'],
-        };
-
-      case 'doTry':
-        return {
-          kinds: [CatalogKind.Processor],
-          names: ['doCatch', 'doFinally'],
-        };
-
-      default:
-        return {};
-    }
   }
 
   static getProcessorStepsProperties(processorName: keyof ProcessorDefinition): CamelProcessorStepsProperties[] {


### PR DESCRIPTION
### Context
At this moment, only CamelK `Pipe`s supports node insite replacement.
The goal for this pull request is to add said functionality for Camel Routes as well.

### Changes
* When removing the `from` node from a Camel Route, it gets replaced with a placeholder, like the `source` and `sink` nodes from CamelK `Pipe`
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/129a427c-f803-4228-a30f-b9b388e7e895)

* When replacing the `from` node from a Camel Route, the catalog only shows components that don't contain the `producerOnly` tag.
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/2a7831d9-3bba-4b4c-9797-e9acd044413a)
