### PR TITLE
feat(tiles) Add deprecation note

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -56,6 +56,19 @@ describe('camelComponentToTile', () => {
 
     expect(tile.tags).toEqual(['consumerOnly', 'producerOnly']);
   });
+
+  it('should replace the supportLevel header tag if the component is deprecated', () => {
+    const componentDef = {
+      component: {
+        supportLevel: 'Stable',
+        deprecated: true,
+      },
+    } as ICamelComponentDefinition;
+
+    const tile = camelComponentToTile(componentDef);
+
+    expect(tile.headerTags).toEqual(['Deprecated']);
+  });
 });
 
 describe('camelProcessorToTile', () => {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -6,8 +6,10 @@ export const camelComponentToTile = (componentDef: ICamelComponentDefinition): I
   const headerTags: string[] = [];
   const tags: string[] = [];
 
-  if (supportLevel) {
+  if (supportLevel && !componentDef.component.deprecated) {
     headerTags.push(supportLevel);
+  } else {
+    headerTags.push('Deprecated');
   }
   if (label) {
     tags.push(...label.split(','));

--- a/packages/ui/src/components/Catalog/Tags/tag-color-resolver.ts
+++ b/packages/ui/src/components/Catalog/Tags/tag-color-resolver.ts
@@ -6,6 +6,8 @@ export const getTagColor = (tag: string): COLOR => {
       return 'green';
     case 'preview':
       return 'orange';
+    case 'deprecated':
+      return 'red';
     default:
       return 'grey';
   }


### PR DESCRIPTION
### Context
At this moment, there's no deprecation warning for deprecated components

### Changes
* Deprecated components are signaled as `Deprecated` in the catalog
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/bf4ca6d1-d656-485f-bf3c-8689e7d3067f)
relates to: #287