### PR TITLE
chore: remove unused catalog filter code

### DIFF
--- a/packages/ui/src/components/Catalog/Catalog.models.ts
+++ b/packages/ui/src/components/Catalog/Catalog.models.ts
@@ -10,6 +10,8 @@ export interface ITile {
   rawObject?: unknown;
 }
 
+export type TileFilter = (item: ITile) => boolean;
+
 export const enum CatalogLayout {
   Gallery = 'Gallery',
   List = 'List',

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -4,7 +4,7 @@ import {
   Kamelet as KameletType,
   Pipe as PipeType,
 } from '@kaoto-next/camel-catalog/types';
-import { CatalogFilter } from '../catalog-filter';
+import { TileFilter } from '../../components/Catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { MetadataEntity } from '../visualization/metadata';
 import { CamelResource } from './camel-resource';
@@ -75,7 +75,7 @@ export abstract class CamelKResource implements CamelResource {
   }
 
   /** Components Catalog related methods */
-  getCompatibleComponents(_mode: AddStepMode, _visualEntityData: IVisualizationNodeData): CatalogFilter {
-    return {};
+  getCompatibleComponents(_mode: AddStepMode, _visualEntityData: IVisualizationNodeData): TileFilter | undefined {
+    return undefined;
   }
 }

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -4,7 +4,7 @@ import {
   Kamelet as KameletType,
   Pipe as PipeType,
 } from '@kaoto-next/camel-catalog/types';
-import { CatalogFilter } from '../catalog-filter';
+import { TileFilter } from '../../components/Catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { BeansEntity } from '../visualization/metadata';
 import { CamelRouteResource } from './camel-route-resource';
@@ -25,7 +25,7 @@ export interface CamelResource {
   getType(): SourceSchemaType;
 
   /** Components Catalog related methods */
-  getCompatibleComponents(mode: AddStepMode, visualEntityData: IVisualizationNodeData): CatalogFilter;
+  getCompatibleComponents(mode: AddStepMode, visualEntityData: IVisualizationNodeData): TileFilter | undefined;
 }
 
 export interface BeansAwareResource {

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -1,7 +1,6 @@
 import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
-import { ITile } from '../../components/Catalog';
+import { ITile, TileFilter } from '../../components/Catalog';
 import { isDefined } from '../../utils';
-import { CatalogFilter } from '../catalog-filter';
 import { CatalogKind } from '../catalog-kind';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity, isCamelRoute } from '../visualization/flows';
@@ -95,13 +94,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
   }
 
   /** Components Catalog related methods */
-  getCompatibleComponents(mode: AddStepMode, visualEntityData: CamelRouteVisualEntityData): CatalogFilter {
-    return {
-      filterFunction: this.getFilterFunction(mode, visualEntityData),
-    };
-  }
-
-  private getFilterFunction(mode: AddStepMode, visualEntityData: CamelRouteVisualEntityData): (item: ITile) => boolean {
+  getCompatibleComponents(mode: AddStepMode, visualEntityData: CamelRouteVisualEntityData): TileFilter {
     if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'from') {
       /**
        * For the `from` step we want to show only components which are not `producerOnly`,

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -1,6 +1,5 @@
 import { Pipe as PipeType } from '@kaoto-next/camel-catalog/types';
-import { ITile } from '../../components/Catalog/Catalog.models';
-import { CatalogFilter } from '../catalog-filter';
+import { ITile, TileFilter } from '../../components/Catalog/Catalog.models';
 import { CatalogKind } from '../catalog-kind';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { PipeVisualEntity } from '../visualization/flows';
@@ -83,13 +82,7 @@ export class PipeResource extends CamelKResource {
   }
 
   /** Components Catalog related methods */
-  getCompatibleComponents(mode: AddStepMode, visualEntityData: IVisualizationNodeData): CatalogFilter {
-    return {
-      filterFunction: this.getFilterFunction(mode, visualEntityData),
-    };
-  }
-
-  private getFilterFunction(mode: AddStepMode, visualEntityData: IVisualizationNodeData): (item: ITile) => boolean {
+  getCompatibleComponents(mode: AddStepMode, visualEntityData: IVisualizationNodeData): TileFilter {
     let kameletType: string = 'action';
 
     if (mode === AddStepMode.ReplaceStep && (visualEntityData.path === 'source' || visualEntityData.path === 'sink')) {

--- a/packages/ui/src/models/catalog-filter.ts
+++ b/packages/ui/src/models/catalog-filter.ts
@@ -1,8 +1,0 @@
-import { ITile } from '../components/Catalog/Catalog.models';
-import { CatalogKind } from './catalog-kind';
-
-export interface CatalogFilter {
-  kinds?: CatalogKind[];
-  names?: string[];
-  filterFunction?: (item: ITile) => boolean;
-}

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -2,7 +2,6 @@ export * from './camel-catalog-index';
 export * from './camel-components-catalog';
 export * from './camel-processors-catalog';
 export * from './camel-properties-common';
-export * from './catalog-filter';
 export * from './catalog-kind';
 export * from './kamelets-catalog';
 export * from './local-storage-keys';

--- a/packages/ui/src/providers/catalog-modal.provider.tsx
+++ b/packages/ui/src/providers/catalog-modal.provider.tsx
@@ -9,15 +9,15 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Catalog, ITile } from '../components/Catalog';
-import { CatalogFilter, CatalogKind, DefinedComponent } from '../models';
+import { Catalog, ITile, TileFilter } from '../components/Catalog';
+import { CatalogKind, DefinedComponent } from '../models';
 import { isDefined } from '../utils';
 import { CatalogTilesContext } from './catalog-tiles.provider';
 import { CatalogContext } from './catalog.provider';
 
 interface CatalogModalContextValue {
   setIsModalOpen: (isOpen: boolean) => void;
-  getNewComponent: (catalogFilter: CatalogFilter) => Promise<DefinedComponent | undefined>;
+  getNewComponent: (catalogFilter?: TileFilter) => Promise<DefinedComponent | undefined>;
 }
 
 export const CatalogModalContext = createContext<CatalogModalContextValue | undefined>(undefined);
@@ -68,24 +68,9 @@ export const CatalogModalProvider: FunctionComponent<PropsWithChildren> = (props
   );
 
   const getNewComponent = useCallback(
-    (catalogFilter: CatalogFilter) => {
-      if (isDefined(catalogFilter.filterFunction) || isDefined(catalogFilter.kinds) || isDefined(catalogFilter.names)) {
-        const localFilteredTiles = tiles.filter((tile) => {
-          if (isDefined(catalogFilter.filterFunction)) {
-            return catalogFilter.filterFunction(tile);
-          }
-
-          if (isDefined(catalogFilter.kinds) && !catalogFilter.kinds.includes(tile.type as CatalogKind)) {
-            return false;
-          }
-
-          if (isDefined(catalogFilter.names) && !catalogFilter.names.includes(tile.name)) {
-            return false;
-          }
-
-          return true;
-        });
-
+    (catalogFilter?: TileFilter) => {
+      if (isDefined(catalogFilter)) {
+        const localFilteredTiles = tiles.filter(catalogFilter);
         setFilteredTiles(localFilteredTiles);
       } else {
         setFilteredTiles(tiles);


### PR DESCRIPTION
### Context
After adding the new filter function signature, there's no need to keep the previous code for filtering by entity type any longer. 