### PR TITLE
fix(306) - kamelets icons not showing in Camel Routes

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer.cy.ts
@@ -35,8 +35,8 @@ describe('Tests for Design page', () => {
     cy.uploadFixture('flows/CamelRoute.yaml');
     cy.openDesignPage();
     cy.removeNodeByName('setHeader');
-    cy.removeNodeByName('log:test');
-    cy.removeNodeByName('timer:test');
+    cy.removeNodeByName('log');
+    cy.removeNodeByName('timer');
     cy.openSourceCode();
     cy.checkCodeSpanLine('uri: timer:test', 0);
     cy.checkCodeSpanLine('setHeader', 0);

--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -27,5 +27,5 @@ Cypress.Commands.add('removeNodeByName', (inputName: string) => {
     .find('g.pf-topology__node__action-icon > rect')
     .click({ force: true });
   cy.get('[data-testid="context-menu-item-remove"]').click();
-  cy.contains(inputName).should('not.exist');
+  cy.get(inputName).should('not.exist');
 });

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Canvas should render correctly 1`] = `
                   data-layer-id="default"
                 >
                   <g
-                    data-id="timer:tutorial-1234-to-set-header-1234"
+                    data-id="timer-1234-to-set-header-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -204,7 +204,7 @@ exports[`Canvas should render correctly 1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="otherwise-1234-to-amqp:queue:-1234"
+                    data-id="otherwise-1234-to-amqp-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -236,7 +236,7 @@ exports[`Canvas should render correctly 1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="log-1234-to-direct:my-route-1234"
+                    data-id="log-1234-to-direct-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -268,7 +268,7 @@ exports[`Canvas should render correctly 1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="timer:tutorial-1234"
+                    data-id="timer-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
@@ -304,13 +304,13 @@ exports[`Canvas should render correctly 1`] = `
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="amqp:queue:-1234"
+                    data-id="amqp-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="direct:my-route-1234"
+                    data-id="direct-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
@@ -562,7 +562,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                   data-layer-id="default"
                 >
                   <g
-                    data-id="timer:tutorial-1234-to-set-header-1234"
+                    data-id="timer-1234-to-set-header-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -722,7 +722,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="otherwise-1234-to-amqp:queue:-1234"
+                    data-id="otherwise-1234-to-amqp-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -754,7 +754,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="log-1234-to-direct:my-route-1234"
+                    data-id="log-1234-to-direct-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -786,7 +786,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="timer:tutorial-1234"
+                    data-id="timer-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
@@ -822,13 +822,13 @@ exports[`Canvas should render correctly with more routes  1`] = `
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="amqp:queue:-1234"
+                    data-id="amqp-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="direct:my-route-1234"
+                    data-id="direct-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
@@ -1080,7 +1080,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                   data-layer-id="default"
                 >
                   <g
-                    data-id="timer:tutorial-1234-to-set-header-1234"
+                    data-id="timer-1234-to-set-header-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -1240,7 +1240,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                     </g>
                   </g>
                   <g
-                    data-id="otherwise-1234-to-amqp:queue:-1234"
+                    data-id="otherwise-1234-to-amqp-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -1272,7 +1272,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                     </g>
                   </g>
                   <g
-                    data-id="log-1234-to-direct:my-route-1234"
+                    data-id="log-1234-to-direct-1234"
                     data-kind="edge"
                     data-type="edge"
                   >
@@ -1304,7 +1304,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                     </g>
                   </g>
                   <g
-                    data-id="timer:tutorial-1234"
+                    data-id="timer-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
@@ -1340,13 +1340,13 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="amqp:queue:-1234"
+                    data-id="amqp-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"
                   />
                   <g
-                    data-id="direct:my-route-1234"
+                    data-id="direct-1234"
                     data-kind="node"
                     data-type="node"
                     transform="translate(0, 0)"

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
@@ -24,7 +24,7 @@ describe('FlowClipboard.tsx', () => {
     expect(clipboardButton).toBeInTheDocument();
   });
 
-  it('should be called clioboard api', () => {
+  it('should be called clipboard api', () => {
     const { result } = renderHook(() => useEntityContext(), { wrapper });
 
     const clipboardButton = screen.getByTestId('clipboardButton');

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -231,7 +231,7 @@ describe('Camel Route', () => {
     it('should use the uri as the node label', () => {
       const vizNode = camelEntity.toVizNode();
 
-      expect(vizNode.data.label).toEqual('timer:tutorial');
+      expect(vizNode.data.label).toEqual('timer');
     });
 
     it('should set a default label if the uri is not available', () => {
@@ -259,7 +259,7 @@ describe('Camel Route', () => {
 
       /** from */
       expect(vizNode.data.path).toEqual('from');
-      expect(vizNode.data.label).toEqual('timer:tutorial');
+      expect(vizNode.data.label).toEqual('timer');
       /** Since this is the root node, there's no previous step */
       expect(vizNode.getPreviousNode()).toBeUndefined();
       expect(vizNode.getNextNode()).toBeUndefined();
@@ -284,7 +284,7 @@ describe('Camel Route', () => {
       /** toDirect */
       const toDirectNode = choiceNode.getNextNode()!;
       expect(toDirectNode.data.path).toEqual('from.steps.2.to');
-      expect(toDirectNode.data.label).toEqual('direct:my-route');
+      expect(toDirectNode.data.label).toEqual('direct');
       expect(toDirectNode.getPreviousNode()).toBe(choiceNode);
       expect(toDirectNode.getNextNode()).toBeUndefined();
 
@@ -323,7 +323,7 @@ describe('Camel Route', () => {
       const firstToOtherwiseNode = otherwiseNode?.getChildren()?.[0];
       expect(firstToOtherwiseNode).toBeDefined();
       expect(firstToOtherwiseNode!.data.path).toEqual('from.steps.1.choice.otherwise.steps.0.to');
-      expect(firstToOtherwiseNode!.data.label).toEqual('amqp:queue:');
+      expect(firstToOtherwiseNode!.data.label).toEqual('amqp');
       expect(firstToOtherwiseNode!.getPreviousNode()).toBeUndefined();
       expect(firstToOtherwiseNode!.getNextNode()).toBeDefined();
       expect(firstToOtherwiseNode!.getParentNode()).toBe(otherwiseNode);
@@ -333,7 +333,7 @@ describe('Camel Route', () => {
       const secondToOtherwiseNode = otherwiseNode?.getChildren()?.[1];
       expect(secondToOtherwiseNode).toBeDefined();
       expect(secondToOtherwiseNode!.data.path).toEqual('from.steps.1.choice.otherwise.steps.1.to');
-      expect(secondToOtherwiseNode!.data.label).toEqual('amqp:queue:');
+      expect(secondToOtherwiseNode!.data.label).toEqual('amqp');
       expect(secondToOtherwiseNode!.getPreviousNode()).toBe(firstToOtherwiseNode);
       expect(secondToOtherwiseNode!.getNextNode()).toBeDefined();
       expect(secondToOtherwiseNode!.getParentNode()).toBe(otherwiseNode);

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -226,7 +226,10 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
   }
 
   toVizNode(): IVisualizationNode {
-    const rootNode = this.getVizNodeFromProcessor('from', { processorName: 'from' as keyof ProcessorDefinition });
+    const rootNode = this.getVizNodeFromProcessor('from', {
+      processorName: 'from' as keyof ProcessorDefinition,
+      componentName: CamelComponentSchemaService.getComponentNameFromUri(this.route.from!.uri),
+    });
     rootNode.data.entity = this;
 
     if (!this.route.from?.uri) {
@@ -271,7 +274,10 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
         return stepsList.reduce((accStepsNodes, step, index) => {
           const singlePropertyName = Object.keys(step)[0];
           const childPath = `${singlePath}.${index}.${singlePropertyName}`;
-          const childComponentLookup = CamelComponentSchemaService.getCamelComponentLookup(childPath, step);
+          const childComponentLookup = CamelComponentSchemaService.getCamelComponentLookup(
+            childPath,
+            get(step, singlePropertyName),
+          );
 
           const vizNode = this.getVizNodeFromProcessor(childPath, childComponentLookup);
 

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -21,7 +21,7 @@ describe('VisualizationNode', () => {
     expect(node.getBaseEntity()).toEqual(visualEntity);
   });
 
-  it('should return the component schema from the underlying BaseVsualCamelEntity', () => {
+  it('should return the component schema from the underlying BaseVisualCamelEntity', () => {
     const getComponentSchemaSpy = jest.fn();
     const visualEntity = {
       getComponentSchema: getComponentSchemaSpy,

--- a/packages/ui/src/utils/node-icon-resolver.ts
+++ b/packages/ui/src/utils/node-icon-resolver.ts
@@ -52,9 +52,19 @@ import uaranteedDelivery from '../assets/eip/uaranteed-delivery.svg';
 import wireTap from '../assets/eip/wire-tap.svg';
 import expandIcon from '../assets/expand.svg';
 import questionIcon from '../assets/question-mark.svg';
+import { CatalogKind } from '../models';
+import { CamelCatalogService } from '../models/visualization/flows/camel-catalog.service';
 
 export class NodeIconResolver {
   static getIcon = (iconName: string | undefined): string => {
+    if (iconName?.startsWith('kamelet:')) {
+      const kameletDefinition = CamelCatalogService.getComponent(CatalogKind.Kamelet, iconName.replace('kamelet:', ''));
+      const icon =
+        kameletDefinition?.metadata.annotations['camel.apache.org/kamelet.icon'] ?? NodeIconResolver.getUnknownIcon();
+
+      return icon;
+    }
+
     switch (iconName) {
       case 'choice':
         return contentBasedRouter;


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/306

Also has following effect - nodes have name not equal to the URI, but rather to the component name - e.g. timer node with URI "timer:tutorial" is not named "timer:tutorial" in the graph, but just "timer" (can be changed back in case this was something we wanted)
The kamelet nodes names remained e.g. "kamelet:pdf-action"

![Screenshot from 2023-11-10 16-48-57](https://github.com/KaotoIO/kaoto-next/assets/4180208/3bfa6452-d2a9-48b1-83b8-4cb0bfa07dbf)
