### PR TITLE
fix(canvas): Avoid rerendering the canvas component

### DIFF
--- a/packages/ui-tests/stories/ContextToolbar.stories.tsx
+++ b/packages/ui-tests/stories/ContextToolbar.stories.tsx
@@ -4,6 +4,7 @@ import {
   ContextToolbar,
   EntitiesContext,
   SchemasLoaderProvider,
+  SourceCodeContext,
   VisibleFlowsProvider,
 } from '@kaoto-next/ui/testing';
 import { Divider, Toolbar, ToolbarContent, ToolbarGroup } from '@patternfly/react-core';
@@ -11,17 +12,19 @@ import { Meta, StoryFn } from '@storybook/react';
 import camelRouteMock from '../cypress/fixtures/camelRouteMock.json';
 
 const EntitiesContextDecorator = (Story: StoryFn) => (
-  <EntitiesContext.Provider value={camelRouteMock}>
-    <SchemasLoaderProvider>
-      <CatalogLoaderProvider>
-        <CatalogTilesProvider>
-          <VisibleFlowsProvider>
-            <Story />
-          </VisibleFlowsProvider>
-        </CatalogTilesProvider>
-      </CatalogLoaderProvider>
-    </SchemasLoaderProvider>
-  </EntitiesContext.Provider>
+  <SourceCodeContext.Provider value={{ sourceCode: '', setCodeAndNotify: () => {} }}>
+    <EntitiesContext.Provider value={camelRouteMock}>
+      <SchemasLoaderProvider>
+        <CatalogLoaderProvider>
+          <CatalogTilesProvider>
+            <VisibleFlowsProvider>
+              <Story />
+            </VisibleFlowsProvider>
+          </CatalogTilesProvider>
+        </CatalogLoaderProvider>
+      </SchemasLoaderProvider>
+    </EntitiesContext.Provider>
+  </SourceCodeContext.Provider>
 );
 
 export default {

--- a/packages/ui-tests/stories/Navigation.stories.tsx
+++ b/packages/ui-tests/stories/Navigation.stories.tsx
@@ -1,4 +1,4 @@
-import { Navigation, Shell } from '@kaoto-next/ui/testing';
+import { Navigation, Shell, SourceCodeProvider } from '@kaoto-next/ui/testing';
 import { StoryFn } from '@storybook/react';
 import { withRouter, reactRouterOutlet, reactRouterParameters } from 'storybook-addon-react-router-v6';
 
@@ -20,7 +20,11 @@ const NavigationTemplate: StoryFn<typeof Navigation> = () => {
 };
 
 const ShellTemplate: StoryFn<typeof Shell> = () => {
-  return <Shell />;
+  return (
+    <SourceCodeProvider>
+      <Shell />
+    </SourceCodeProvider>
+  );
 };
 
 export const NavigationOpen = NavigationTemplate.bind({});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4,20 +4,23 @@ import { CatalogTilesProvider } from './providers/catalog-tiles.provider';
 import { CatalogLoaderProvider } from './providers/catalog.provider';
 import { EntitiesProvider } from './providers/entities.provider';
 import { SchemasLoaderProvider } from './providers/schemas.provider';
+import { SourceCodeProvider } from './providers/source-code.provider';
 
 function App() {
   return (
-    <EntitiesProvider>
-      <Shell>
-        <SchemasLoaderProvider>
-          <CatalogLoaderProvider>
-            <CatalogTilesProvider>
-              <Outlet />
-            </CatalogTilesProvider>
-          </CatalogLoaderProvider>
-        </SchemasLoaderProvider>
-      </Shell>
-    </EntitiesProvider>
+    <SourceCodeProvider>
+      <EntitiesProvider>
+        <Shell>
+          <SchemasLoaderProvider>
+            <CatalogLoaderProvider>
+              <CatalogTilesProvider>
+                <Outlet />
+              </CatalogTilesProvider>
+            </CatalogLoaderProvider>
+          </SchemasLoaderProvider>
+        </Shell>
+      </EntitiesProvider>
+    </SourceCodeProvider>
   );
 }
 

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -33,7 +33,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const handleOnChange = useCallback(
     (newModel: Record<string, unknown>) => {
       props.selectedNode.data?.vizNode?.updateModel(newModel);
-      entitiesContext?.updateCodeFromEntities();
+      entitiesContext?.updateSourceCodeFromEntities();
       setModel(newModel);
     },
     [entitiesContext, props.selectedNode.data?.vizNode],

--- a/packages/ui/src/components/Visualization/Canvas/ExpressionEditor.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/ExpressionEditor.tsx
@@ -54,7 +54,7 @@ export const ExpressionEditor: FunctionComponent<ExpressionEditorProps> = (props
       if (!model) return;
       ExpressionService.setExpressionModel(languageCatalogMap, model, selectedLanguage, newExpressionModel);
       props.selectedNode.data?.vizNode?.updateModel(model);
-      entitiesContext?.updateCodeFromEntities();
+      entitiesContext?.updateSourceCodeFromEntities();
     },
     [entitiesContext, languageCatalogMap, model, props.selectedNode.data?.vizNode],
   );

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { FlowClipboard } from './FlowClipboard';
-import { EntitiesProvider } from '../../../../providers/entities.provider';
-import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { act } from 'react-dom/test-utils';
+import { useSourceCodeContext } from '../../../../hooks/useSourceCodeContext/useSourceCodeContext';
+import { SourceCodeProvider } from '../../../../providers/source-code.provider';
+import { FlowClipboard } from './FlowClipboard';
 
-const wrapper = ({ children }: PropsWithChildren) => <EntitiesProvider>{children}</EntitiesProvider>;
+const wrapper = ({ children }: PropsWithChildren) => <SourceCodeProvider>{children}</SourceCodeProvider>;
 
 Object.defineProperty(navigator, 'clipboard', {
   value: {
@@ -25,13 +25,13 @@ describe('FlowClipboard.tsx', () => {
   });
 
   it('should be called clipboard api', () => {
-    const { result } = renderHook(() => useEntityContext(), { wrapper });
+    const { result } = renderHook(() => useSourceCodeContext(), { wrapper });
 
     const clipboardButton = screen.getByTestId('clipboardButton');
 
     act(() => fireEvent.click(clipboardButton));
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(result.current.code);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(result.current.sourceCode);
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react';
-import { CopyIcon } from '@patternfly/react-icons';
 import { Button, Tooltip, TooltipProps } from '@patternfly/react-core';
-import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
+import { CopyIcon } from '@patternfly/react-icons';
+import { useState } from 'react';
+import { useSourceCodeContext } from '../../../../hooks/useSourceCodeContext/useSourceCodeContext';
 
 export const successTooltipText = 'Content added to clipboard';
 
 export const defaultTooltipText = 'Copy to clipboard';
 
 export function FlowClipboard() {
-  const { code } = useEntityContext();
+  const { sourceCode } = useSourceCodeContext();
   const [isCopied, setIsCopied] = useState(false);
 
   const onClick = () => {
     setIsCopied(true);
-    navigator.clipboard.writeText(code);
+    navigator.clipboard.writeText(sourceCode);
   };
 
   const tooltipProps: TooltipProps = {

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
@@ -1,10 +1,12 @@
-import { NewFlow } from './NewFlow';
 import { act, fireEvent, render } from '@testing-library/react';
-import { sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
-import { EntitiesContext } from '../../../../providers/entities.provider';
-import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
-import { Schema } from '../../../../models';
 import { EntitiesContextResult } from '../../../../hooks';
+import { Schema } from '../../../../models';
+import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
+import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
+import { VisibleFlowsProvider } from '../../../../providers';
+import { EntitiesContext } from '../../../../providers/entities.provider';
+import { SourceCodeContext } from '../../../../providers/source-code.provider';
+import { NewFlow } from './NewFlow';
 
 describe('NewFlow.tsx', () => {
   const config = sourceSchemaConfig;
@@ -21,16 +23,25 @@ describe('NewFlow.tsx', () => {
 
   const renderWithContext = () => {
     return render(
-      <EntitiesContext.Provider
-        value={
-          {
-            currentSchemaType: SourceSchemaType.Integration,
-            visualEntities: visualEntities,
-          } as unknown as EntitiesContextResult
-        }
+      <SourceCodeContext.Provider
+        value={{
+          sourceCode: '',
+          setCodeAndNotify: jest.fn(),
+        }}
       >
-        <NewFlow />
-      </EntitiesContext.Provider>,
+        <EntitiesContext.Provider
+          value={
+            {
+              currentSchemaType: SourceSchemaType.Integration,
+              visualEntities: visualEntities,
+            } as unknown as EntitiesContextResult
+          }
+        >
+          <VisibleFlowsProvider>
+            <NewFlow />
+          </VisibleFlowsProvider>
+        </EntitiesContext.Provider>
+      </SourceCodeContext.Provider>,
     );
   };
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
@@ -1,15 +1,17 @@
-import { FlowTypeSelector } from './FlowTypeSelector';
+import { Button, Modal } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, PropsWithChildren, useCallback, useContext, useState } from 'react';
-import { Button, Modal } from '@patternfly/react-core';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
+import { useSourceCodeContext } from '../../../../hooks/useSourceCodeContext/useSourceCodeContext';
 import { SourceSchemaType } from '../../../../models/camel';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
+import { FlowTypeSelector } from './FlowTypeSelector';
 
 export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
-  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
-  const entitiesContext = useContext(EntitiesContext)!;
+  const sourceCodeContext = useSourceCodeContext();
+  const entitiesContext = useEntityContext();
   const visibleFlowsContext = useContext(VisibleFlowsContext)!;
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const [proposedFlowType, setProposedFlowType] = useState<SourceSchemaType>();
 
   const checkBeforeAddNewFlow = useCallback(
@@ -25,7 +27,7 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
         const newId = entitiesContext.camelResource.addNewEntity();
         visibleFlowsContext.visualFlowsApi.hideAllFlows();
         visibleFlowsContext.visualFlowsApi.setVisibleFlows([newId]);
-        entitiesContext.updateCodeFromEntities();
+        entitiesContext.updateEntitiesFromCamelResource();
       } else {
         /**
          * If it is not the same DSL, this operation might result in
@@ -35,7 +37,7 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
         setIsConfirmationModalOpen(true);
       }
     },
-    [entitiesContext.currentSchemaType],
+    [entitiesContext, visibleFlowsContext.visualFlowsApi],
   );
 
   return (
@@ -57,7 +59,9 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
             onClick={() => {
               if (proposedFlowType) {
                 entitiesContext.setCurrentSchemaType(proposedFlowType);
-                entitiesContext.setCode(entitiesContext.flowTemplateService.getFlowYamlTemplate(proposedFlowType));
+                sourceCodeContext.setCodeAndNotify(
+                  entitiesContext.flowTemplateService.getFlowYamlTemplate(proposedFlowType),
+                );
                 setIsConfirmationModalOpen(false);
               }
             }}

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -14,7 +14,7 @@ interface IFlowsList {
 }
 
 export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
-  const { visualEntities, camelResource, updateCodeFromEntities } = useContext(EntitiesContext)!;
+  const { visualEntities, camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
   const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
 
   const isListEmpty = visualEntities.length === 0;
@@ -91,7 +91,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 variant="plain"
                 onClick={(event) => {
                   camelResource.removeEntity(flow.id);
-                  updateCodeFromEntities();
+                  updateEntitiesFromCamelResource();
                   /** Required to avoid closing the Dropdown after clicking in the icon */
                   event.stopPropagation();
                 }}

--- a/packages/ui/src/components/Visualization/Custom/ItemAddNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemAddNode.tsx
@@ -39,7 +39,7 @@ export const ItemAddNode: FunctionComponent<ItemAddNodeProps> = (props) => {
     vizNode.addBaseEntityStep(definedComponent, props.mode);
 
     /** Update entity */
-    entitiesContext.updateCodeFromEntities();
+    entitiesContext.updateEntitiesFromCamelResource();
   }, [catalogModalContext, entitiesContext, props.mode, vizNode]);
 
   return shouldRender ? (

--- a/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
@@ -39,7 +39,7 @@ export const ItemInsertChildNode: FunctionComponent<ItemInsertChildNodeProps> = 
     vizNode.addBaseEntityStep(definedComponent, props.mode, targetProperty);
 
     /** Update entity */
-    entitiesContext.updateCodeFromEntities();
+    entitiesContext.updateEntitiesFromCamelResource();
   }, [catalogModalContext, entitiesContext, props.mode, vizNode]);
 
   return shouldRender ? (

--- a/packages/ui/src/components/Visualization/Custom/ItemRemoveNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemRemoveNode.tsx
@@ -12,7 +12,7 @@ export const ItemRemoveNode: FunctionComponent<IDataTestID> = (props) => {
 
   const onRemoveNode = useCallback(() => {
     vizNode?.removeChild();
-    entitiesContext?.updateCodeFromEntities();
+    entitiesContext?.updateEntitiesFromCamelResource();
   }, [entitiesContext, vizNode]);
 
   return (

--- a/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
@@ -30,7 +30,7 @@ export const ItemReplaceNode: FunctionComponent<IDataTestID> = (props) => {
     vizNode.addBaseEntityStep(definedComponent, AddStepMode.ReplaceStep);
 
     /** Update entity */
-    entitiesContext.updateCodeFromEntities();
+    entitiesContext.updateEntitiesFromCamelResource();
   }, [catalogModalContext, entitiesContext, vizNode]);
 
   return (

--- a/packages/ui/src/hooks/entities.test.tsx
+++ b/packages/ui/src/hooks/entities.test.tsx
@@ -1,141 +1,146 @@
 import { act, renderHook } from '@testing-library/react';
+import { CamelResource, SourceSchemaType } from '../models/camel';
+import { CamelRouteVisualEntity } from '../models/visualization/flows';
+import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
+import { EventNotifier } from '../utils';
 import { useEntities } from './entities';
-import { camelRouteYaml } from '../stubs/camel-route';
 
 describe('useEntities', () => {
-  it('should set the source code', () => {
-    const { result } = renderHook(() => useEntities());
-
-    act(() => {
-      result.current.setCode(camelRouteYaml);
-    });
-
-    expect(result.current.code).toEqual(camelRouteYaml);
+  let eventNotifier: EventNotifier;
+  beforeEach(() => {
+    eventNotifier = EventNotifier.getInstance();
   });
 
-  it('should parse the source code and set visual entities', () => {
-    const { result } = renderHook(() => useEntities());
+  it('it should subscribe to the `code:updated` notification', () => {
+    const notifierSpy = jest.spyOn(eventNotifier, 'subscribe');
 
-    act(() => {
-      result.current.setCode(camelRouteYaml);
-    });
+    renderHook(() => useEntities());
 
-    expect(result.current.visualEntities).toEqual([
-      {
-        id: expect.any(String),
-        route: {
-          from: {
-            steps: [
-              {
-                'set-header': {
-                  name: 'myChoice',
-                  simple: '${random(2)}',
-                },
-              },
-              {
-                choice: {
-                  otherwise: {
-                    steps: [
-                      {
-                        to: {
-                          uri: 'amqp:queue:',
-                        },
-                      },
-                      {
-                        to: {
-                          uri: 'amqp:queue:',
-                        },
-                      },
-                      {
-                        log: {
-                          id: 'log-2',
-                          message: 'We got a ${body}',
-                        },
-                      },
-                    ],
-                  },
-                  when: [
-                    {
-                      simple: '${header.myChoice} == 1',
-                      steps: [
-                        {
-                          log: {
-                            id: 'log-1',
-                            message: 'We got a one.',
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              },
-              {
-                to: {
-                  parameters: {
-                    bridgeErrorHandler: true,
-                  },
-                  uri: 'direct:my-route',
-                },
-              },
-            ],
-            uri: 'timer:tutorial',
-          },
-          id: 'route-8888',
-        },
-        type: 'route',
-      },
-    ]);
+    expect(notifierSpy).toHaveBeenCalledWith('code:updated', expect.anything());
   });
 
-  it('should parse the source code and set entities', () => {
+  it('updating the source code should NOT recreate the Camel Resource', () => {
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      result.current.setCode(`
-      - rest:
-          consumes: application/json
-          get:
-            description: "Returns all the orders"
-            outType: java.util.List
-            responseCode: 200
-            to: "direct:getOrders"
-      `);
-    });
+      const firstCamelResource = result.current.camelResource;
+      result.current.updateSourceCodeFromEntities();
+      const secondCamelResource = result.current.camelResource;
 
-    expect(result.current.entities).toEqual([
-      {
-        rest: {
-          consumes: 'application/json',
-          get: {
-            description: 'Returns all the orders',
-            outType: 'java.util.List',
-            responseCode: 200,
-            to: 'direct:getOrders',
-          },
-        },
-      },
-    ]);
+      expect(firstCamelResource).toBe(secondCamelResource);
+    });
   });
 
-  it('should return empty arrays if the source code is empty', () => {
+  it('should recreate the entities when the source code is updated', () => {
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      result.current.setCode('');
+      eventNotifier.next('code:updated', camelRouteYaml);
     });
 
-    expect(result.current.visualEntities).toEqual([]);
     expect(result.current.entities).toEqual([]);
+    expect(result.current.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson.route)]);
   });
 
-  it('should return empty arrays if the source code is invalid', () => {
+  it('should notifiy subscribers when the entities are updated', () => {
+    const notifierSpy = jest.spyOn(eventNotifier, 'next');
+
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      result.current.setCode('invalid');
+      result.current.camelResource.addNewEntity();
+      result.current.updateSourceCodeFromEntities();
     });
 
-    expect(result.current.visualEntities).toEqual([]);
+    expect(notifierSpy).toHaveBeenCalledWith(
+      'entities:updated',
+      `- route:
+    from:
+      uri: timer:template
+      parameters:
+        period: "1000"
+      steps:
+        - log:
+            message: template message
+    id: route-1234
+`,
+    );
+  });
+
+  it('updating entities should NOT recreate the Camel Resource', () => {
+    let firstCamelResource: CamelResource;
+    let secondCamelResource: CamelResource;
+
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      firstCamelResource = result.current.camelResource;
+      result.current.updateEntitiesFromCamelResource();
+    });
+
+    act(() => {
+      secondCamelResource = result.current.camelResource;
+      expect(firstCamelResource).toBe(secondCamelResource);
+    });
+  });
+
+  it('should refresh entities', () => {
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      result.current.camelResource.addNewEntity();
+      result.current.camelResource.addNewEntity();
+      result.current.updateEntitiesFromCamelResource();
+    });
+
     expect(result.current.entities).toEqual([]);
+    expect(result.current.visualEntities).toHaveLength(2);
+  });
+
+  it('should refresh entities and notify subscribers', () => {
+    const notifierSpy = jest.spyOn(eventNotifier, 'next');
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      result.current.updateEntitiesFromCamelResource();
+    });
+
+    expect(notifierSpy).toHaveBeenCalledWith(
+      'entities:updated',
+      `[]
+`,
+    );
+  });
+
+  it('should recreate the Camel Resource when the schema is updated', () => {
+    let firstCamelResource: CamelResource;
+    let secondCamelResource: CamelResource;
+
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      firstCamelResource = result.current.camelResource;
+      result.current.setCurrentSchemaType(SourceSchemaType.Route);
+    });
+
+    act(() => {
+      secondCamelResource = result.current.camelResource;
+      expect(firstCamelResource).not.toBe(secondCamelResource);
+    });
+  });
+
+  it('should notify subscribers when the schema is updated', () => {
+    const notifierSpy = jest.spyOn(eventNotifier, 'next');
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      result.current.setCurrentSchemaType(SourceSchemaType.Route);
+    });
+
+    expect(notifierSpy).toHaveBeenCalledWith(
+      'entities:updated',
+      `[]
+`,
+    );
   });
 });

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -7,6 +7,7 @@ const wrapper = ({ children }: PropsWithChildren) => <EntitiesProvider>{children
 
 describe('useEntityContext', () => {
   it('should be throw when use hook without provider', () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => null);
     expect(() => renderHook(() => useEntityContext())).toThrow(errorMessage);
   });
 

--- a/packages/ui/src/hooks/useSourceCodeContext/useSourceCodeContext.test.tsx
+++ b/packages/ui/src/hooks/useSourceCodeContext/useSourceCodeContext.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { SourceCodeProvider } from '../../providers/source-code.provider';
+import { errorMessage, useSourceCodeContext } from './useSourceCodeContext';
+
+const wrapper = ({ children }: PropsWithChildren) => <SourceCodeProvider>{children}</SourceCodeProvider>;
+
+describe('useSourceCodeContext', () => {
+  it('should be throw when use hook without provider', () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+    expect(() => renderHook(() => useSourceCodeContext())).toThrow(errorMessage);
+  });
+
+  it('should be return SourceCodeContext', () => {
+    const { result } = renderHook(() => useSourceCodeContext(), { wrapper });
+
+    expect(result.current).not.toBe(null);
+  });
+});

--- a/packages/ui/src/hooks/useSourceCodeContext/useSourceCodeContext.tsx
+++ b/packages/ui/src/hooks/useSourceCodeContext/useSourceCodeContext.tsx
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { SourceCodeContext } from '../../providers/source-code.provider';
+
+export const errorMessage = 'useSourceCodeContext should be called into SourceCodeProvider';
+
+export function useSourceCodeContext() {
+  const ctx = useContext(SourceCodeContext);
+
+  if (!ctx) throw new Error(errorMessage);
+
+  return ctx;
+}

--- a/packages/ui/src/layout/Shell.tsx
+++ b/packages/ui/src/layout/Shell.tsx
@@ -2,7 +2,7 @@ import { Page, Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
 import { FunctionComponent, PropsWithChildren, useCallback, useContext, useEffect, useState } from 'react';
 import { useLocalStorage } from '../hooks';
 import { LocalStorageKeys } from '../models';
-import { EntitiesContext } from '../providers/entities.provider';
+import { SourceCodeContext } from '../providers/source-code.provider';
 import { camelRouteYaml } from '../stubs/camel-route';
 import { Navigation } from './Navigation';
 import './Shell.scss';
@@ -10,10 +10,10 @@ import { TopBar } from './TopBar';
 
 export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
   const [isNavOpen, setIsNavOpen] = useState(true);
-  const entitiesContext = useContext(EntitiesContext);
+  const sourceCodeContext = useContext(SourceCodeContext)!;
 
   /** Load the source code from localStorage */
-  const [localSourceCode, setLocalSourceCode] = useLocalStorage(LocalStorageKeys.SourceCode, camelRouteYaml);
+  const [localSourceCode, setLocalStorageSourceCode] = useLocalStorage(LocalStorageKeys.SourceCode, camelRouteYaml);
 
   const navToggle = useCallback(() => {
     setIsNavOpen(!isNavOpen);
@@ -22,15 +22,14 @@ export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
   useEffect(() => {
     /** Set the source code, entities, and visual entities from localStorage if available */
     if (localSourceCode) {
-      entitiesContext?.setCode(localSourceCode);
+      sourceCodeContext.setCodeAndNotify(localSourceCode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    return entitiesContext?.eventNotifier.subscribe('code:update', (code) => {
-      setLocalSourceCode(code);
-    });
-  }, [entitiesContext?.eventNotifier, setLocalSourceCode]);
+    setLocalStorageSourceCode(sourceCodeContext.sourceCode);
+  }, [setLocalStorageSourceCode, sourceCodeContext.sourceCode]);
 
   return (
     <Page header={<TopBar navToggle={navToggle} />} sidebar={<Navigation isNavOpen={isNavOpen} />}>

--- a/packages/ui/src/pages/Beans/BeansPage.tsx
+++ b/packages/ui/src/pages/Beans/BeansPage.tsx
@@ -43,7 +43,7 @@ export const BeansPage: FunctionComponent = () => {
         const entity = findBeansEntity();
         entity && beansAwareResource.deleteBeansEntity(entity);
       }
-      entitiesContext?.updateCodeFromEntities();
+      entitiesContext?.updateSourceCodeFromEntities();
     },
     [camelResource, entitiesContext, findBeansEntity],
   );

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -36,7 +36,7 @@ export const MetadataPage: FunctionComponent = () => {
       } else {
         camelkResource.deleteMetadataEntity();
       }
-      entitiesContext?.updateCodeFromEntities();
+      entitiesContext?.updateSourceCodeFromEntities();
     },
     [camelkResource, entitiesContext],
   );

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -35,7 +35,7 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
       } else {
         pipeResource!.deleteErrorHandlerEntity();
       }
-      entitiesContext!.updateCodeFromEntities();
+      entitiesContext!.updateSourceCodeFromEntities();
     },
     [entitiesContext, pipeResource],
   );

--- a/packages/ui/src/pages/SourceCode/SourceCodePage.tsx
+++ b/packages/ui/src/pages/SourceCode/SourceCodePage.tsx
@@ -1,23 +1,17 @@
 import { FunctionComponent, useCallback, useContext } from 'react';
 import { SourceCode } from '../../components/SourceCode';
-import { useLocalStorage } from '../../hooks';
-import { LocalStorageKeys } from '../../models';
-import { EntitiesContext } from '../../providers/entities.provider';
+import { SourceCodeContext } from '../../providers/source-code.provider';
 
 export const SourceCodePage: FunctionComponent = () => {
-  const entitiesContext = useContext(EntitiesContext);
-  const [, setLocalSourceCode] = useLocalStorage(LocalStorageKeys.SourceCode, '');
+  const sourceCodeContext = useContext(SourceCodeContext);
 
   const handleCodeChange = useCallback(
     (code: string) => {
       /** Update Entities and Visual Entities */
-      entitiesContext?.setCode(code);
-
-      /** Auto save code */
-      setLocalSourceCode(code);
+      sourceCodeContext?.setCodeAndNotify(code);
     },
-    [entitiesContext],
+    [sourceCodeContext],
   );
 
-  return <SourceCode code={entitiesContext?.code ?? ''} onCodeChange={handleCodeChange} />;
+  return <SourceCode code={sourceCodeContext?.sourceCode ?? ''} onCodeChange={handleCodeChange} />;
 };

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,6 +1,7 @@
 export * from './entities.provider';
 export * from './visible-flows.provider';
 export * from './schemas.provider';
+export * from './source-code.provider';
 export * from './catalog.provider';
 export * from './catalog-tiles.provider';
 export * from './catalog-modal.provider';

--- a/packages/ui/src/providers/source-code.provider.tsx
+++ b/packages/ui/src/providers/source-code.provider.tsx
@@ -1,0 +1,46 @@
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { EventNotifier } from '../utils';
+
+export const SourceCodeContext = createContext<{
+  sourceCode: string;
+
+  /** Set the Source Code and notify subscribers */
+  setCodeAndNotify: (sourceCode: string) => void;
+} | null>(null);
+
+export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) => {
+  const eventNotifier = EventNotifier.getInstance();
+  const [sourceCode, setSourceCode] = useState<string>('');
+
+  useLayoutEffect(() => {
+    return eventNotifier.subscribe('entities:updated', (code) => {
+      setSourceCode(code);
+    });
+  }, [eventNotifier]);
+
+  const setCodeAndNotify = useCallback(
+    (code: string) => {
+      setSourceCode(code);
+      eventNotifier.next('code:updated', code);
+    },
+    [eventNotifier],
+  );
+
+  const value = useMemo(
+    () => ({
+      sourceCode,
+      setCodeAndNotify,
+    }),
+    [setCodeAndNotify, sourceCode],
+  );
+
+  return <SourceCodeContext.Provider value={value}>{props.children}</SourceCodeContext.Provider>;
+};

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -21,7 +21,7 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
 
     entitiesContext?.visualEntities.forEach((visualEntity) => (flows[visualEntity.id] = visibleFlows[visualEntity.id]));
     const hiddenAll = Object.values(flows).every((visible) => !visible);
-    if (hiddenAll) {
+    if (hiddenAll && (entitiesContext?.visualEntities.length ?? 0) > 0) {
       flows[entitiesContext!.visualEntities[0].id] = true;
     }
 

--- a/packages/ui/src/utils/event-notifier.test.ts
+++ b/packages/ui/src/utils/event-notifier.test.ts
@@ -5,8 +5,8 @@ describe('EventNotifier', () => {
     const eventNotifier = new EventNotifier();
     const listener = jest.fn();
 
-    eventNotifier.subscribe('code:update', listener);
-    eventNotifier.next('code:update', 'my source code');
+    eventNotifier.subscribe('code:updated', listener);
+    eventNotifier.next('code:updated', 'my source code');
 
     expect(listener).toHaveBeenCalledWith('my source code');
   });
@@ -15,9 +15,9 @@ describe('EventNotifier', () => {
     const eventNotifier = new EventNotifier();
     const listener = jest.fn();
 
-    const unsubscribe = eventNotifier.subscribe('code:update', listener);
+    const unsubscribe = eventNotifier.subscribe('code:updated', listener);
     unsubscribe();
-    eventNotifier.next('code:update', 'payload');
+    eventNotifier.next('code:updated', 'payload');
 
     expect(listener).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/utils/event-notifier.ts
+++ b/packages/ui/src/utils/event-notifier.ts
@@ -1,11 +1,21 @@
 interface Events {
-  'code:update': string;
-  'entities:update': undefined;
+  'code:updated': string;
+  'entities:updated': string;
 }
 
 export class EventNotifier extends EventTarget {
+  private static instance: EventNotifier | undefined;
+
   constructor() {
     super();
+  }
+
+  static getInstance(): EventNotifier {
+    if (!this.instance) {
+      this.instance = new EventNotifier();
+    }
+
+    return this.instance;
   }
 
   next<EventName extends keyof Events>(event: EventName, payload: Events[EventName]): void {


### PR DESCRIPTION
### Context
Currently, when a canvas node is configured, the entities are being regenerated, causing the canvas to be re-rendered.

### Changes
* Extract SourceCodeProvider from EntitiesProvider
* Regenerate the entities whenever a structural change happens.

For reference, here's a change table:

| When modifying               | Should update |
| ---                          | --- |
| Source Code                  | * Camel Resource <br> * Entities |
| Add / Remove Flows           | * Source Code (one way) <br> * Entities |
| Add / Remove / Replace Steps | * Source Code (one way) <br> * Entities |
| Add / Remove / Beans         | * Source Code (one way) <br> * Entities |
| Update Step's properties     | * Source Code (one way) |

fixes: https://github.com/KaotoIO/kaoto-next/issues/266

### Notes
This pull request it's a prerequisite of https://github.com/KaotoIO/kaoto-next/issues/291