### PR TITLE
fix(313) - Kamelets in Camel Routes are not handled properly

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -1,6 +1,8 @@
 import { SourceSchemaType } from './source-schema-type';
 import { CamelRouteResource } from './camel-route-resource';
-import { camelRouteJson } from '../../stubs/camel-route';
+import { createCamelResource } from './camel-resource';
+import { camelRouteJson, camelRoute } from '../../stubs/camel-route';
+import { AddStepMode } from '../visualization/base-visual-entity';
 
 describe('CamelRouteResource', () => {
   it('should create CamelRouteResource', () => {
@@ -15,5 +17,51 @@ describe('CamelRouteResource', () => {
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
+  });
+});
+
+describe('getCompatibleComponents', () => {
+  it('should not provide isProducerOnly components', () => {
+    const resource = createCamelResource(camelRouteJson);
+    expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined;
+  });
+
+  it('should  provide consumerOnly components', () => {
+    const resource = new CamelRouteResource(camelRouteJson);
+    expect(
+      resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
+        path: 'from.steps.2.to',
+        processorName: 'to',
+        label: 'timer',
+      }),
+    ).toBeDefined;
+  });
+
+  it('scenario for InsertSpecialChild', () => {
+    const resource = createCamelResource(camelRouteJson);
+    expect(resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }))
+      .toBeDefined;
+  });
+
+  it('scenario for a new step before an existing step', () => {
+    const resource = new CamelRouteResource(camelRouteJson);
+    expect(
+      resource.getCompatibleComponents(AddStepMode.PrependStep, {
+        path: 'from.steps.0.to',
+        processorName: 'to',
+        label: 'timer',
+      }),
+    ).toBeDefined;
+  });
+
+  it('scenario for a new step after an existing step', () => {
+    const resource = new CamelRouteResource(camelRouteJson);
+    expect(
+      resource.getCompatibleComponents(AddStepMode.AppendStep, {
+        path: 'from.steps.1.to',
+        processorName: 'to',
+        label: 'timer',
+      }),
+    ).toBeDefined;
   });
 });

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -21,12 +21,12 @@ describe('CamelRouteResource', () => {
 });
 
 describe('getCompatibleComponents', () => {
-  it('should not provide isProducerOnly components', () => {
+  it('should not provide ProducerOnly components', () => {
     const resource = createCamelResource(camelRouteJson);
-    expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined;
+    expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined();
   });
 
-  it('should  provide consumerOnly components', () => {
+  it('should not provide consumerOnly components', () => {
     const resource = new CamelRouteResource(camelRouteJson);
     expect(
       resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
@@ -34,13 +34,14 @@ describe('getCompatibleComponents', () => {
         processorName: 'to',
         label: 'timer',
       }),
-    ).toBeDefined;
+    ).toBeDefined();
   });
 
   it('scenario for InsertSpecialChild', () => {
     const resource = createCamelResource(camelRouteJson);
-    expect(resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }))
-      .toBeDefined;
+    expect(
+      resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }),
+    ).toBeDefined();
   });
 
   it('scenario for a new step before an existing step', () => {
@@ -51,7 +52,7 @@ describe('getCompatibleComponents', () => {
         processorName: 'to',
         label: 'timer',
       }),
-    ).toBeDefined;
+    ).toBeDefined();
   });
 
   it('scenario for a new step after an existing step', () => {
@@ -62,6 +63,6 @@ describe('getCompatibleComponents', () => {
         processorName: 'to',
         label: 'timer',
       }),
-    ).toBeDefined;
+    ).toBeDefined();
   });
 });

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -1,7 +1,7 @@
 import { SourceSchemaType } from './source-schema-type';
 import { CamelRouteResource } from './camel-route-resource';
+import { camelRouteJson } from '../../stubs/camel-route';
 import { createCamelResource } from './camel-resource';
-import { camelRouteJson, camelRoute } from '../../stubs/camel-route';
 import { AddStepMode } from '../visualization/base-visual-entity';
 
 describe('CamelRouteResource', () => {

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -101,7 +101,8 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
        * as this mean that they can be used only as a consumer.
        */
       return (item: ITile) => {
-        return (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) || (item.type === CatalogKind.Kamelet && item.tags.includes('source'));
+        return (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) || 
+        (item.type === CatalogKind.Kamelet && item.tags.includes('source'));
       };
     }
 
@@ -132,7 +133,8 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
      * as this mean that they can be used only as a consumer.
      */
     return (item: ITile) => {
-      return !item.tags.includes('consumerOnly');
+      return (item.type !== CatalogKind.Kamelet && !item.tags.includes('consumerOnly')) || 
+      (item.type === CatalogKind.Kamelet && !item.tags.includes('source'));
     };
   }
 }

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -101,7 +101,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
        * as this mean that they can be used only as a consumer.
        */
       return (item: ITile) => {
-        return item.type === CatalogKind.Component && !item.tags.includes('producerOnly');
+        return (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) || (item.type === CatalogKind.Kamelet && item.tags.includes('source'));
       };
     }
 

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -101,8 +101,10 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
        * as this mean that they can be used only as a consumer.
        */
       return (item: ITile) => {
-        return (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) || 
-        (item.type === CatalogKind.Kamelet && item.tags.includes('source'));
+        return (
+          (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) ||
+          (item.type === CatalogKind.Kamelet && item.tags.includes('source'))
+        );
       };
     }
 
@@ -133,8 +135,10 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
      * as this mean that they can be used only as a consumer.
      */
     return (item: ITile) => {
-      return (item.type !== CatalogKind.Kamelet && !item.tags.includes('consumerOnly')) || 
-      (item.type === CatalogKind.Kamelet && !item.tags.includes('source'));
+      return (
+        (item.type !== CatalogKind.Kamelet && !item.tags.includes('consumerOnly')) ||
+        (item.type === CatalogKind.Kamelet && !item.tags.includes('source'))
+      );
     };
   }
 }


### PR DESCRIPTION
Fixes [#313](https://github.com/KaotoIO/kaoto-next/issues/313)

Now, when we replace the source node, the catalog page loads like this:
![image](https://github.com/KaotoIO/kaoto-next/assets/73224329/ec48aa5e-cc34-4c01-b1c2-265377699f7b)

Similarly, the Catalog page looks like this when we replace the last node:
![image](https://github.com/KaotoIO/kaoto-next/assets/73224329/abfffd71-7959-4124-9cc3-dea750ced217)



