### PR TITLE
chore(lint): Make lint mandatory for UI package

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -31,6 +31,10 @@ jobs:
       - name: 💅 Run eslint
         run: yarn workspaces foreach --verbose --topological-dev run lint
 
+      # Lint style files
+      - name: 💅 Run stylelint
+        run: yarn workspace @kaoto-next/ui run lint:style
+
       # Run tests
       - name: 🧪 Run tests
         run: yarn workspaces foreach --verbose --topological-dev run test

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,10 +35,8 @@
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "yarn lint:code; yarn lint:style",
-    "lint:fix": "yarn lint:code:fix; yarn lint:style:fix",
-    "lint:code": "yarn eslint \"src/**/*.{ts,tsx}\"",
-    "lint:code:fix": "yarn lint:code --fix",
+    "lint": "yarn eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "yarn lint:code --fix",
     "lint:style": "yarn stylelint \"src/**/*.{css,scss}\"",
     "lint:style:fix": "yarn lint:style --fix"
   },

--- a/packages/ui/src/utils/node-icon-resolver.ts
+++ b/packages/ui/src/utils/node-icon-resolver.ts
@@ -23,8 +23,8 @@ import process from '../assets/eip/process.png';
 import recipient_list from '../assets/eip/recipient-list.png';
 import remove_header from '../assets/eip/removeheader.png';
 import remove_headers from '../assets/eip/removeheaders.png';
-import remove_property from '../assets/eip/removeproperty.png';
 import remove_properties from '../assets/eip/removeproperties.png';
+import remove_property from '../assets/eip/removeproperty.png';
 import resequence from '../assets/eip/resequence.png';
 import rollback from '../assets/eip/rollback.png';
 import sample from '../assets/eip/sample.png';
@@ -689,7 +689,7 @@ function getEIPIcon(elementName?: string): string | undefined {
     case 'transform':
       return transform;
     case 'unmarshal':
-        return transform;
+      return transform;
     case 'validate':
       return validate;
     case 'weighted':
@@ -698,7 +698,7 @@ function getEIPIcon(elementName?: string): string | undefined {
       return when;
     case 'wireTap':
       return wiretap;
-    default: 
+    default:
       return undefined;
   }
 }


### PR DESCRIPTION
### Context
Currently, both `lint:code` and `lint:style` are optional as both are run with `;` syntax, meaning that if `lint:code` fails, but `stylelint` doesn't, the stage is passed as only the last exit code gets stored.

### Changes
The fix is to separate both scripts and execute them in dedicated stages.