### PR TITLE
chore(build): Expose @kaoto-next/camel-catalog files through the lib

### DIFF
--- a/packages/ui/scripts/copy-camel-catalog-files.cjs
+++ b/packages/ui/scripts/copy-camel-catalog-files.cjs
@@ -1,0 +1,35 @@
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const fs = require('node:fs');
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const path = require('node:path');
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const { getCamelCatalogFiles } = require('./get-camel-catalog-files.cjs');
+
+/**
+ * Copy the built Kaoto Camel Catalog files into the assets/camel-catalog folder
+ */
+function copyCamelCatalogFiles(destinationFolder) {
+  const camelCatalogFiles = getCamelCatalogFiles();
+
+  camelCatalogFiles.forEach((file) => {
+    const dest = path.resolve(path.join(destinationFolder, path.basename(file)));
+
+    console.info('\t', `Copying '${file}' to '${dest}'`);
+
+    fs.copyFileSync(file, dest);
+  });
+}
+
+// eslint-disable-next-line no-undef
+const dest = process.argv[2];
+console.info(`Copying Kaoto Camel Catalog files to '${dest}'`, '\n');
+
+if (!dest) {
+  throw new Error('Missing destination folder');
+}
+
+if (!fs.existsSync(dest)) {
+  fs.mkdirSync(dest, { recursive: true });
+}
+
+copyCamelCatalogFiles(dest);

--- a/packages/ui/scripts/get-camel-catalog-files.cjs
+++ b/packages/ui/scripts/get-camel-catalog-files.cjs
@@ -1,0 +1,57 @@
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const fs = require('node:fs');
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const path = require('node:path');
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const vite = require('vite');
+const { normalizePath } = vite;
+
+/**
+ * Temporary function to copy the built Kaoto Camel Catalog into the assets folder
+ *
+ * When dynamically importing the Camel Catalog is supported, this function can be removed
+ * and this file can be restored to a .ts file.
+ * Related issue: https://github.com/sveltejs/vite-plugin-svelte/issues/141#issuecomment-898900239
+ */
+function getCamelCatalogFiles() {
+  let camelCatalogPath = '';
+
+  try {
+    // eslint-disable-next-line no-undef
+    camelCatalogPath = normalizePath(path.dirname(require.resolve('@kaoto-next/camel-catalog/package.json')));
+    camelCatalogPath = path.join(camelCatalogPath, 'dist');
+  } catch (error) {
+    console.error(error);
+    /* empty */
+  }
+
+  console.info(`Found '@kaoto-next/camel-catalog' in ${camelCatalogPath}`, '\n');
+
+  try {
+    if (fs.readdirSync(camelCatalogPath).length === 0) {
+      throw new Error();
+    }
+  } catch (error) {
+    const message = [
+      `The '${camelCatalogPath}' folder is empty.`,
+      'No files found in the Camel Catalog directory.',
+      'Please run `yarn workspace @kaoto-next/camel-catalog run build`',
+      'or `yarn build` in the `@kaoto-next/camel-catalog` package',
+    ];
+
+    throw new Error(message.join('\n\n'));
+  }
+
+  /** List all the JSON files in the Camel Catalog folder */
+  const jsonFiles = fs
+    .readdirSync(camelCatalogPath)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => path.join(camelCatalogPath, file));
+
+  return jsonFiles;
+}
+
+// eslint-disable-next-line no-undef
+module.exports = {
+  getCamelCatalogFiles,
+};


### PR DESCRIPTION
### Context
Currently, the Camel Catalog is not exposed through Kaoto in lib mode.

### Changes
Export the processed Camel Catalog through Kaoto in lib mode for VSCode.

### Notes
It's possible that in the future, the `@kaoto-next/camel-catalog` package will transition into a catalog processor only and will be consumed by `VSCode` directly, meaning that every consumer could decide which catalog to bundle when building Kaoto perspectives.