### PR TITLE
chore(deps): Force @patternfly/react-core resolution to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   ],
   "resolutions": {
     "@babel/traverse": "7.23.3",
+    "@patternfly/patternfly": "^5.0.0",
+    "@patternfly/react-code-editor": "^5.0.0",
+    "@patternfly/react-core": "^5.0.0",
+    "@patternfly/react-icons": "^5.0.0",
+    "@patternfly/react-table": "^5.0.0",
+    "@patternfly/react-topology": "^5.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "uniforms": "4.0.0-alpha.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,7 +3309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:5.0.2, @patternfly/patternfly@npm:^5.0.0":
+"@patternfly/patternfly@npm:^5.0.0":
   version: 5.0.2
   resolution: "@patternfly/patternfly@npm:5.0.2"
   checksum: 5b386efb172b553cf90622c613170c63ead66d388c4cb62bdf264ee9ba7f03df2fcaab497fd2d1390482e7e93dca36eab428a370e21578205a30b857c100bc10
@@ -3333,7 +3333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^5.0.0, @patternfly/react-core@npm:^5.1.0":
+"@patternfly/react-core@npm:^5.0.0":
   version: 5.1.0
   resolution: "@patternfly/react-core@npm:5.1.0"
   dependencies:
@@ -3351,7 +3351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:^5.0.0, @patternfly/react-icons@npm:^5.1.0":
+"@patternfly/react-icons@npm:^5.0.0":
   version: 5.1.0
   resolution: "@patternfly/react-icons@npm:5.1.0"
   dependencies:


### PR DESCRIPTION
### Context
`@kie-tools-core` depends on a few components from `@patternfly` v4.

This commit forces the resolution to the latest available version from `@patternfly`.