### PR TITLE
feat(multiplying-architecture): Provide an editor using the multiplying architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@patternfly/react-icons": "^5.0.0",
     "@patternfly/react-table": "^5.0.0",
     "@patternfly/react-topology": "^5.0.0",
+    "axios": "1.6.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "uniforms": "4.0.0-alpha.5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,9 +29,10 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build --config vite.config.js",
-    "build:lib": "yarn rimraf ./lib && yarn build:esm && yarn build:cjs",
+    "build:lib": "yarn rimraf ./lib && yarn copy-catalog && yarn build:esm && yarn build:cjs",
     "build:esm": "tsc --project tsconfig.esm.json && copyfiles -u 1 ./src/**/*.scss ./src/assets/** ./lib/esm",
     "build:cjs": "tsc --project tsconfig.cjs.json && copyfiles -u 1 ./src/**/*.scss ./src/assets/** ./lib/cjs",
+    "copy-catalog": "node ./scripts/copy-camel-catalog-files.js ./lib/camel-catalog",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -42,6 +43,8 @@
   },
   "dependencies": {
     "@kaoto-next/uniforms-patternfly": "^0.5.0",
+    "@kie-tools-core/editor": "0.32.0",
+    "@kie-tools-core/notifications": "0.32.0",
     "@patternfly/patternfly": "^5.0.0",
     "@patternfly/react-code-editor": "^5.0.0",
     "@patternfly/react-core": "^5.0.0",

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -1,0 +1,9 @@
+.canvas-page {
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+
+  &__canvas {
+    flex-grow: 1;
+  }
+}

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -1,0 +1,145 @@
+import { ChannelType, EditorApi, StateControlCommand } from '@kie-tools-core/editor/dist/api';
+import { Notification } from '@kie-tools-core/notifications/dist/api';
+import { WorkspaceEdit } from '@kie-tools-core/workspace/dist/api';
+import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useRef } from 'react';
+import { Visualization } from '../components/Visualization';
+import { CatalogModalProvider } from '../providers/catalog-modal.provider';
+import { CatalogTilesProvider } from '../providers/catalog-tiles.provider';
+import { CatalogLoaderProvider } from '../providers/catalog.provider';
+import { EntitiesContext } from '../providers/entities.provider';
+import { SchemasLoaderProvider } from '../providers/schemas.provider';
+import { SourceCodeContext } from '../providers/source-code.provider';
+import { EventNotifier } from '../utils';
+import './KaotoEditor.scss';
+
+interface Props {
+  /**
+   * Delegation for KogitoEditorChannelApi.kogitoEditor_ready() to signal to the Channel
+   * that the editor is ready.
+   */
+  onReady: () => void;
+
+  /**
+   * Delegation for KogitoEditorChannelApi.kogitoEditor_stateControlCommandUpdate(command) to signal to the Channel
+   * that the editor is performing an undo/redo operation.
+   */
+  onStateControlCommandUpdate: (command: StateControlCommand) => void;
+
+  /**
+   * Delegation for WorkspaceChannelApi.kogitoWorkspace_newEdit(edit) to signal to the Channel
+   * that a change has taken place.
+   * @param edit An object representing the unique change.
+   */
+  onNewEdit: (edit: WorkspaceEdit) => void;
+
+  /**
+   * Delegation for NotificationsChannelApi.kogigotNotifications_setNotifications(path, notifications) to report all validation
+   * notifications to the Channel that will replace existing notification for the path.
+   * @param path The path that references the Notification
+   * @param notifications List of Notifications
+   */
+  setNotifications: (path: string, notifications: Notification[]) => void;
+
+  /**
+   * ChannelType where the component is running.
+   */
+  channelType: ChannelType;
+
+  /**
+   * Catalog URL to load the components and schemas.
+   */
+  catalogUrl: string;
+}
+
+export const KaotoEditor = forwardRef<EditorApi, Props>((props, forwardedRef) => {
+  const eventNotifier = EventNotifier.getInstance();
+  const entitiesContext = useContext(EntitiesContext);
+  const sourceCodeContext = useContext(SourceCodeContext);
+  const sourceCodeRef = useRef<string>(sourceCodeContext?.sourceCode ?? '');
+
+  /**
+   * Callback is exposed to the Channel that is called when a new file is opened.
+   * It sets the originalContent to the received value.
+   */
+  const setContent = useCallback(
+    (_path: string, content: string) => {
+      /**
+       * If the new content is the same as the current one, we don't need to update the Editor,
+       * as it will regenerate the Camel Resource, hence disconnecting the configuration form (if open).
+       *
+       * This happens due to the multiplying architecture lifecycle, where the content is set
+       * after saving the file.
+       *
+       * The lifecycle is:
+       * 1. User edits the file either adding a new node or modifying an existing one using the form
+       * 2. User saves the file
+       * 3. The Envelope uses the `getContent` callback to retrieve the new content
+       * 4. The Envelope sets the new content using the `setContent` callback
+       *
+       * At this point, both the new content and the current content are the same, so the Editor
+       * don't need to be updated.
+       */
+      if (sourceCodeRef.current === content) return;
+
+      sourceCodeContext?.setCodeAndNotify(content);
+      sourceCodeRef.current = content;
+    },
+    [sourceCodeContext],
+  );
+
+  /**
+   * Subscribe to the `entities:updated` event to update the File content.
+   */
+  useEffect(() => {
+    return eventNotifier.subscribe('entities:updated', (newContent: string) => {
+      props.onNewEdit(new WorkspaceEdit(newContent));
+      sourceCodeRef.current = newContent;
+    });
+  }, [eventNotifier, props]);
+
+  /**
+   * The useImperativeHandler gives the control of the Editor component to who has it's reference,
+   * making it possible to communicate with the Editor.
+   * It returns all methods that are determined on the EditorApi.
+   */
+  useImperativeHandle(forwardedRef, () => {
+    return {
+      /**
+       * Callback is exposed to the Channel to retrieve the current value of the Editor. It returns the value of
+       * the editorContent, which is the state that has the kaoto yaml.
+       */
+      getContent: () => Promise.resolve(sourceCodeRef.current),
+      /* Callback is exposed to the Channel to set the content of the file into the current Editor. */
+      setContent: (path: string, content: string) => Promise.resolve(setContent(path, content)),
+      getPreview: () => Promise.resolve(undefined),
+      undo: (): Promise<void> => {
+        return Promise.resolve();
+      },
+      redo: (): Promise<void> => {
+        return Promise.resolve();
+      },
+      getElementPosition: () => Promise.resolve(undefined),
+      validate: () => Promise.resolve([]),
+      setTheme: () => Promise.resolve(),
+    };
+  });
+
+  const visualEntities = entitiesContext?.visualEntities ?? [];
+
+  /** Set editor as Ready */
+  useEffect(() => {
+    props.onReady();
+  }, [props]);
+
+  return (
+    <SchemasLoaderProvider catalogUrl={props.catalogUrl}>
+      <CatalogLoaderProvider catalogUrl={props.catalogUrl}>
+        <CatalogTilesProvider>
+          <CatalogModalProvider>
+            <Visualization className="canvas-page" entities={visualEntities} />
+          </CatalogModalProvider>
+        </CatalogTilesProvider>
+      </CatalogLoaderProvider>
+    </SchemasLoaderProvider>
+  );
+});

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -1,0 +1,97 @@
+import {
+  Editor,
+  EditorApi,
+  EditorInitArgs,
+  EditorTheme,
+  KogitoEditorChannelApi,
+  KogitoEditorEnvelopeContextType,
+} from '@kie-tools-core/editor/dist/api';
+import { Notification } from '@kie-tools-core/notifications/dist/api';
+import { RefObject, createRef } from 'react';
+import { EntitiesProvider } from '../providers/entities.provider';
+import { SourceCodeProvider } from '../providers/source-code.provider';
+import { KaotoEditor } from './KaotoEditor';
+
+export class KaotoEditorView implements Editor {
+  private readonly editorRef: RefObject<EditorApi>;
+  af_isReact = true;
+  af_componentId = 'kaoto-editor';
+  af_componentTitle = 'Kaoto Editor';
+
+  constructor(
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    private readonly initArgs: EditorInitArgs,
+  ) {
+    this.editorRef = createRef<EditorApi>();
+  }
+
+  async getElementPosition() {
+    return {
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    };
+  }
+
+  async setContent(path: string, content: string): Promise<void> {
+    return this.editorRef.current?.setContent(path, content);
+  }
+
+  async getContent(): Promise<string> {
+    const content = await this.editorRef.current?.getContent();
+
+    return content ?? '';
+  }
+
+  async getPreview(): Promise<string | undefined> {
+    return this.editorRef.current?.getPreview();
+  }
+
+  async undo(): Promise<void> {
+    return this.editorRef.current?.undo();
+  }
+
+  async redo(): Promise<void> {
+    return this.editorRef.current?.redo();
+  }
+
+  async validate(): Promise<Notification[]> {
+    return this.editorRef.current?.validate() ?? [];
+  }
+
+  async setTheme(theme: EditorTheme): Promise<void> {
+    return this.editorRef.current?.setTheme(theme);
+  }
+
+  af_componentRoot() {
+    return (
+      <SourceCodeProvider>
+        <EntitiesProvider>
+          <KaotoEditor
+            ref={this.editorRef}
+            channelType={this.initArgs.channel}
+            onReady={() => this.envelopeContext.channelApi.notifications.kogitoEditor_ready.send()}
+            onNewEdit={(edit) => {
+              this.envelopeContext.channelApi.notifications.kogitoWorkspace_newEdit.send(edit);
+            }}
+            setNotifications={(path, notifications) =>
+              this.envelopeContext.channelApi.notifications.kogitoNotifications_setNotifications.send(
+                path,
+                notifications,
+              )
+            }
+            onStateControlCommandUpdate={(command) =>
+              this.envelopeContext.channelApi.notifications.kogitoEditor_stateControlCommandUpdate.send(command)
+            }
+            catalogUrl={`${this.initArgs.resourcesPathPrefix}/camel-catalog`}
+          />
+        </EntitiesProvider>
+      </SourceCodeProvider>
+    );
+  }
+}

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
@@ -1,0 +1,17 @@
+import { KaotoEditorView } from './KaotoEditorApp';
+import {
+  Editor,
+  EditorFactory,
+  EditorInitArgs,
+  KogitoEditorEnvelopeContextType,
+  KogitoEditorChannelApi,
+} from '@kie-tools-core/editor/dist/api';
+
+export class KaotoEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi> {
+  public createEditor(
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    initArgs: EditorInitArgs,
+  ): Promise<Editor> {
+    return Promise.resolve(new KaotoEditorView(envelopeContext, initArgs));
+  }
+}

--- a/packages/ui/src/multiplying-architecture/index.ts
+++ b/packages/ui/src/multiplying-architecture/index.ts
@@ -1,0 +1,1 @@
+export * from './KaotoEditorFactory';

--- a/packages/ui/src/public-api.ts
+++ b/packages/ui/src/public-api.ts
@@ -5,3 +5,4 @@ export * from './components/Visualization';
 export * from './components/Visualization/Canvas';
 export * from './components/Visualization/ContextToolbar';
 export * from './components/MetadataEditor';
+export * from './multiplying-architecture';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,6 +2625,8 @@ __metadata:
     "@babel/preset-typescript": ^7.21.5
     "@kaoto-next/camel-catalog": "workspace:*"
     "@kaoto-next/uniforms-patternfly": ^0.5.0
+    "@kie-tools-core/editor": 0.32.0
+    "@kie-tools-core/notifications": 0.32.0
     "@patternfly/patternfly": ^5.0.0
     "@patternfly/react-code-editor": ^5.0.0
     "@patternfly/react-core": ^5.0.0
@@ -2701,6 +2703,121 @@ __metadata:
     react-dom: ^18.2.0
     uniforms: 4.0.0-alpha.5
   checksum: d50f480d7647fee7f97d851c6783431846fd8459623728df154f4b92673870f67bcd3f49d67ec89f101317b544e2b338886eb74b1c77cffbc0cc31eb1a3f7ee1
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/backend@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/backend@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/i18n": 0.32.0
+    "@kie-tools-core/notifications": 0.32.0
+    "@kie-tools-core/workspace": 0.32.0
+    axios: ^0.27.2
+    fast-xml-parser: ^4.3.1
+    portfinder: ^1.0.32
+    semver: ^7.5.4
+    sinon: ^11.1.1
+  checksum: 7c338dfe0ccfaa2b9c37dff38860462cc339466ae1f99e5039d4fe682bfc5d036348c894f84f3cbc7d4d8b5c88e0f7a9e806a977d76973600b0811c0c2453dca
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/editor@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/editor@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/backend": 0.32.0
+    "@kie-tools-core/envelope": 0.32.0
+    "@kie-tools-core/envelope-bus": 0.32.0
+    "@kie-tools-core/i18n": 0.32.0
+    "@kie-tools-core/keyboard-shortcuts": 0.32.0
+    "@kie-tools-core/notifications": 0.32.0
+    "@kie-tools-core/operating-system": 0.32.0
+    "@kie-tools-core/patternfly-base": 0.32.0
+    "@kie-tools-core/workspace": 0.32.0
+    "@patternfly/react-core": ^4.276.6
+    "@patternfly/react-icons": ^4.93.6
+    csstype: ^3.0.11
+    minimatch: ^3.0.5
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: 6649b6dcef81d004bac0f9a5f5c9c51b43f30460ef2c87272412d8064b5b7920fc86b19ce848d0603c07afe11e250300a0cab62ad7b6c3f4cbb9d94ba491bf01
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/envelope-bus@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/envelope-bus@npm:0.32.0"
+  dependencies:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: 676ac6978ac89bae4a6380da52a5b55ca30217cb397bbf279c076deb4b1b643fff88788fc9043383d29719f17f7d1c1f56ebab93e93cd7fb80ec987938fb86bc
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/envelope@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/envelope@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/envelope-bus": 0.32.0
+    csstype: ^3.0.11
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: c80f02f7dabe3e9f64ae7ce22a9af313e1954787b0d6c5db676482fed16b45cf6e833cf3760b596d549ec5253b93b4345b7c4a8e34ca2fb12fa78389abd9df57
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/i18n@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/i18n@npm:0.32.0"
+  dependencies:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: 6fa171f17d40a10fbfa5df0b4c68c360d2ac84fde6a6a016645dcfa059814e40a0054b2bc3234123fb35c1802c032bf00792603163be8d5d6388a273d66de5c2
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/keyboard-shortcuts@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/keyboard-shortcuts@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/envelope-bus": 0.32.0
+    "@kie-tools-core/operating-system": 0.32.0
+    react: ^17.0.2
+  checksum: afc71049a14166cc3789a3e3b655a53af912aa27c3ac6b0924de245e9dfea1a35664490bba0a6bd0992972fa4074a8e717088fdd07baa360644829ddeebfa282
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/notifications@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/notifications@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/i18n": 0.32.0
+    "@kie-tools-core/workspace": 0.32.0
+  checksum: 3d31a4a8b7d0c740a72511831b00b55c588f1bac4ca49c81bb9e2556ee858652607d23e2a49d698a81cffb76921b66fd99036bdcd16e348578e131620a48646b
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/operating-system@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/operating-system@npm:0.32.0"
+  checksum: a2e95735bfdfdb13879326207374873400438fcf510a3cd0f830f2fe97ec99753e7dd53091198d0be055d9524bc286656a00ca52ab3b2c9e8cd279a4b3be8fdb
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/patternfly-base@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/patternfly-base@npm:0.32.0"
+  checksum: 88c1094a39e1aef2a4c2e6f4d17c871c11ad5c00b57d815bc5840b060c3fdfbf5e5e0c4a28d006d7197042be2b5a096ab01e5908957970a1b9990e41caea87bf
+  languageName: node
+  linkType: hard
+
+"@kie-tools-core/workspace@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@kie-tools-core/workspace@npm:0.32.0"
+  dependencies:
+    "@kie-tools-core/operating-system": 0.32.0
+  checksum: a9695c14a42a03db533b9566cd85c30e4dd656a74e75cafc80d8c06a6f61446f8025b86516fb328915ce4e201c43fd7dc8c57c646cc94764799d152cd18806aa
   languageName: node
   linkType: hard
 
@@ -4175,6 +4292,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.3":
+  version: 1.8.6
+  resolution: "@sinonjs/commons@npm:1.8.6"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 7d3f8c1e85f30cd4e83594fc19b7a657f14d49eb8d95a30095631ce15e906c869e0eff96c5b93dffea7490c00418b07f54582ba49c6560feb2a8c34c0b16832d
+  languageName: node
+  linkType: hard
+
+"@sinonjs/commons@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sinonjs/commons@npm:2.0.0"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 5023ba17edf2b85ed58262313b8e9b59e23c6860681a9af0200f239fe939e2b79736d04a260e8270ddd57196851dde3ba754d7230be5c5234e777ae2ca8af137
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^3.0.0":
   version: 3.0.0
   resolution: "@sinonjs/commons@npm:3.0.0"
@@ -4190,6 +4325,33 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^3.0.0
   checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "@sinonjs/fake-timers@npm:7.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: c84773d7973edad5511a31d2cc75023447b5cf714a84de9bb50eda45dda88a0d3bd2c30bf6e6e936da50a048d5352e2151c694e13e59b97d187ba1f329e9a00c
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^6.0.2":
+  version: 6.1.3
+  resolution: "@sinonjs/samsam@npm:6.1.3"
+  dependencies:
+    "@sinonjs/commons": ^1.6.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: d533e8792af00879d78dd181822e8b00bb8a81671f2fbcf1c5257a59649b21d881ba7ddc42aaf09690d7325c8a6dcc7a1a341591a379742b54e4eb25b273417a
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@sinonjs/text-encoding@npm:0.7.2"
+  checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
   languageName: node
   linkType: hard
 
@@ -7279,6 +7441,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^2.6.4":
+  version: 2.6.4
+  resolution: "async@npm:2.6.4"
+  dependencies:
+    lodash: ^4.17.14
+  checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
+  languageName: node
+  linkType: hard
+
 "async@npm:^3.2.0, async@npm:^3.2.3":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
@@ -8679,7 +8850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
+"csstype@npm:^3.0.11, csstype@npm:^3.0.2":
   version: 3.1.2
   resolution: "csstype@npm:3.1.2"
   checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
@@ -9498,6 +9669,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "diff@npm:5.1.0"
+  checksum: c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90
   languageName: node
   linkType: hard
 
@@ -10633,6 +10811,17 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^4.3.1":
+  version: 4.3.2
+  resolution: "fast-xml-parser@npm:4.3.2"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: d507ce2efa5fd13d0a5ba28bd76dd68f2fc30ad8748357c37b70f360d19417866d79e35a688af067d5bceaaa796033fa985206aef9692f7a421e1326b6e73309
   languageName: node
   linkType: hard
 
@@ -13559,6 +13748,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^4.0.2":
+  version: 4.2.1
+  resolution: "just-extend@npm:4.2.1"
+  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
+  languageName: node
+  linkType: hard
+
 "kaoto-next@workspace:.":
   version: 0.0.0-use.local
   resolution: "kaoto-next@workspace:."
@@ -13872,7 +14068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.0.0, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.15":
+"lodash@npm:^4.0.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.15":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -14472,7 +14668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.4":
+"mkdirp@npm:^0.5.4, mkdirp@npm:^0.5.6":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -14751,6 +14947,19 @@ __metadata:
   version: 1.1.0
   resolution: "next-tick@npm:1.1.0"
   checksum: 83b5cf36027a53ee6d8b7f9c0782f2ba87f4858d977342bfc3c20c21629290a2111f8374d13a81221179603ffc4364f38374b5655d17b6a8f8a8c77bdea4fe8b
+  languageName: node
+  linkType: hard
+
+"nise@npm:^5.1.0":
+  version: 5.1.5
+  resolution: "nise@npm:5.1.5"
+  dependencies:
+    "@sinonjs/commons": ^2.0.0
+    "@sinonjs/fake-timers": ^10.0.2
+    "@sinonjs/text-encoding": ^0.7.1
+    just-extend: ^4.0.2
+    path-to-regexp: ^1.7.0
+  checksum: c763dc62c5796cafa5c9268e14a5b34db6e6fa2f1dbc57a891fe5d7ea632a87868e22b5bb34965006f984630793ea11368351e94971163228d9e20b2e88edce8
   languageName: node
   linkType: hard
 
@@ -15543,6 +15752,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "path-to-regexp@npm:1.8.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:^6.2.0":
   version: 6.2.1
   resolution: "path-to-regexp@npm:6.2.1"
@@ -15712,6 +15930,17 @@ __metadata:
   version: 1.16.1
   resolution: "popper.js@npm:1.16.1"
   checksum: c56ae5001ec50a77ee297a8061a0221d99d25c7348d2e6bcd3e45a0d0f32a1fd81bca29d46cb0d4bdf13efb77685bd6a0ce93f9eb3c608311a461f945fffedbe
+  languageName: node
+  linkType: hard
+
+"portfinder@npm:^1.0.32":
+  version: 1.0.32
+  resolution: "portfinder@npm:1.0.32"
+  dependencies:
+    async: ^2.6.4
+    debug: ^3.2.7
+    mkdirp: ^0.5.6
+  checksum: 116b4aed1b9e16f6d5503823d966d9ffd41b1c2339e27f54c06cd2f3015a9d8ef53e2a53b57bc0a25af0885977b692007353aa28f9a0a98a44335cb50487240d
   languageName: node
   linkType: hard
 
@@ -17259,6 +17488,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^11.1.1":
+  version: 11.1.2
+  resolution: "sinon@npm:11.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.8.3
+    "@sinonjs/fake-timers": ^7.1.2
+    "@sinonjs/samsam": ^6.0.2
+    diff: ^5.0.0
+    nise: ^5.1.0
+    supports-color: ^7.2.0
+  checksum: 1d01377e230c9ba976bf33f28b588bae7901b0b5a503d2f6b2a7914b0dbaa9f09823481926c6f2abed820123c7fa865519695af3ae2e9ba18d8b025616163501
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -17821,6 +18064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
+  languageName: node
+  linkType: hard
+
 "strong-log-transformer@npm:^2.1.0":
   version: 2.1.0
   resolution: "strong-log-transformer@npm:2.1.0"
@@ -17980,7 +18230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -18516,7 +18766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15

--- a/yarn.lock
+++ b/yarn.lock
@@ -7328,13 +7328,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
+"axios@npm:1.6.2":
+  version: 1.6.2
+  resolution: "axios@npm:1.6.2"
   dependencies:
-    follow-redirects: ^1.14.9
+    follow-redirects: ^1.15.0
     form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+    proxy-from-env: ^1.1.0
+  checksum: 4a7429e2b784be0f2902ca2680964391eae7236faa3967715f30ea45464b98ae3f1c6f631303b13dfe721b17126b01f486c7644b9ef276bfc63112db9fd379f8
   languageName: node
   linkType: hard
 
@@ -10887,13 +10888,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.9":
-  version: 1.15.2
-  resolution: "follow-redirects@npm:1.15.2"
+"follow-redirects@npm:^1.15.0":
+  version: 1.15.3
+  resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
   languageName: node
   linkType: hard
 
@@ -15966,7 +15967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.0.0":
+"proxy-from-env@npm:^1.0.0, proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4


### PR DESCRIPTION
### Context
In order to use `kaoto-next`'s public components in VSCode, we need to combine the desired components into an `Editor` and then wrap it using the `Envelope` functionality from the multiplying architecture.

### Changes
This pull request provides a custom `Editor` that will be used in `VSCode`.

### Notes
This pull request is a prerequisite of https://github.com/KaotoIO/vscode-kaoto/issues/400

If the new content is the same as the current one, we don't need to update the Editor,
as it will regenerate the Camel Resource, hence disconnecting the configuration form (if open).

This happens due to the multiplying architecture lifecycle, where the content is set
after saving the file.

The lifecycle is:

1. The user edits the file by either adding a new node or modifying an existing one using the form
2. The user saves the file
3.  The Envelope uses the `getContent` callback to retrieve the new content
4.  The Envelope sets the new content using the `setContent` callback

At this point, both the new content and the current content are the same, so the Editor
don't need to be updated.

fixes: https://github.com/KaotoIO/kaoto-next/issues/291