### PR TITLE
feat(canvas): Split Canvas fallback component

### DIFF
--- a/packages/ui/src/components/Visualization/CanvasFallback/CanvasFallback.tsx
+++ b/packages/ui/src/components/Visualization/CanvasFallback/CanvasFallback.tsx
@@ -1,20 +1,7 @@
-import {
-  Bullseye,
-  Button,
-  EmptyState,
-  EmptyStateActions,
-  EmptyStateBody,
-  EmptyStateFooter,
-  EmptyStateHeader,
-  EmptyStateIcon,
-} from '@patternfly/react-core';
-import { ArrowLeftIcon, EyeSlashIcon } from '@patternfly/react-icons';
-import { Links } from '../../../router/links.models';
-import { useComponentLink } from '../../../hooks/ComponentLink';
+import { Bullseye, EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon } from '@patternfly/react-core';
+import { EyeSlashIcon } from '@patternfly/react-icons';
 
 export const CanvasFallback = () => {
-  const backLink = useComponentLink(Links.SourceCode);
-
   return (
     <Bullseye>
       <EmptyState>
@@ -28,13 +15,6 @@ export const CanvasFallback = () => {
           <br />
           <p>Try to go back to the source code and check if the source code is valid.</p>
         </EmptyStateBody>
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <Button variant="primary" component={backLink} icon={<ArrowLeftIcon />}>
-              Go to the source code
-            </Button>
-          </EmptyStateActions>
-        </EmptyStateFooter>
       </EmptyState>
     </Bullseye>
   );

--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 import { BaseVisualCamelEntity } from '../../models/visualization/base-visual-entity';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Canvas } from './Canvas';
@@ -10,12 +10,13 @@ import { VisibleFlowsProvider } from '../../providers/visible-flows.provider';
 interface CanvasProps {
   className?: string;
   entities: BaseVisualCamelEntity[];
+  fallback?: ReactNode;
 }
 
 export const Visualization: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
   return (
     <div className={`canvas-surface ${props.className ?? ''}`}>
-      <ErrorBoundary fallback={<CanvasFallback />}>
+      <ErrorBoundary fallback={props.fallback ?? <CanvasFallback />}>
         <VisibleFlowsProvider>
           <Canvas contextToolbar={<ContextToolbar />} entities={props.entities} />
         </VisibleFlowsProvider>

--- a/packages/ui/src/pages/Design/DesignPage.tsx
+++ b/packages/ui/src/pages/Design/DesignPage.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useContext } from 'react';
 import { Visualization } from '../../components/Visualization';
 import { CatalogModalProvider } from '../../providers/catalog-modal.provider';
 import { EntitiesContext } from '../../providers/entities.provider';
+import { ReturnToSourceCodeFallback } from './ReturnToSourceCodeFallback';
 import './DesignPage.scss';
 
 export const DesignPage: FunctionComponent = () => {
@@ -14,7 +15,11 @@ export const DesignPage: FunctionComponent = () => {
       <Title headingLevel="h1">Visualization</Title>
 
       <CatalogModalProvider>
-        <Visualization className="canvas-page__canvas" entities={visualEntities} />
+        <Visualization
+          className="canvas-page__canvas"
+          entities={visualEntities}
+          fallback={<ReturnToSourceCodeFallback />}
+        />
       </CatalogModalProvider>
     </div>
   );

--- a/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/ReturnToSourceCodeFallback.test.tsx
+++ b/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/ReturnToSourceCodeFallback.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReturnToSourceCodeFallback } from './ReturnToSourceCodeFallback';
+
+describe('ReturnToSourceCodeFallback', () => {
+  it('renders correctly', () => {
+    const wrapper = render(
+      <MemoryRouter>
+        <ReturnToSourceCodeFallback />
+      </MemoryRouter>,
+    );
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/ReturnToSourceCodeFallback.tsx
+++ b/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/ReturnToSourceCodeFallback.tsx
@@ -1,0 +1,41 @@
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+import { ArrowLeftIcon, EyeSlashIcon } from '@patternfly/react-icons';
+import { Links } from '../../../router/links.models';
+import { useComponentLink } from '../../../hooks/ComponentLink';
+
+export const ReturnToSourceCodeFallback = () => {
+  const backLink = useComponentLink(Links.SourceCode);
+
+  return (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateHeader
+          titleText="The provided source code cannot be shown"
+          headingLevel="h4"
+          icon={<EmptyStateIcon icon={EyeSlashIcon} />}
+        />
+        <EmptyStateBody>
+          <p>It might be that the source code is not available, or that the source code is not valid.</p>
+          <br />
+          <p>Try to go back to the source code and check if the source code is valid.</p>
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button variant="primary" component={backLink} icon={<ArrowLeftIcon />}>
+              Go to the source code
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </Bullseye>
+  );
+};

--- a/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/__snapshots__/ReturnToSourceCodeFallback.test.tsx.snap
+++ b/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/__snapshots__/ReturnToSourceCodeFallback.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CanvasFallback renders correctly 1`] = `
+exports[`ReturnToSourceCodeFallback renders correctly 1`] = `
 <DocumentFragment>
   <div
     class="pf-v5-l-bullseye"
@@ -51,6 +51,41 @@ exports[`CanvasFallback renders correctly 1`] = `
           <p>
             Try to go back to the source code and check if the source code is valid.
           </p>
+        </div>
+        <div
+          class="pf-v5-c-empty-state__footer"
+        >
+          <div
+            class="pf-v5-c-empty-state__actions"
+          >
+            <a
+              aria-disabled="false"
+              class="pf-v5-c-button pf-m-primary"
+              data-ouia-component-id="OUIA-Generated-Button-primary-1"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              href="/code"
+            >
+              <span
+                class="pf-v5-c-button__icon pf-m-start"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v5-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M257.5 445.1l-22.2 22.2c-9.4 9.4-24.6 9.4-33.9 0L7 273c-9.4-9.4-9.4-24.6 0-33.9L201.4 44.7c9.4-9.4 24.6-9.4 33.9 0l22.2 22.2c9.5 9.5 9.3 25-.4 34.3L136.6 216H424c13.3 0 24 10.7 24 24v32c0 13.3-10.7 24-24 24H136.6l120.5 114.8c9.8 9.3 10 24.8.4 34.3z"
+                  />
+                </svg>
+              </span>
+              Go to the source code
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/index.ts
+++ b/packages/ui/src/pages/Design/ReturnToSourceCodeFallback/index.ts
@@ -1,0 +1,1 @@
+export * from './ReturnToSourceCodeFallback';


### PR DESCRIPTION
### Context
Currently, the canvas fallback component that is loaded when a route cannot be parsed, has a link to the SourceCode editor. The issue with this approach is that some consumers won't have said source code editor.

### Changes
This commit provides a default fallback component and moves the custom fallback component to the DesignPage, which is Source Code editor aware.

| Default fallback | DesignPage fallback |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/84d2b9f8-dd6d-49ee-aed5-336ae607403f) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/4b71f323-2d81-4923-a2ae-4760defc3cae) |
