### PR TITLE
fix(viz): Configure nodes that could contain children

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -13,6 +13,8 @@ interface CanvasFormProps {
   selectedNode: CanvasNode;
 }
 
+const omitFields = ['expression', 'dataFormatType', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally'];
+
 export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
   const formRef = useRef<typeof AutoForm>();
@@ -54,7 +56,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
       {isExpressionAwareStep && <ExpressionEditor selectedNode={props.selectedNode} />}
       {isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}
       <AutoForm ref={formRef} schema={schema} model={model} onChangeModel={handleOnChange}>
-        <AutoFields autoField={CustomAutoField} omitFields={['expression', 'dataFormatType']} />
+        <AutoFields autoField={CustomAutoField} omitFields={omitFields} />
         <ErrorsField />
       </AutoForm>
     </ErrorBoundary>


### PR DESCRIPTION
### Context
There are some EIPs that could contain children, like `choice`, `when`, `otherwise`, `filter`, and others.
At this moment, the configuration panel doesn't work for those EIPs because those properties signal where to add the children.

### Changes
As this property is handled by the canvas itself, this pull request filters them out from the configuration form.

### Notes
A more robust solution might be added in the future, as new EIPs are added.

### Screenshots
## Choice
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/ac97acaf-89bb-4591-9de0-e463f3d3c16f)

## When
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/6757cf4a-8d18-4280-9103-ae6fe29a8650)

## Otherwise
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/b0a581e7-f12c-41dd-8a82-53f4b1507452)

## Filter
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/ae8f7cc5-f89e-4f5c-815b-077731076671)

Fixes:
- https://github.com/KaotoIO/kaoto-next/issues/320
- https://github.com/KaotoIO/kaoto-next/issues/321
- https://github.com/KaotoIO/kaoto-next/issues/395
Relates to:
- https://github.com/KaotoIO/kaoto-next/issues/331