### PR TITLE
feat(viz): Add Support for `from` construct

### DIFF
--- a/packages/ui/src/models/camel/__snapshots__/camel-route-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/camel-route-resource.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelRouteResource toJSON should return JSON 1`] = `
+[
+  {
+    "route": {
+      "from": {
+        "steps": [
+          {
+            "set-header": {
+              "name": "myChoice",
+              "simple": "\${random(2)}",
+            },
+          },
+          {
+            "choice": {
+              "otherwise": {
+                "steps": [
+                  {
+                    "to": {
+                      "uri": "amqp:queue:",
+                    },
+                  },
+                  {
+                    "to": {
+                      "uri": "amqp:queue:",
+                    },
+                  },
+                  {
+                    "log": {
+                      "id": "log-2",
+                      "message": "We got a \${body}",
+                    },
+                  },
+                ],
+              },
+              "when": [
+                {
+                  "simple": "\${header.myChoice} == 1",
+                  "steps": [
+                    {
+                      "log": {
+                        "id": "log-1",
+                        "message": "We got a one.",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            "to": {
+              "parameters": {
+                "bridgeErrorHandler": true,
+              },
+              "uri": "direct:my-route",
+            },
+          },
+        ],
+        "uri": "timer:tutorial",
+      },
+      "id": "route-8888",
+    },
+  },
+]
+`;

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -1,8 +1,12 @@
-import { SourceSchemaType } from './source-schema-type';
-import { CamelRouteResource } from './camel-route-resource';
+import { beansJson } from '../../stubs/beans';
+import { camelFromJson } from '../../stubs/camel-from';
 import { camelRouteJson } from '../../stubs/camel-route';
-import { createCamelResource } from './camel-resource';
 import { AddStepMode } from '../visualization/base-visual-entity';
+import { CamelRouteVisualEntity } from '../visualization/flows/camel-route-visual-entity';
+import { BeansEntity } from '../visualization/metadata/beansEntity';
+import { createCamelResource } from './camel-resource';
+import { CamelRouteResource } from './camel-route-resource';
+import { SourceSchemaType } from './source-schema-type';
 
 describe('CamelRouteResource', () => {
   it('should create CamelRouteResource', () => {
@@ -18,51 +22,173 @@ describe('CamelRouteResource', () => {
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
-});
 
-describe('getCompatibleComponents', () => {
-  it('should not provide ProducerOnly components', () => {
-    const resource = createCamelResource(camelRouteJson);
-    expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined();
+  describe('constructor', () => {
+    it.each([
+      [camelRouteJson, CamelRouteVisualEntity],
+      [camelFromJson, CamelRouteVisualEntity],
+      [{ from: { uri: 'direct:foo', steps: [] } }, CamelRouteVisualEntity],
+      [{ from: 'direct:foo' }, { from: 'direct:foo' }],
+      [{ from: { uri: 'direct:foo' } }, { from: { uri: 'direct:foo' } }],
+      [{ beans: [] }, BeansEntity],
+      [{}, {}],
+      [undefined, undefined],
+      [null, undefined],
+      [[], undefined],
+    ])('should return the appropriate entity for: %s', (json, expected) => {
+      const resource = new CamelRouteResource(json);
+      const firstEntity = resource.getVisualEntities()[0] ?? resource.getEntities()[0];
+
+      if (typeof expected === 'function') {
+        expect(firstEntity).toBeInstanceOf(expected);
+      } else {
+        expect(firstEntity).toEqual(expected);
+      }
+    });
   });
 
-  it('should not provide consumerOnly components', () => {
+  describe('addNewEntity', () => {
+    it('should add new entity and return its ID', () => {
+      const resource = new CamelRouteResource();
+      const id = resource.addNewEntity();
+
+      expect(resource.getVisualEntities()).toHaveLength(1);
+      expect(resource.getVisualEntities()[0].id).toEqual(id);
+    });
+  });
+
+  it('should return the right type', () => {
+    const resource = new CamelRouteResource();
+    expect(resource.getType()).toEqual(SourceSchemaType.Route);
+  });
+
+  it('should allow consumers to have multiple visual entities', () => {
+    const resource = new CamelRouteResource();
+    expect(resource.supportsMultipleVisualEntities()).toEqual(true);
+  });
+
+  it('should return visual entities', () => {
     const resource = new CamelRouteResource(camelRouteJson);
-    expect(
-      resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
-        path: 'from.steps.2.to',
-        processorName: 'to',
-        label: 'timer',
-      }),
-    ).toBeDefined();
+    expect(resource.getVisualEntities()).toHaveLength(1);
+    expect(resource.getVisualEntities()[0]).toBeInstanceOf(CamelRouteVisualEntity);
+    expect(resource.getEntities()).toHaveLength(0);
   });
 
-  it('scenario for InsertSpecialChild', () => {
-    const resource = createCamelResource(camelRouteJson);
-    expect(
-      resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }),
-    ).toBeDefined();
+  it('should return entities', () => {
+    const resource = new CamelRouteResource(beansJson);
+    expect(resource.getEntities()).toHaveLength(1);
+    expect(resource.getEntities()[0]).toBeInstanceOf(BeansEntity);
+    expect(resource.getVisualEntities()).toHaveLength(0);
   });
 
-  it('scenario for a new step before an existing step', () => {
-    const resource = new CamelRouteResource(camelRouteJson);
-    expect(
-      resource.getCompatibleComponents(AddStepMode.PrependStep, {
-        path: 'from.steps.0.to',
-        processorName: 'to',
-        label: 'timer',
-      }),
-    ).toBeDefined();
+  describe('toJSON', () => {
+    it('should return JSON', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+      expect(resource.toJSON()).toMatchSnapshot();
+    });
+
+    it.todo('should position the ID at the top of the JSON');
+    it.todo('should position the parameters after the ID');
   });
 
-  it('scenario for a new step after an existing step', () => {
-    const resource = new CamelRouteResource(camelRouteJson);
-    expect(
-      resource.getCompatibleComponents(AddStepMode.AppendStep, {
-        path: 'from.steps.1.to',
-        processorName: 'to',
-        label: 'timer',
-      }),
-    ).toBeDefined();
+  it('should create beans entity', () => {
+    const resource = new CamelRouteResource();
+    const beansEntity = resource.createBeansEntity();
+
+    expect(resource.getEntities()).toHaveLength(1);
+    expect(resource.getEntities()[0]).toBeInstanceOf(BeansEntity);
+    expect(resource.getEntities()[0]).toEqual(beansEntity);
+  });
+
+  it('should delete beans entity', () => {
+    const resource = new CamelRouteResource();
+    const beansEntity = resource.createBeansEntity();
+
+    resource.deleteBeansEntity(beansEntity);
+
+    expect(resource.getEntities()).toHaveLength(0);
+  });
+
+  describe('removeEntity', () => {
+    it('should not do anything if the ID is not provided', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+
+      resource.removeEntity();
+
+      expect(resource.getVisualEntities()).toHaveLength(1);
+    });
+
+    it('should not do anything when providing a non existing ID', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+
+      resource.removeEntity('non-existing-id');
+
+      expect(resource.getVisualEntities()).toHaveLength(1);
+    });
+
+    it('should allow to remove an entity', () => {
+      const resource = new CamelRouteResource([camelRouteJson, camelFromJson]);
+      const camelRouteEntity = resource.getVisualEntities()[0];
+
+      resource.removeEntity(camelRouteEntity.id);
+
+      expect(resource.getVisualEntities()).toHaveLength(1);
+    });
+
+    it('should create a new entity after deleting them all', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+      const camelRouteEntity = resource.getVisualEntities()[0];
+
+      resource.removeEntity(camelRouteEntity.id);
+
+      expect(resource.getVisualEntities()).toHaveLength(1);
+    });
+  });
+
+  describe('getCompatibleComponents', () => {
+    it('should not provide ProducerOnly components', () => {
+      const resource = createCamelResource(camelRouteJson);
+      expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined();
+    });
+
+    it('should not provide consumerOnly components', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+      expect(
+        resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
+          path: 'from.steps.2.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('scenario for InsertSpecialChild', () => {
+      const resource = createCamelResource(camelRouteJson);
+      expect(
+        resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }),
+      ).toBeDefined();
+    });
+
+    it('scenario for a new step before an existing step', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+      expect(
+        resource.getCompatibleComponents(AddStepMode.PrependStep, {
+          path: 'from.steps.0.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('scenario for a new step after an existing step', () => {
+      const resource = new CamelRouteResource(camelRouteJson);
+      expect(
+        resource.getCompatibleComponents(AddStepMode.AppendStep, {
+          path: 'from.steps.1.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -1,11 +1,12 @@
 import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
 import { JSONSchemaType } from 'ajv';
 import cloneDeep from 'lodash.clonedeep';
+import { camelFromJson } from '../../../stubs/camel-from';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { EntityType } from '../../camel/entities/base-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntity, isCamelRoute } from './camel-route-visual-entity';
 import { IVisualizationNode } from '../base-visual-entity';
+import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from './camel-route-visual-entity';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('Camel Route', () => {
   let camelEntity: CamelRouteVisualEntity;
@@ -17,13 +18,33 @@ describe('Camel Route', () => {
   describe('isCamelRoute', () => {
     it.each([
       [{ route: { from: 'direct:foo' } }, true],
+      [{ from: 'direct:foo' }, false],
+      [{ from: { uri: 'direct:foo', steps: [] } }, false],
       [camelRouteJson, true],
+      [camelFromJson, false],
       [undefined, false],
       [null, false],
       [true, false],
       [false, false],
     ])('should mark %s as isCamelRoute: %s', (route, result) => {
       expect(isCamelRoute(route)).toEqual(result);
+    });
+  });
+
+  describe('isCamelFrom', () => {
+    it.each([
+      [{ route: { from: 'direct:foo' } }, false],
+      [{ from: 'direct:foo' }, false],
+      [{ from: { uri: 'direct:foo' } }, false],
+      [{ from: { uri: 'direct:foo', steps: [] } }, true],
+      [camelRouteJson, false],
+      [camelFromJson, true],
+      [undefined, false],
+      [null, false],
+      [true, false],
+      [false, false],
+    ])('should mark %s as isCamelFrom: %s', (route, result) => {
+      expect(isCamelFrom(route)).toEqual(result);
     });
   });
 
@@ -34,7 +55,7 @@ describe('Camel Route', () => {
     });
 
     it('should use a default camel random id if the route id is not provided', () => {
-      const route = new CamelRouteVisualEntity();
+      const route = new CamelRouteVisualEntity({ from: { uri: 'direct:foo', steps: [] } });
 
       /** This is being mocked at the window.crypto.get */
       expect(route.id).toEqual('route-1234');
@@ -104,7 +125,7 @@ describe('Camel Route', () => {
 
   describe('getSteps', () => {
     it('should return an empty array if there is no route', () => {
-      const route = new CamelRouteVisualEntity();
+      const route = new CamelRouteVisualEntity({ from: {} } as RouteDefinition);
 
       expect(route.getSteps()).toEqual([]);
     });

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { DoCatch, ProcessorDefinition, RouteDefinition, When1 } from '@kaoto-next/camel-catalog/types';
+import { DoCatch, FromDefinition, ProcessorDefinition, RouteDefinition, When1 } from '@kaoto-next/camel-catalog/types';
 import get from 'lodash.get';
 import set from 'lodash.set';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
@@ -40,11 +40,25 @@ export const isCamelRoute = (rawEntity: unknown): rawEntity is { route: RouteDef
   );
 };
 
+/** Very basic check to determine whether this object is a Camel From */
+export const isCamelFrom = (rawEntity: unknown): rawEntity is { from: FromDefinition } => {
+  if (!isDefined(rawEntity) || Array.isArray(rawEntity) || typeof rawEntity !== 'object') {
+    return false;
+  }
+
+  const objectKeys = Object.keys(rawEntity!);
+  const isFromHolder = objectKeys.length === 1 && objectKeys[0] === 'from';
+  const isValidUriField = typeof (rawEntity as { from: FromDefinition })?.from?.uri === 'string';
+  const isValidStepsArray = Array.isArray((rawEntity as { from: FromDefinition })?.from?.steps);
+
+  return isFromHolder && isValidUriField && isValidStepsArray;
+};
+
 export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
   readonly id: string;
   readonly type = EntityType.Route;
 
-  constructor(public route: Partial<RouteDefinition> = {}) {
+  constructor(public route: RouteDefinition) {
     this.id = route.id ?? getCamelRandomId('route');
     this.route.id = this.id;
   }

--- a/packages/ui/src/stubs/camel-from.ts
+++ b/packages/ui/src/stubs/camel-from.ts
@@ -1,0 +1,33 @@
+import { FromDefinition } from '@kaoto-next/camel-catalog/types';
+import { CamelRouteVisualEntity } from '../models/visualization/flows';
+
+/**
+ * This is a stub Camel From in YAML format.
+ * It is used to test the Canvas component.
+ */
+export const camelFromYaml = `
+- from:
+    uri: timer:tutorial
+    steps:
+    - to:
+        uri: direct:my-route
+`;
+
+/**
+ * This is a stub Camel From in JSON format.
+ * It is used to test the Canvas component.
+ */
+export const camelFromJson: { from: FromDefinition } = {
+  from: {
+    uri: 'timer:tutorial',
+    steps: [
+      {
+        to: {
+          uri: 'direct:my-route',
+        },
+      },
+    ],
+  },
+};
+
+export const camelFrom = new CamelRouteVisualEntity({ from: camelFromJson.from });


### PR DESCRIPTION
### Changes
This commit adds support for the `from` Camel construct.

If no entity is modified, the syntax is preserved, otherwise, it gets serialized as a `route` to hold an ID.

Fixes: https://github.com/KaotoIO/kaoto-next/issues/323