### PR TITLE
fix(catalog): Avoid offering already existing single properties.

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
@@ -28,7 +28,11 @@ export const ItemInsertChildNode: FunctionComponent<ItemInsertChildNodeProps> = 
     if (!vizNode || !entitiesContext) return;
 
     /** Get compatible nodes and the location where can be introduced */
-    const compatibleNodes = entitiesContext.camelResource.getCompatibleComponents(props.mode, vizNode.data);
+    const compatibleNodes = entitiesContext.camelResource.getCompatibleComponents(
+      props.mode,
+      vizNode.data,
+      vizNode.getComponentSchema()?.definition,
+    );
 
     /** Open Catalog modal, filtering the compatible nodes */
     const definedComponent = await catalogModalContext?.getNewComponent(compatibleNodes);

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -25,7 +25,12 @@ export interface CamelResource {
   getType(): SourceSchemaType;
 
   /** Components Catalog related methods */
-  getCompatibleComponents(mode: AddStepMode, visualEntityData: IVisualizationNodeData): TileFilter | undefined;
+  getCompatibleComponents(
+    mode: AddStepMode,
+    visualEntityData: IVisualizationNodeData,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    definition?: any,
+  ): TileFilter | undefined;
 }
 
 export interface BeansAwareResource {

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -83,7 +83,12 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
   }
 
   /** Components Catalog related methods */
-  getCompatibleComponents(mode: AddStepMode, visualEntityData: CamelRouteVisualEntityData): TileFilter {
+  getCompatibleComponents(
+    mode: AddStepMode,
+    visualEntityData: CamelRouteVisualEntityData,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    definition?: any,
+  ): TileFilter {
     if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'from') {
       /**
        * For the `from` step we want to show only components which are not `producerOnly`,
@@ -102,9 +107,18 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
        * specialChildren is a map of processor names and their special children.
        */
       const specialChildren: Record<string, string[]> = {
-        choice: ['when', 'otherwise'],
-        doTry: ['doCatch', 'doFinally'],
+        choice: ['when'],
+        doTry: ['doCatch'],
       };
+
+      /** If an `otherwise` or a `doFinally` already exists, we shouldn't offer it in the catalog */
+      const definitionKeys = Object.keys(definition ?? {});
+      if (!definitionKeys.includes('otherwise')) {
+        specialChildren.choice.push('otherwise');
+      }
+      if (!definitionKeys.includes('doTry')) {
+        specialChildren.doTry.push('doTry');
+      }
 
       /**
        * For special child steps, we need to check which type of processor it is, in order to determine

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -262,6 +262,41 @@ describe('Camel Route', () => {
       expect(vizNode.data.label).toEqual('from: Unknown');
     });
 
+    it('should not create a viz node if a single-clause property is not defined', () => {
+      const vizNode = new CamelRouteVisualEntity({
+        from: { uri: 'timer', steps: [{ choice: { when: [{ steps: [{ log: { message: 'We got a one.' } }] }] } }] },
+      } as unknown as RouteDefinition).toVizNode();
+
+      /** Given a structure of
+       * from
+       *  - choice
+       *    - when
+       *      - log
+       */
+
+      /** from */
+      expect(vizNode.data.path).toEqual('from');
+      expect(vizNode.data.label).toEqual('timer');
+      /** Since this is the root node, there's no previous step */
+      expect(vizNode.getPreviousNode()).toBeUndefined();
+      expect(vizNode.getNextNode()).toBeUndefined();
+      expect(vizNode.getChildren()).toHaveLength(1);
+
+      /** choice */
+      const choiceNode = vizNode.getChildren()?.[0] as IVisualizationNode;
+      expect(choiceNode.data.path).toEqual('from.steps.0.choice');
+      expect(choiceNode.data.label).toEqual('choice');
+      expect(choiceNode.getPreviousNode()).toBeUndefined();
+      expect(choiceNode.getNextNode()).toBeUndefined();
+      expect(choiceNode.getChildren()).toHaveLength(1);
+
+      /** choice.when */
+      const whenNode = choiceNode.getChildren()?.[0];
+      expect(whenNode).toBeDefined();
+      expect(whenNode!.data.path).toEqual('from.steps.0.choice.when.0');
+      expect(whenNode!.data.label).toEqual('when');
+    });
+
     it('should populate the viz node chain with the steps', () => {
       const vizNode = camelEntity.toVizNode();
 

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -308,6 +308,10 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
       case 'single-clause':
         const childPath = `${path}.${stepsProperty.name}`;
         const childComponentLookup = CamelComponentSchemaService.getCamelComponentLookup(childPath, this.route);
+
+        /** If the single-clause property is not defined, we don't create a IVisualizationNode for it */
+        if (get(this.route, childPath) === undefined) return [];
+
         return [this.getVizNodeFromProcessor(childPath, childComponentLookup)];
 
       case 'clause-list':


### PR DESCRIPTION
### Context
For some Processors like `Choice` and `DoTry`, there are properties that could contain nested processors. In case of `Choice`, it's the `otherwise` property.

### Changes
This pull request checks what's already defined in the `Processor` to avoid offering it again since it might cause data loss.

### Screencast
[Screencast from 2023-11-22 15-22-23.webm](https://github.com/KaotoIO/kaoto-next/assets/16512618/b19d38a6-63d1-44d7-aec8-771a6cead46e)

Fixes: https://github.com/KaotoIO/kaoto-next/issues/334

