### PR TITLE
fix(catalog): Avoid adding a doFinally when already exists

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -116,8 +116,8 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
       if (!definitionKeys.includes('otherwise')) {
         specialChildren.choice.push('otherwise');
       }
-      if (!definitionKeys.includes('doTry')) {
-        specialChildren.doTry.push('doTry');
+      if (!definitionKeys.includes('doFinally')) {
+        specialChildren.doTry.push('doFinally');
       }
 
       /**


### PR DESCRIPTION
Follow up of: https://github.com/KaotoIO/kaoto-next/pull/398#discussion_r1402249390

Fixes: https://github.com/KaotoIO/kaoto-next/issues/334

Thanks once again @tplevko for catching this up.