### PR TITLE
fix(viz): Add support for processor's string definition

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -460,3 +460,137 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should not build a
   "title": "to",
 }
 `;
+
+exports[`CamelComponentSchemaService getVisualComponentSchema should transform a string-based \`Log\` processor 1`] = `
+{
+  "definition": {
+    "message": "\${body}",
+  },
+  "schema": {
+    "properties": {
+      "description": {
+        "deprecated": false,
+        "description": "Sets the description of this node",
+        "title": "Description",
+        "type": "string",
+      },
+      "disabled": {
+        "deprecated": false,
+        "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
+        "title": "Disabled",
+        "type": "boolean",
+      },
+      "id": {
+        "deprecated": false,
+        "description": "Sets the id of this node",
+        "title": "Id",
+        "type": "string",
+      },
+      "logName": {
+        "deprecated": false,
+        "description": "Sets the name of the logger",
+        "title": "Log Name",
+        "type": "string",
+      },
+      "logger": {
+        "deprecated": false,
+        "description": "To refer to a custom logger instance to lookup from the registry.",
+        "title": "Logger",
+        "type": "object",
+      },
+      "loggingLevel": {
+        "deprecated": false,
+        "description": "Sets the logging level. The default value is INFO",
+        "enum": [
+          "TRACE",
+          "DEBUG",
+          "INFO",
+          "WARN",
+          "ERROR",
+          "OFF",
+        ],
+        "title": "Logging Level",
+        "type": undefined,
+      },
+      "marker": {
+        "deprecated": false,
+        "description": "To use slf4j marker",
+        "title": "Marker",
+        "type": "string",
+      },
+      "message": {
+        "deprecated": false,
+        "description": "Sets the log message (uses simple language)",
+        "title": "Message",
+        "type": "string",
+      },
+    },
+    "required": [
+      "message",
+    ],
+    "type": "object",
+  },
+  "title": "log",
+}
+`;
+
+exports[`CamelComponentSchemaService getVisualComponentSchema should transform a string-based \`To\` processor 1`] = `
+{
+  "definition": {
+    "uri": "bean:myBean?method=hello",
+  },
+  "schema": {
+    "properties": {
+      "description": {
+        "deprecated": false,
+        "description": "Sets the description of this node",
+        "title": "Description",
+        "type": "string",
+      },
+      "disabled": {
+        "deprecated": false,
+        "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
+        "title": "Disabled",
+        "type": "boolean",
+      },
+      "id": {
+        "deprecated": false,
+        "description": "Sets the id of this node",
+        "title": "Id",
+        "type": "string",
+      },
+      "pattern": {
+        "deprecated": false,
+        "description": "Sets the optional ExchangePattern used to invoke this endpoint",
+        "enum": [
+          "InOnly",
+          "InOut",
+        ],
+        "title": "Pattern",
+        "type": undefined,
+      },
+      "uri": {
+        "deprecated": false,
+        "description": "Sets the uri of the endpoint to send to.",
+        "title": "Uri",
+        "type": "string",
+      },
+    },
+    "required": [
+      "uri",
+    ],
+    "type": "object",
+  },
+  "title": "to",
+}
+`;
+
+exports[`CamelComponentSchemaService getVisualComponentSchema should transform a string-based \`ToD\` processor 1`] = `
+{
+  "definition": {
+    "uri": "bean:myBean?method=hello",
+  },
+  "schema": {},
+  "title": "toD",
+}
+`;

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -82,6 +82,33 @@ describe('CamelComponentSchemaService', () => {
       expect(result).toMatchSnapshot();
     });
 
+    it('should transform a string-based `To` processor', () => {
+      const toBeanPath = 'from.steps.0.to';
+      const toBeanDefinition = 'bean:myBean?method=hello';
+
+      const result = CamelComponentSchemaService.getVisualComponentSchema(toBeanPath, toBeanDefinition);
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should transform a string-based `ToD` processor', () => {
+      const toDBeanPath = 'from.steps.0.toD';
+      const toDBeanDefinition = 'bean:myBean?method=hello';
+
+      const result = CamelComponentSchemaService.getVisualComponentSchema(toDBeanPath, toDBeanDefinition);
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should transform a string-based `Log` processor', () => {
+      const logPath = 'from.steps.0.log';
+      const logDefinition = '${body}';
+
+      const result = CamelComponentSchemaService.getVisualComponentSchema(logPath, logDefinition);
+
+      expect(result).toMatchSnapshot();
+    });
+
     it('should not build a schema for an unknown component', () => {
       const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
       const toNonExistingPath = 'from.steps.0.to';

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -15,11 +15,12 @@ export class CamelComponentSchemaService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static getVisualComponentSchema(path: string, definition: any): VisualComponentSchema | undefined {
     const camelElementLookup = this.getCamelComponentLookup(path, definition);
+    const updatedDefinition = this.getUpdatedDefinition(camelElementLookup, definition);
 
     return {
       title: camelElementLookup.processorName,
       schema: this.getSchema(camelElementLookup),
-      definition,
+      definition: updatedDefinition,
     };
   }
 
@@ -273,5 +274,24 @@ export class CamelComponentSchemaService {
     });
 
     return schema;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static getUpdatedDefinition(camelElementLookup: ICamelElementLookupResult, definition: any) {
+    switch (camelElementLookup.processorName) {
+      case 'to':
+      case 'toD':
+        if (typeof definition === 'string') {
+          return { uri: definition };
+        }
+        break;
+
+      case 'log':
+        if (typeof definition === 'string') {
+          return { message: definition };
+        }
+        break;
+    }
+    return definition;
   }
 }


### PR DESCRIPTION
Currently, expressions like the following, are not supported:

```yaml
- route:
    id: "foo"
    from:
      uri: "quartz:foo?cron={{myCron}}"
      steps:
        - to: "bean:myBean?method=hello"
        - log: "${body}"
```

This commit adds support for string-based processors by transforming them into regular objects when edited.

```yaml
- route:
    id: "foo"
    from:
      uri: "quartz:foo?cron={{myCron}}"
      steps:
        - to:
            uri: "bean:myBean?method=hello"
        - log: 
            message: "${body}"
```

Fixes: https://github.com/KaotoIO/kaoto-next/issues/332