### PR TITLE
chore(catalog): Load both full and filtered Camel Catalog

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelCatalogProcessor.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelCatalogProcessor.java
@@ -44,7 +44,7 @@ public class CamelCatalogProcessor {
         this.api = new DefaultCamelCatalog();
         this.schemaProcessor = schemaProcessor;
         patternBlocklist = new ArrayList<>();
-        populatePatterBlocklist();
+        populatePatternBlocklist();
     }
 
     /**
@@ -170,9 +170,7 @@ public class CamelCatalogProcessor {
         return JsonMapper.serialize(answer);
     }
 
-    private void populatePatterBlocklist() {
-        this.patternBlocklist.add("doCatch");
-        this.patternBlocklist.add("doFinally");
+    private void populatePatternBlocklist() {
         this.patternBlocklist.add("kamelet");
         this.patternBlocklist.add("loadBalance");
         this.patternBlocklist.add("onFallback");
@@ -183,7 +181,9 @@ public class CamelCatalogProcessor {
         this.patternBlocklist.add("setExchangePattern");
         this.patternBlocklist.add("whenSkipSendToEndpoint");
         // reactivate entries once we have a better handling of how to add WHEN and OTHERWISE without Catalog
-        //this.patternBlocklist.add("Otherwise");
-        //this.patternBlocklist.add("when");
+        // this.patternBlocklist.add("Otherwise");
+        // this.patternBlocklist.add("when");
+        // this.patternBlocklist.add("doCatch");
+        // this.patternBlocklist.add("doFinally");
     }
 }

--- a/packages/ui/src/components/IconResolver/IconResolver.test.tsx
+++ b/packages/ui/src/components/IconResolver/IconResolver.test.tsx
@@ -23,18 +23,11 @@ describe('IconResolver', () => {
     const kameletTile = {
       ...mockTile,
       type: CatalogKind.Kamelet,
-      rawObject: {
-        metadata: {
-          annotations: {
-            'camel.apache.org/kamelet.icon': 'kamelet-icon.svg',
-          },
-        },
-      },
+      rawObject: {},
     };
 
     const { container } = render(<IconResolver tile={kameletTile} />);
 
     expect(container.querySelector('img')).toHaveAttribute('alt', 'kamelet icon');
-    expect(container.querySelector('img')).toHaveAttribute('src', 'kamelet-icon.svg');
   });
 });

--- a/packages/ui/src/components/IconResolver/IconResolver.tsx
+++ b/packages/ui/src/components/IconResolver/IconResolver.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { CatalogKind, IKameletDefinition } from '../../models';
-import { ITile } from '../Catalog/Catalog.models';
+import { CatalogKind } from '../../models';
 import { NodeIconResolver } from '../../utils/node-icon-resolver';
+import { ITile } from '../Catalog/Catalog.models';
 
 interface IconResolverProps {
   className?: string;
@@ -14,7 +14,7 @@ export const IconResolver: FunctionComponent<PropsWithChildren<IconResolverProps
       return (
         <img
           className={props.className}
-          src={(props.tile.rawObject as IKameletDefinition).metadata.annotations['camel.apache.org/kamelet.icon']}
+          src={NodeIconResolver.getIcon(`kamelet:${props.tile.name}`)}
           alt="kamelet icon"
         />
       );

--- a/packages/ui/src/models/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel-catalog-index.ts
@@ -45,6 +45,7 @@ export type DefinedComponent = {
 export interface ComponentsCatalog {
   [CatalogKind.Component]?: Record<string, ICamelComponentDefinition>;
   [CatalogKind.Processor]?: Record<string, ICamelProcessorDefinition>;
+  [CatalogKind.Pattern]?: Record<string, ICamelProcessorDefinition>;
   [CatalogKind.Language]?: Record<string, ICamelLanguageDefinition>;
   [CatalogKind.Dataformat]?: Record<string, ICamelDataformatDefinition>;
   [CatalogKind.Kamelet]?: Record<string, IKameletDefinition>;

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -1,6 +1,7 @@
 export const enum CatalogKind {
   Component = 'component',
   Processor = 'model',
+  Pattern = 'pattern',
   Language = 'language',
   Dataformat = 'dataformat',
   Kamelet = 'kamelet',

--- a/packages/ui/src/providers/catalog-tiles.provider.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.tsx
@@ -19,7 +19,13 @@ export const CatalogTilesProvider: FunctionComponent<PropsWithChildren> = (props
     Object.values(catalogService.getCatalogByKey(CatalogKind.Component) ?? {}).forEach((component) => {
       combinedTiles.push(camelComponentToTile(component));
     });
-    Object.values(catalogService.getCatalogByKey(CatalogKind.Processor) ?? {}).forEach((processor) => {
+    /**
+     * To build the Patterns catalog, we use the short list, as opposed of the CatalogKind.Processor which have all definitions
+     * This is because the short list contains only the patterns that can be used within an integration.
+     *
+     * The full list of patterns is available in the CatalogKind.Processor catalog and it's being used as lookup for components properties.
+     */
+    Object.values(catalogService.getCatalogByKey(CatalogKind.Pattern) ?? {}).forEach((processor) => {
       combinedTiles.push(camelProcessorToTile(processor));
     });
     Object.values(catalogService.getCatalogByKey(CatalogKind.Kamelet) ?? {}).forEach((kamelet) => {

--- a/packages/ui/src/providers/catalog.provider.tsx
+++ b/packages/ui/src/providers/catalog.provider.tsx
@@ -17,32 +17,44 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
     fetch(`${props.catalogUrl}/index.json`)
       .then((response) => response.json())
       .then(async (catalogIndex: CamelCatalogIndex) => {
+        /** Camel Component list */
         const camelComponentsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Component]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.components.file}`,
         );
-        const camelProcessorsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Processor]>(
+        /** Full list of Camel Models, used as lookup for processors definitions definitions */
+        const camelModelsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Processor]>(
+          `${props.catalogUrl}/${catalogIndex.catalogs.models.file}`,
+        );
+        /** Short list of patterns (EIPs) to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
+        const camelPatternsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Pattern]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.patterns.file}`,
         );
+        /** Camel Languages list */
         const camelLanguagesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Language]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.languages.file}`,
         );
+        /** Camel Dataformats list */
         const camelDataformatsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Dataformat]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.dataformats.file}`,
         );
+        /** Camel Kamelets definitions list (CRDs) */
         const kameletsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.kamelets.file}`,
         );
 
-        const [camelComponents, camelProcessors, camelLanguages, camelDataformats, kamelets] = await Promise.all([
-          camelComponentsFiles,
-          camelProcessorsFiles,
-          camelLanguagesFiles,
-          camelDataformatsFiles,
-          kameletsFiles,
-        ]);
+        const [camelComponents, camelModels, camelPatterns, camelLanguages, camelDataformats, kamelets] =
+          await Promise.all([
+            camelComponentsFiles,
+            camelModelsFiles,
+            camelPatternsFiles,
+            camelLanguagesFiles,
+            camelDataformatsFiles,
+            kameletsFiles,
+          ]);
 
         CamelCatalogService.setCatalogKey(CatalogKind.Component, camelComponents.body);
-        CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelProcessors.body);
+        CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelModels.body);
+        CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatterns.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, kamelets.body);


### PR DESCRIPTION
### Context
Currently, we're loading the short version of the Camel Models Catalog to not only populate the UI catalog but also as a lookup registry when building the Configuration Form.

This is not ideal since having fewer elements in the catalog also means fewer available definitions, rendering some processors not configurable.

### Changes
This pull request loads both catalogs and uses the short list to build the UI Catalog and the full one for the lookup.

### Notes
This pull request is a follow up of https://github.com/KaotoIO/kaoto-next/pull/404