### PR TITLE
fix(canvas): Replace nodes that contains a single steps property don't work

### DIFF
--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -126,17 +126,6 @@ export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
       return;
     }
 
-    /**
-     * If the current node contains a single property of type list, it means the target has a single
-     * property to place the new node in, therefore we add the new one at the beginning of the array
-     */
-    if (stepsProperties.length === 1 && stepsProperties[0].type === 'branch') {
-      const stepsArray = getArrayProperty(this.route, `${options.data.path}.${stepsProperties[0].name}`);
-      stepsArray.unshift(defaultValue);
-
-      return;
-    }
-
     const pathArray = options.data.path.split('.');
     const last = pathArray[pathArray.length - 1];
     const penultimate = pathArray[pathArray.length - 2];


### PR DESCRIPTION
### Context
Currently, there's a piece of logic that checks if the node meant to be replaced has a single `step` property that can have children. This logic was causing that for some special nodes, like `doCatch`, the replace step functionality didn't work, and the intended replacement step gets appended instead.

### Changes
The fix is to remove said functionality as it was already implemented in a different manner.

### Notes
There are more changes to make, as an example, `doCatch` and `doFinally` shouldn't be offered as valid EIP if they are not inside of a `doTry`. Another topic is that special children shouldn't be replaced, for instance, `when`, `otherwise`, `doCatch` and `doFinally`.

Fixes: https://github.com/KaotoIO/kaoto-next/issues/370