### PR TITLE
Use Java 21 instead of Java 17

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # Install dependencies
       - run: yarn

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
       - name: Install dependencies

--- a/.github/workflows/create-pre-release-pr.yml
+++ b/.github/workflows/create-pre-release-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🔧 Install dependencies
         run:  yarn

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🛰️ Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # Install dependencies
       - run: yarn install --immutable
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v3
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v3
@@ -194,7 +194,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v3

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: 🔧 Install dependencies
         run: yarn

--- a/packages/camel-catalog/pom.xml
+++ b/packages/camel-catalog/pom.xml
@@ -44,7 +44,7 @@
     <version.camel-k-crds>2.1.0</version.camel-k-crds>
     <version.camel-kamelets>4.2.0</version.camel-kamelets>
     <version.jackson>2.16.0</version.jackson>
-    <version.java>17</version.java>
+    <version.java>21</version.java>
     <version.junit>5.10.1</version.junit>
     <version.kubernetes-model>6.9.2</version.kubernetes-model>
     <version.maven-antrun-plugin>3.1.0</version.maven-antrun-plugin>
@@ -142,8 +142,7 @@
           <version>${version.maven-compiler-plugin}</version>
           <configuration>
             <encoding>${project.build.sourceEncoding}</encoding>
-            <source>${version.java}</source>
-            <target>${version.java}</target>
+            <release>${version.java}</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Java 21 is the latest LTS
Java is used internally so we can upgrade without external impact. it will allow easier maintenance and more power.