### PR TITLE
feat(kamelet): Add Flow support for Kamelets

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
@@ -1,13 +1,17 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { FlowTypeSelector } from './FlowTypeSelector';
-import { EntitiesContext } from '../../../../providers/entities.provider';
-import { sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
-import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
-import { Schema } from '../../../../models';
 import { EntitiesContextResult } from '../../../../hooks';
+import { Schema } from '../../../../models';
+import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
+import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
+import { EntitiesContext } from '../../../../providers/entities.provider';
+import { FlowTypeSelector } from './FlowTypeSelector';
 
 const config = sourceSchemaConfig;
 config.config[SourceSchemaType.Pipe].schema = { name: 'Pipe', schema: { name: 'Pipe', description: 'desc' } } as Schema;
+config.config[SourceSchemaType.Kamelet].schema = {
+  name: 'Kamelet',
+  schema: { name: 'Kamelet', description: 'desc' },
+} as Schema;
 config.config[SourceSchemaType.Route].schema = {
   name: 'route',
   schema: { name: 'route', description: 'desc' },

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
@@ -98,6 +98,7 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
       <SelectList>
         {Object.entries({
           [SourceSchemaType.Route]: sourceSchemaConfig.config[SourceSchemaType.Route],
+          [SourceSchemaType.Kamelet]: sourceSchemaConfig.config[SourceSchemaType.Kamelet],
           [SourceSchemaType.Pipe]: sourceSchemaConfig.config[SourceSchemaType.Pipe],
         }).map((obj, index) => {
           const sourceType = obj[0] as SourceSchemaType;

--- a/packages/ui/src/models/camel/__snapshots__/camel-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/camel-resource.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createCamelResource should create an empty KameletResource if no args is specified 1`] = `
+[
+  {
+    "route": {
+      "from": {
+        "id": "from-1234",
+        "steps": [],
+        "uri": "kamelet:source",
+      },
+      "id": "kamelet-1234",
+    },
+  },
+]
+`;

--- a/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KameletResource should convert to JSON 1`] = `
+{
+  "apiVersion": "camel.apache.org/v1",
+  "kind": "Kamelet",
+  "spec": {
+    "definition": {
+      "title": "kamelet-1234",
+      "type": "source",
+    },
+    "dependencies": [],
+    "template": {
+      "beans": {},
+      "from": {
+        "id": "from-1234",
+        "steps": [],
+        "uri": "kamelet:source",
+      },
+    },
+  },
+}
+`;
+
+exports[`KameletResource should create a new KameletResource 1`] = `
+{
+  "apiVersion": "camel.apache.org/v1",
+  "kind": "Kamelet",
+  "spec": {
+    "definition": {
+      "title": "kamelet-1234",
+      "type": "source",
+    },
+    "dependencies": [],
+    "template": {
+      "beans": {},
+      "from": {
+        "id": "from-1234",
+        "steps": [],
+        "uri": "kamelet:source",
+      },
+    },
+  },
+}
+`;
+
+exports[`KameletResource should create a new KameletResource with a kamelet 1`] = `
+{
+  "kind": "Kamelet",
+  "metadata": {
+    "annotations": {
+      "camel.apache.org/catalog.version": "",
+      "camel.apache.org/kamelet.group": "",
+      "camel.apache.org/kamelet.icon": "",
+      "camel.apache.org/kamelet.namespace": "",
+      "camel.apache.org/kamelet.support.level": "",
+      "camel.apache.org/provider": "",
+    },
+    "labels": {
+      "camel.apache.org/kamelet.type": "",
+    },
+    "name": "kamelet",
+  },
+  "spec": {
+    "definition": {
+      "title": "kamelet",
+      "type": "source",
+    },
+    "dependencies": [],
+    "template": {
+      "beans": {},
+      "from": {
+        "id": "from",
+        "steps": [],
+        "uri": "kamelet:source",
+      },
+    },
+  },
+}
+`;
+
+exports[`KameletResource should get the visual entities (Camel Route Visual Entity) 1`] = `
+[
+  {
+    "route": {
+      "from": {
+        "id": "from-1234",
+        "steps": [],
+        "uri": "kamelet:source",
+      },
+      "id": "kamelet-1234",
+    },
+  },
+]
+`;

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -1,17 +1,17 @@
 import {
   Integration as IntegrationType,
   KameletBinding as KameletBindingType,
-  Kamelet as KameletType,
   Pipe as PipeType,
 } from '@kaoto-next/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
+import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { MetadataEntity } from '../visualization/metadata';
 import { CamelResource } from './camel-resource';
 import { BaseCamelEntity } from './entities';
 import { SourceSchemaType } from './source-schema-type';
 
-export type CamelKType = IntegrationType | KameletType | KameletBindingType | PipeType;
+export type CamelKType = IntegrationType | IKameletDefinition | KameletBindingType | PipeType;
 
 export enum CamelKResourceKinds {
   Integration = 'Integration',
@@ -35,13 +35,13 @@ export abstract class CamelKResource implements CamelResource {
         spec: {},
       };
     }
-    this.metadata = this.resource.metadata && new MetadataEntity(this.resource!);
+    this.metadata = this.resource.metadata && new MetadataEntity(this.resource);
   }
 
   removeEntity(_id?: string) {}
   createMetadataEntity() {
     this.resource.metadata = {};
-    this.metadata = new MetadataEntity(this.resource!);
+    this.metadata = new MetadataEntity(this.resource);
     return this.metadata;
   }
 
@@ -66,12 +66,16 @@ export abstract class CamelKResource implements CamelResource {
 
   abstract getVisualEntities(): BaseVisualCamelEntity[];
 
-  abstract supportsMultipleVisualEntities(): boolean;
-
   abstract toJSON(): unknown;
 
   addNewEntity(): string {
+    /** Not supported by default */
     return '';
+  }
+
+  supportsMultipleVisualEntities(): boolean {
+    /** Not supported by default */
+    return false;
   }
 
   /** Components Catalog related methods */

--- a/packages/ui/src/models/camel/camel-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-resource.test.ts
@@ -29,11 +29,11 @@ describe('createCamelResource', () => {
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty CamelRouteResource if no args is specified', () => {
+  it('should create an empty KameletResource if no args is specified', () => {
     const resource = createCamelResource(undefined, SourceSchemaType.Kamelet);
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     expect(resource.getEntities()).toEqual([]);
-    expect(resource.getVisualEntities()).toEqual([]);
+    expect(resource.getVisualEntities()).toMatchSnapshot();
   });
 
   it('should create an empty CameletBindingResource if no args is specified', () => {

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -1,10 +1,10 @@
 import {
   Integration as IntegrationType,
   KameletBinding as KameletBindingType,
-  Kamelet as KameletType,
   Pipe as PipeType,
 } from '@kaoto-next/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
+import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { BeansEntity } from '../visualization/metadata';
 import { CamelRouteResource } from './camel-route-resource';
@@ -60,7 +60,7 @@ function doCreateCamelResource(json?: unknown, type?: SourceSchemaType): CamelRe
     case SourceSchemaType.Integration:
       return new IntegrationResource(json as IntegrationType);
     case SourceSchemaType.Kamelet:
-      return new KameletResource(json as KameletType);
+      return new KameletResource(json as IKameletDefinition);
     case SourceSchemaType.KameletBinding:
       return new KameletBindingResource(json as KameletBindingType);
     case SourceSchemaType.Pipe:

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -3,6 +3,7 @@ import { camelFromJson } from '../../stubs/camel-from';
 import { camelRouteJson } from '../../stubs/camel-route';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity } from '../visualization/flows/camel-route-visual-entity';
+import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
 import { BeansEntity } from '../visualization/metadata/beansEntity';
 import { createCamelResource } from './camel-resource';
 import { CamelRouteResource } from './camel-route-resource';
@@ -146,49 +147,13 @@ describe('CamelRouteResource', () => {
   });
 
   describe('getCompatibleComponents', () => {
-    it('should not provide ProducerOnly components', () => {
+    it('should delegate to the CamelComponentFilterService', () => {
+      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getCompatibleComponents');
+
       const resource = createCamelResource(camelRouteJson);
-      expect(resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' })).toBeDefined();
-    });
+      resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' });
 
-    it('should not provide consumerOnly components', () => {
-      const resource = new CamelRouteResource(camelRouteJson);
-      expect(
-        resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
-          path: 'from.steps.2.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
-    });
-
-    it('scenario for InsertSpecialChild', () => {
-      const resource = createCamelResource(camelRouteJson);
-      expect(
-        resource.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, { path: 'from', label: 'timer' }),
-      ).toBeDefined();
-    });
-
-    it('scenario for a new step before an existing step', () => {
-      const resource = new CamelRouteResource(camelRouteJson);
-      expect(
-        resource.getCompatibleComponents(AddStepMode.PrependStep, {
-          path: 'from.steps.0.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
-    });
-
-    it('scenario for a new step after an existing step', () => {
-      const resource = new CamelRouteResource(camelRouteJson);
-      expect(
-        resource.getCompatibleComponents(AddStepMode.AppendStep, {
-          path: 'from.steps.1.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
+      expect(filterSpy).toHaveBeenCalledWith(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' }, undefined);
     });
   });
 });

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -1,10 +1,10 @@
 import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
-import { ITile, TileFilter } from '../../components/Catalog';
+import { TileFilter } from '../../components/Catalog';
 import { isDefined } from '../../utils';
-import { CatalogKind } from '../catalog-kind';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from '../visualization/flows';
 import { flowTemplateService } from '../visualization/flows/flow-templates-service';
+import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
 import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
 import { BeansEntity, isBeans } from '../visualization/metadata';
 import { BeansAwareResource, CamelResource } from './camel-resource';
@@ -89,60 +89,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {
-    if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'from') {
-      /**
-       * For the `from` step we want to show only components which are not `producerOnly`,
-       * as this mean that they can be used only as a consumer.
-       */
-      return (item: ITile) => {
-        return (
-          (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) ||
-          (item.type === CatalogKind.Kamelet && item.tags.includes('source'))
-        );
-      };
-    }
-
-    if (mode === AddStepMode.InsertSpecialChildStep) {
-      /**
-       * specialChildren is a map of processor names and their special children.
-       */
-      const specialChildren: Record<string, string[]> = {
-        choice: ['when'],
-        doTry: ['doCatch'],
-      };
-
-      /** If an `otherwise` or a `doFinally` already exists, we shouldn't offer it in the catalog */
-      const definitionKeys = Object.keys(definition ?? {});
-      if (!definitionKeys.includes('otherwise')) {
-        specialChildren.choice.push('otherwise');
-      }
-      if (!definitionKeys.includes('doFinally')) {
-        specialChildren.doTry.push('doFinally');
-      }
-
-      /**
-       * For special child steps, we need to check which type of processor it is, in order to determine
-       * what kind of components we want to show.
-       */
-      return (item: ITile) => {
-        if (item.type !== CatalogKind.Processor || specialChildren[visualEntityData.processorName] === undefined) {
-          return false;
-        }
-
-        return specialChildren[visualEntityData.processorName].includes(item.name);
-      };
-    }
-
-    /**
-     * For the rest, we want to filter out components that are `consumerOnly`,
-     * as this mean that they can be used only as a consumer.
-     */
-    return (item: ITile) => {
-      return (
-        (item.type !== CatalogKind.Kamelet && !item.tags.includes('consumerOnly')) ||
-        (item.type === CatalogKind.Kamelet && !item.tags.includes('source'))
-      );
-    };
+    return CamelComponentFilterService.getCompatibleComponents(mode, visualEntityData, definition);
   }
 
   private getEntity(rawItem: unknown): BaseCamelEntity | undefined {

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -1,0 +1,88 @@
+import { kameletJson } from '../../stubs/kamelet';
+import { AddStepMode } from '../visualization/base-visual-entity';
+import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
+import { createCamelResource } from './camel-resource';
+import { KameletResource } from './kamelet-resource';
+import { SourceSchemaType } from './source-schema-type';
+
+describe('KameletResource', () => {
+  it('should create a new KameletResource', () => {
+    const kameletResource = new KameletResource();
+    expect(kameletResource).toMatchSnapshot();
+  });
+
+  it('should create a new KameletResource with a kamelet', () => {
+    const kameletResource = new KameletResource({
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        name: 'kamelet',
+        annotations: {
+          'camel.apache.org/kamelet.support.level': '',
+          'camel.apache.org/catalog.version': '',
+          'camel.apache.org/kamelet.icon': '',
+          'camel.apache.org/provider': '',
+          'camel.apache.org/kamelet.group': '',
+          'camel.apache.org/kamelet.namespace': '',
+        },
+        labels: {
+          'camel.apache.org/kamelet.type': '',
+        },
+      },
+      spec: {
+        definition: {
+          title: 'kamelet',
+          type: 'source',
+        },
+        dependencies: [],
+        template: {
+          from: {
+            id: 'from',
+            uri: 'kamelet:source',
+            steps: [],
+          },
+          beans: {},
+        },
+      },
+    });
+
+    expect(kameletResource).toMatchSnapshot();
+  });
+
+  it('should remove the entity', () => {
+    const kameletResource = new KameletResource();
+    const previousKameletId = kameletResource.getVisualEntities()[0].id;
+
+    kameletResource.removeEntity();
+
+    const kameletVisualEntities = kameletResource.getVisualEntities();
+
+    expect(kameletVisualEntities).toHaveLength(1);
+    expect(kameletVisualEntities[0].route.id).not.toEqual(previousKameletId);
+  });
+
+  it('should get the type', () => {
+    const kameletResource = new KameletResource();
+    expect(kameletResource.getType()).toEqual(SourceSchemaType.Kamelet);
+  });
+
+  it('should get the visual entities (Camel Route Visual Entity)', () => {
+    const kameletResource = new KameletResource();
+    expect(kameletResource.getVisualEntities()).toMatchSnapshot();
+  });
+
+  it('should convert to JSON', () => {
+    const kameletResource = new KameletResource();
+    expect(kameletResource.toJSON()).toMatchSnapshot();
+  });
+
+  describe('getCompatibleComponents', () => {
+    it('should delegate to the CamelComponentFilterService', () => {
+      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getCompatibleComponents');
+
+      const resource = createCamelResource(kameletJson);
+      resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' });
+
+      expect(filterSpy).toHaveBeenCalledWith(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' }, undefined);
+    });
+  });
+});

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -1,45 +1,83 @@
-import { BaseCamelEntity } from './entities';
-import { BaseVisualCamelEntity } from '../visualization/base-visual-entity';
-import { Kamelet as KameletType } from '@kaoto-next/camel-catalog/types';
-import { SourceSchemaType } from './source-schema-type';
+import { getCamelRandomId } from '../../camel-utils/camel-random-id';
+import { TileFilter } from '../../components/Catalog/Catalog.models';
+import { IKameletDefinition } from '../kamelets-catalog';
+import { AddStepMode } from '../visualization/base-visual-entity';
+import { CamelRouteVisualEntity } from '../visualization/flows/camel-route-visual-entity';
+import { flowTemplateService } from '../visualization/flows/flow-templates-service';
+import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
+import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
 import { CamelKResource } from './camel-k-resource';
+import { SourceSchemaType } from './source-schema-type';
 
 export class KameletResource extends CamelKResource {
   private kamelet;
+  private flow: CamelRouteVisualEntity;
 
-  constructor(kamelet?: KameletType) {
+  constructor(kamelet?: IKameletDefinition) {
+    const kameletId = getCamelRandomId('kamelet');
     super(kamelet);
+
     if (kamelet) {
       this.kamelet = kamelet;
     } else {
-      this.kamelet = this.resource as KameletType;
+      this.kamelet = this.resource as IKameletDefinition;
       this.kamelet.kind = SourceSchemaType.Kamelet;
-      return;
+      this.kamelet.spec = {
+        definition: {
+          title: kameletId,
+          type: 'source',
+        },
+        dependencies: [],
+        template: {
+          from: {
+            id: getCamelRandomId('from'),
+            uri: 'kamelet:source',
+            steps: [],
+          },
+          beans: {},
+        },
+      };
     }
+
+    this.flow = new CamelRouteVisualEntity({ id: kameletId, from: this.kamelet.spec.template.from });
   }
 
-  getEntities(): BaseCamelEntity[] {
-    return super.getEntities(); // TODO
+  removeEntity(): void {
+    super.removeEntity();
+    const flowTemplate: IKameletDefinition = flowTemplateService.getFlowTemplate(this.getType());
+    this.kamelet.spec = flowTemplate.spec;
+    this.flow = new CamelRouteVisualEntity({ from: flowTemplate.spec.template.from });
   }
 
   getType(): SourceSchemaType {
     return SourceSchemaType.Kamelet;
   }
 
-  getVisualEntities(): BaseVisualCamelEntity[] {
-    return []; // TODO
+  getVisualEntities(): CamelRouteVisualEntity[] {
+    /** A kamelet always have a single flow defined, even if is empty */
+    return [this.flow];
   }
 
-  supportsMultipleVisualEntities(): boolean {
-    return false;
-  }
-
-  toJSON(): KameletType {
+  toJSON(): IKameletDefinition {
+    /**
+     * The underlying CamelRouteVisualEntity has a root route property which holds
+     * the route definition. Inside of this property, there's a `from` property which
+     * holds the kamelet definition.
+     *
+     * The `from` kamelet property is a reference to the underlying CamelRouteVisualEntity
+     * and this way the kamelet definition is updated when the user interacts with
+     * the CamelRouteVisualEntity.
+     */
     return this.kamelet;
   }
 
-  addNewEntity(): string {
-    //TODO
-    return '';
+  /** Components Catalog related methods */
+  getCompatibleComponents(
+    mode: AddStepMode,
+    visualEntityData: CamelRouteVisualEntityData,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    definition?: any,
+  ): TileFilter {
+    return CamelComponentFilterService.getCompatibleComponents(mode, visualEntityData, definition);
   }
 }

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -30,9 +30,9 @@ export class PipeResource extends CamelKResource {
       this.pipe.spec.errorHandler && new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler);
   }
 
-  removeEntity(_id?: string): void {
+  removeEntity(): void {
     super.removeEntity();
-    const flowTemplate = flowTemplateService.getFlowTemplate(this.getType())!;
+    const flowTemplate: PipeType = flowTemplateService.getFlowTemplate(this.getType());
     this.pipe.spec = flowTemplate.spec;
     this.flow = new PipeVisualEntity(flowTemplate.spec);
   }
@@ -53,10 +53,6 @@ export class PipeResource extends CamelKResource {
     return this.flow ? [this.flow] : [];
   }
 
-  supportsMultipleVisualEntities(): boolean {
-    return false;
-  }
-
   toJSON(): PipeType {
     return this.pipe;
   }
@@ -74,11 +70,6 @@ export class PipeResource extends CamelKResource {
   deleteErrorHandlerEntity() {
     this.pipe.spec!.errorHandler = undefined;
     this.errorHandler = undefined;
-  }
-
-  addNewEntity(): string {
-    //not supported
-    return '';
   }
 
   /** Components Catalog related methods */

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -1,13 +1,13 @@
-import { CatalogKind } from './catalog-kind';
+import { FromDefinition, Kamelet, ObjectMeta } from '@kaoto-next/camel-catalog/types';
+import { SourceSchemaType } from './camel/source-schema-type';
 
-export interface IKameletDefinition {
-  apiVersion: string;
-  kind: CatalogKind.Kamelet;
+export interface IKameletDefinition extends Omit<Kamelet, 'kind' | 'metadata' | 'spec'> {
+  kind: SourceSchemaType.Kamelet;
   metadata: IKameletMetadata;
   spec: IKameletSpec;
 }
 
-export interface IKameletMetadata {
+export interface IKameletMetadata extends ObjectMeta {
   name: string;
   annotations: IKameletMetadataAnnotations;
   labels: IKameletMetadataLabels;
@@ -20,10 +20,12 @@ export interface IKameletMetadataAnnotations {
   'camel.apache.org/provider': string;
   'camel.apache.org/kamelet.group': string;
   'camel.apache.org/kamelet.namespace': string;
+  [k: string]: string;
 }
 
 export interface IKameletMetadataLabels {
   'camel.apache.org/kamelet.type': string;
+  [k: string]: string;
 }
 
 export interface IKameletSpec {
@@ -31,7 +33,7 @@ export interface IKameletSpec {
   dependencies: string[];
   template: {
     beans: unknown;
-    from: unknown;
+    from: FromDefinition;
   };
 }
 

--- a/packages/ui/src/models/visualization/flows/flow-templates-service.ts
+++ b/packages/ui/src/models/visualization/flows/flow-templates-service.ts
@@ -1,5 +1,6 @@
-import { SourceSchemaType } from '../../camel/source-schema-type';
 import { parse } from 'yaml';
+import { SourceSchemaType } from '../../camel/source-schema-type';
+import { kameletTemplate } from './templates/kamelet';
 
 export class FlowTemplateService {
   getFlowTemplate = (type: SourceSchemaType) => {
@@ -26,7 +27,7 @@ spec:
       kind: Kamelet
       apiVersion: camel.apache.org/v1
       name: log-sink`;
-        break;
+
       case SourceSchemaType.Route:
         return `- route:
     from:
@@ -36,6 +37,10 @@ spec:
       steps:
         - log:
             message: template message`;
+
+      case SourceSchemaType.Kamelet:
+        return kameletTemplate();
+
       default:
         return '';
     }

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
@@ -1,0 +1,57 @@
+import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { AddStepMode } from '../../base-visual-entity';
+import { CamelComponentFilterService } from './camel-component-filter.service';
+
+describe('CamelComponentFilterService', () => {
+  describe('getCompatibleComponents', () => {
+    it('should not provide ProducerOnly components', () => {
+      expect(
+        CamelComponentFilterService.getCompatibleComponents(AddStepMode.ReplaceStep, {
+          path: 'from',
+          processorName: 'from' as keyof ProcessorDefinition,
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('should not provide consumerOnly components', () => {
+      expect(
+        CamelComponentFilterService.getCompatibleComponents(AddStepMode.ReplaceStep, {
+          path: 'from.steps.2.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('scenario for InsertSpecialChild', () => {
+      expect(
+        CamelComponentFilterService.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, {
+          path: 'from',
+          processorName: 'from' as keyof ProcessorDefinition,
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('scenario for a new step before an existing step', () => {
+      expect(
+        CamelComponentFilterService.getCompatibleComponents(AddStepMode.PrependStep, {
+          path: 'from.steps.0.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+
+    it('scenario for a new step after an existing step', () => {
+      expect(
+        CamelComponentFilterService.getCompatibleComponents(AddStepMode.AppendStep, {
+          path: 'from.steps.1.to',
+          processorName: 'to',
+          label: 'timer',
+        }),
+      ).toBeDefined();
+    });
+  });
+});

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
@@ -1,0 +1,68 @@
+import { ITile, TileFilter } from '../../../../components/Catalog/Catalog.models';
+import { CatalogKind } from '../../../catalog-kind';
+import { AddStepMode } from '../../base-visual-entity';
+import { CamelRouteVisualEntityData } from './camel-component-types';
+
+export class CamelComponentFilterService {
+  static getCompatibleComponents(
+    mode: AddStepMode,
+    visualEntityData: CamelRouteVisualEntityData,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    definition?: any,
+  ): TileFilter {
+    if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'from') {
+      /**
+       * For the `from` step we want to show only components which are not `producerOnly`,
+       * as this mean that they can be used only as a consumer.
+       */
+      return (item: ITile) => {
+        return (
+          (item.type === CatalogKind.Component && !item.tags.includes('producerOnly')) ||
+          (item.type === CatalogKind.Kamelet && item.tags.includes('source'))
+        );
+      };
+    }
+
+    if (mode === AddStepMode.InsertSpecialChildStep) {
+      /**
+       * specialChildren is a map of processor names and their special children.
+       */
+      const specialChildren: Record<string, string[]> = {
+        choice: ['when'],
+        doTry: ['doCatch'],
+      };
+
+      /** If an `otherwise` or a `doFinally` already exists, we shouldn't offer it in the catalog */
+      const definitionKeys = Object.keys(definition ?? {});
+      if (!definitionKeys.includes('otherwise')) {
+        specialChildren.choice.push('otherwise');
+      }
+      if (!definitionKeys.includes('doFinally')) {
+        specialChildren.doTry.push('doFinally');
+      }
+
+      /**
+       * For special child steps, we need to check which type of processor it is, in order to determine
+       * what kind of components we want to show.
+       */
+      return (item: ITile) => {
+        if (item.type !== CatalogKind.Processor || specialChildren[visualEntityData.processorName] === undefined) {
+          return false;
+        }
+
+        return specialChildren[visualEntityData.processorName].includes(item.name);
+      };
+    }
+
+    /**
+     * For the rest, we want to filter out components that are `consumerOnly`,
+     * as this mean that they can be used only as a consumer.
+     */
+    return (item: ITile) => {
+      return (
+        (item.type !== CatalogKind.Kamelet && !item.tags.includes('consumerOnly')) ||
+        (item.type === CatalogKind.Kamelet && !item.tags.includes('source'))
+      );
+    };
+  }
+}

--- a/packages/ui/src/models/visualization/flows/templates/kamelet.ts
+++ b/packages/ui/src/models/visualization/flows/templates/kamelet.ts
@@ -1,0 +1,45 @@
+import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
+
+export const kameletTemplate = () => {
+  const kameletId = getCamelRandomId('kamelet');
+
+  return `
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: ${kameletId}
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "main-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Users"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: ${kameletId}
+    description: "Produces periodic events about random users!"
+    type: object
+    properties:
+      period:
+        title: Period
+        description: The time interval between two events
+        type: integer
+        default: 5000
+  types:
+    out:
+      mediaType: application/json
+  dependencies:
+    - "camel:timer"
+    - "camel:http"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "timer:user"
+      parameters:
+        period: "{{period}}"
+      steps:
+      - to: https://random-data-api.com/api/v2/users
+      - to: "kamelet:sink"`;
+};

--- a/packages/ui/src/stubs/beer-source-kamelet.ts
+++ b/packages/ui/src/stubs/beer-source-kamelet.ts
@@ -1,8 +1,9 @@
-import { CatalogKind, IKameletDefinition } from '../models';
+import { IKameletDefinition } from '../models';
+import { SourceSchemaType } from '../models/camel';
 
 export const beerSourceKamelet: IKameletDefinition = {
   apiVersion: 'camel.apache.org/v1',
-  kind: CatalogKind.Kamelet,
+  kind: SourceSchemaType.Kamelet,
   metadata: {
     name: 'beer-source',
     annotations: {

--- a/packages/ui/src/stubs/xj-template-action.kamelet.ts
+++ b/packages/ui/src/stubs/xj-template-action.kamelet.ts
@@ -1,8 +1,9 @@
-import { CatalogKind, IKameletDefinition } from '../models';
+import { IKameletDefinition } from '../models';
+import { SourceSchemaType } from '../models/camel';
 
 export const xjTemplateAction: IKameletDefinition = {
   apiVersion: 'camel.apache.org/v1',
-  kind: CatalogKind.Kamelet,
+  kind: SourceSchemaType.Kamelet,
   metadata: {
     name: 'xj-template-action',
     annotations: {


### PR DESCRIPTION
### Changes
This commit adds basic support for Kamelets canvas flow.

### Notes
There are still pending topics that will be handled in upcoming pull requests, such as:

* Dependency array management
* Metadata configuration (f.i. Icon, Title, Annotations, and labels)

### Screenshots:
#### Example is taken [from here](https://github.com/apache/camel-kamelets-examples/blob/main/custom-kamelets/user-source.kamelet.yaml)

#### Canvas
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/deb6e957-8f8c-49a9-a20a-e029dbc59449)

#### Source code
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/052efab4-3e3b-49f4-a044-b4b008697438)

Relates to: https://github.com/KaotoIO/kaoto-next/issues/110