### PR TITLE
chore(canvas): Improve Canvas toolbar styling

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.scss
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.scss
@@ -1,0 +1,22 @@
+.current-dsl-tag {
+  align-self: center;
+  position: relative;
+  border: 0;
+  border-bottom: 1px solid var(--pf-v5-global--BorderColor--200);
+
+  &::before {
+    border: 1px solid var(--pf-v5-global--BorderColor--300);
+    border-bottom: 0;
+    content: ' ';
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    box-sizing: border-box;
+  }
+
+  & > span {
+    margin: var(--pf-v5-global--spacer--form-element) var(--pf-v5-global--spacer--sm)
+      var(--pf-v5-global--spacer--form-element) var(--pf-v5-global--spacer--sm);
+    line-height: 22px;
+  }
+}

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -1,11 +1,11 @@
-import { FunctionComponent, useContext } from 'react';
 import { Chip, ToolbarItem } from '@patternfly/react-core';
+import { FunctionComponent, useContext } from 'react';
 import { sourceSchemaConfig } from '../../../models/camel';
-import { FlowsMenu } from './Flows/FlowsMenu';
 import { EntitiesContext } from '../../../providers/entities.provider';
-import { NewFlow } from './FlowType/NewFlow';
 import { FlowClipboard } from './FlowClipboard/FlowClipboard';
 import { FlowExportImage } from './FlowExportImage/FlowExportImage';
+import { NewFlow } from './FlowType/NewFlow';
+import { FlowsMenu } from './Flows/FlowsMenu';
 
 export const ContextToolbar: FunctionComponent = () => {
   const { currentSchemaType } = useContext(EntitiesContext)!;

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -15,11 +15,11 @@ export const ContextToolbar: FunctionComponent = () => {
         {sourceSchemaConfig.config[currentSchemaType].name || 'None'}
       </Chip>
     </ToolbarItem>,
-    <ToolbarItem key={'toolbar-new-route'}>
-      <NewFlow />
-    </ToolbarItem>,
     <ToolbarItem key={'toolbar-flows-list'}>
       <FlowsMenu />
+    </ToolbarItem>,
+    <ToolbarItem key={'toolbar-new-route'}>
+      <NewFlow />
     </ToolbarItem>,
     <ToolbarItem key={'toolbar-clipboard'}>
       <FlowClipboard />

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -1,7 +1,8 @@
-import { Chip, ToolbarItem } from '@patternfly/react-core';
+import { ToolbarItem } from '@patternfly/react-core';
 import { FunctionComponent, useContext } from 'react';
 import { sourceSchemaConfig } from '../../../models/camel';
 import { EntitiesContext } from '../../../providers/entities.provider';
+import './ContextToolbar.scss';
 import { FlowClipboard } from './FlowClipboard/FlowClipboard';
 import { FlowExportImage } from './FlowExportImage/FlowExportImage';
 import { NewFlow } from './FlowType/NewFlow';
@@ -9,19 +10,18 @@ import { FlowsMenu } from './Flows/FlowsMenu';
 
 export const ContextToolbar: FunctionComponent = () => {
   const { currentSchemaType } = useContext(EntitiesContext)!;
+
   return [
-    <ToolbarItem key={'toolbar-current-dsl'}>
-      <Chip data-testid="toolbar-current-dsl" isReadOnly>
-        {sourceSchemaConfig.config[currentSchemaType].name || 'None'}
-      </Chip>
+    <ToolbarItem className="current-dsl-tag" key="toolbar-current-dsl">
+      <span data-testid="toolbar-current-dsl">{sourceSchemaConfig.config[currentSchemaType].name || 'None'}</span>
     </ToolbarItem>,
-    <ToolbarItem key={'toolbar-flows-list'}>
+    <ToolbarItem key="toolbar-flows-list">
       <FlowsMenu />
     </ToolbarItem>,
-    <ToolbarItem key={'toolbar-new-route'}>
+    <ToolbarItem key="toolbar-new-route">
       <NewFlow />
     </ToolbarItem>,
-    <ToolbarItem key={'toolbar-clipboard'}>
+    <ToolbarItem key="toolbar-clipboard">
       <FlowClipboard />
     </ToolbarItem>,
     <ToolbarItem key={'toolbar-export-image'}>

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.tsx
@@ -1,5 +1,3 @@
-import { FunctionComponent, PropsWithChildren, Ref, MouseEvent, useCallback, useContext, useState } from 'react';
-import { EntitiesContext } from '../../../../providers/entities.provider';
 import {
   MenuToggle,
   MenuToggleAction,
@@ -9,7 +7,9 @@ import {
   SelectOption,
   Tooltip,
 } from '@patternfly/react-core';
-import { ISourceSchema, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
+import { FunctionComponent, MouseEvent, PropsWithChildren, Ref, useCallback, useContext, useState } from 'react';
+import { ISourceSchema, SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
+import { EntitiesContext } from '../../../../providers/entities.provider';
 
 interface ISourceTypeSelector extends PropsWithChildren {
   isStatic?: boolean;
@@ -111,7 +111,7 @@ export const FlowTypeSelector: FunctionComponent<ISourceTypeSelector> = (props) 
               data-testid={`dsl-${sourceSchema.schema?.name}`}
               itemId={sourceType}
               description={
-                <span className="pf-u-text-break-word">
+                <span className="pf-v5-u-text-break-word">
                   {(sourceSchema.schema?.schema as { description: string }).description ?? ''}
                 </span>
               }

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
@@ -44,7 +44,7 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
     <>
       <FlowTypeSelector isStatic onSelect={checkBeforeAddNewFlow}>
         <PlusIcon />
-        <span className="pf-u-m-sm-on-lg">New route</span>
+        <span className="pf-v5-u-m-sm">New route</span>
       </FlowTypeSelector>
       <Modal
         title="Warning"

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsListEmptyState.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsListEmptyState.tsx
@@ -1,14 +1,15 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import { FunctionComponent } from 'react';
 
 export const FlowsListEmptyState: FunctionComponent = () => {
   return (
     <EmptyState data-testid="empty-state">
-      <EmptyStateIcon icon={CubesIcon} />
-      <Title headingLevel="h4" size="md">
-        There's no routes to show
-      </Title>
+      <EmptyStateHeader
+        titleText="There's no routes to show"
+        icon={<EmptyStateIcon icon={CubesIcon} />}
+        headingLevel="h4"
+      />
       <EmptyStateBody>You could create a new route using the New route button</EmptyStateBody>
     </EmptyState>
   );

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
@@ -36,7 +36,7 @@ export const FlowsMenu: FunctionComponent = () => {
             <Icon isInline>
               <ListIcon />
             </Icon>
-            <span data-testid="flows-list-route-id" className="pf-u-m-sm-on-lg">
+            <span data-testid="flows-list-route-id" className="pf-v5-u-m-sm">
               {visibleFlowsInformation().singleFlowId ?? 'Routes'}
             </span>
             <Badge data-testid="flows-list-route-count" isRead>

--- a/packages/ui/src/components/Visualization/Visualization.scss
+++ b/packages/ui/src/components/Visualization/Visualization.scss
@@ -2,3 +2,8 @@
   display: flex;
   flex-flow: column;
 }
+
+// Override for the default patternfly class
+.pf-v5-u-m-sm {
+  margin: var(--pf-v5-global--spacer--sm);
+}

--- a/packages/ui/src/pages/Design/DesignPage.tsx
+++ b/packages/ui/src/pages/Design/DesignPage.tsx
@@ -1,10 +1,9 @@
-import { Title } from '@patternfly/react-core';
 import { FunctionComponent, useContext } from 'react';
 import { Visualization } from '../../components/Visualization';
 import { CatalogModalProvider } from '../../providers/catalog-modal.provider';
 import { EntitiesContext } from '../../providers/entities.provider';
-import { ReturnToSourceCodeFallback } from './ReturnToSourceCodeFallback';
 import './DesignPage.scss';
+import { ReturnToSourceCodeFallback } from './ReturnToSourceCodeFallback';
 
 export const DesignPage: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);
@@ -12,8 +11,6 @@ export const DesignPage: FunctionComponent = () => {
 
   return (
     <div className="canvas-page">
-      <Title headingLevel="h1">Visualization</Title>
-
       <CatalogModalProvider>
         <Visualization
           className="canvas-page__canvas"


### PR DESCRIPTION
### Changes
Improve the style of the canvas' toolbar

* Add spacing around the controls' text
* Reorder controls
* Increase the size of the current flow type
* Remove the Visualization title

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/264a9ee1-829c-4d86-9295-fc4b9bb9b6d8) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/b12a2913-3f37-4b2c-979d-4d26ec1823e8) |

Fixes: https://github.com/KaotoIO/kaoto-next/issues/428