### PR TITLE
chore(actions): Enable fetch-flags property

### DIFF
--- a/.github/workflows/create-pre-release-pr.yml
+++ b/.github/workflows/create-pre-release-pr.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0 # Checkout all branches and tags
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-tags: true
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
### Context
In order to build the changelogs, we need to fetch the previous git tags.

relates: https://github.com/KaotoIO/kaoto-next/issues/420