### PR TITLE
feat(kamelets): Load Kamelet boundaries catalog

### DIFF
--- a/packages/ui/jest-setup.ts
+++ b/packages/ui/jest-setup.ts
@@ -4,6 +4,11 @@ import { FilterDOMPropsKeys, filterDOMProps } from 'uniforms';
 
 filterDOMProps.register('inputRef' as FilterDOMPropsKeys, 'placeholder' as FilterDOMPropsKeys);
 
+Object.defineProperty(window, 'fetch', {
+  writable: true,
+  value: jest.fn(),
+});
+
 jest
   .spyOn(global, 'crypto', 'get')
   .mockImplementation(() => ({ getRandomValues: () => [12345678] }) as unknown as Crypto);
@@ -17,4 +22,10 @@ jest.spyOn(console, 'warn').mockImplementation((...args) => {
   }
 
   console.log(...args);
+});
+
+const fetchMock = jest.spyOn(window, 'fetch');
+
+beforeEach(() => {
+  fetchMock.mockResolvedValue(null as unknown as Response);
 });

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -33,6 +33,8 @@ export default {
     '!src/**/*.models.ts',
     // Ignore stub files
     '!src/**/stubs/*.ts',
+    // Ignore icon resolver
+    '!src/**/node-icon-resolver.ts',
   ],
 
   // The directory where Jest should output its coverage files

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -150,6 +150,48 @@ describe('kameletToTile', () => {
     expect(tile.tags).toEqual(['source']);
   });
 
+  it('should use the selected CatalogKind.Kamelet by default', () => {
+    const kameletDef = {
+      metadata: {
+        labels: {
+          'camel.apache.org/kamelet.type': 'source',
+        },
+        annotations: {},
+      },
+      spec: {
+        definition: {
+          title: 'My Kamelet',
+          description: 'My Kamelet Description',
+        },
+      },
+    } as IKameletDefinition;
+
+    const tile = kameletToTile(kameletDef);
+
+    expect(tile.type).toEqual(CatalogKind.Kamelet);
+  });
+
+  it('should use the selected CatalogKind', () => {
+    const kameletDef = {
+      metadata: {
+        labels: {
+          'camel.apache.org/kamelet.type': 'source',
+        },
+        annotations: {},
+      },
+      spec: {
+        definition: {
+          title: 'My Kamelet',
+          description: 'My Kamelet Description',
+        },
+      },
+    } as IKameletDefinition;
+
+    const tile = kameletToTile(kameletDef, CatalogKind.KameletBoundary);
+
+    expect(tile.type).toEqual(CatalogKind.KameletBoundary);
+  });
+
   it('should populate the version for annotations', () => {
     const kameletDef = {
       metadata: {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -47,7 +47,10 @@ export const camelProcessorToTile = (processorDef: ICamelProcessorDefinition): I
   };
 };
 
-export const kameletToTile = (kameletDef: IKameletDefinition): ITile => {
+export const kameletToTile = (
+  kameletDef: IKameletDefinition,
+  type: CatalogKind.Kamelet | CatalogKind.KameletBoundary = CatalogKind.Kamelet,
+): ITile => {
   const headerTags: string[] = [];
   if (kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']) {
     headerTags.push(kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']);
@@ -64,7 +67,7 @@ export const kameletToTile = (kameletDef: IKameletDefinition): ITile => {
   }
 
   return {
-    type: CatalogKind.Kamelet,
+    type,
     name: kameletDef.metadata.name,
     title: kameletDef.spec.definition.title,
     description: kameletDef.spec.definition.description,

--- a/packages/ui/src/models/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel-catalog-index.ts
@@ -16,6 +16,7 @@ export interface Catalogs {
   languages: CatalogEntry;
   dataformats: CatalogEntry;
   kamelets: CatalogEntry;
+  'kamelets-boundaries': CatalogEntry;
   patterns: CatalogEntry;
 }
 
@@ -49,4 +50,5 @@ export interface ComponentsCatalog {
   [CatalogKind.Language]?: Record<string, ICamelLanguageDefinition>;
   [CatalogKind.Dataformat]?: Record<string, ICamelDataformatDefinition>;
   [CatalogKind.Kamelet]?: Record<string, IKameletDefinition>;
+  [CatalogKind.KameletBoundary]?: Record<string, IKameletDefinition>;
 }

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -5,4 +5,5 @@ export const enum CatalogKind {
   Language = 'language',
   Dataformat = 'dataformat',
   Kamelet = 'kamelet',
+  KameletBoundary = 'kamelet-boundary',
 }

--- a/packages/ui/src/providers/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.test.tsx
@@ -1,0 +1,102 @@
+import componentsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-components.json';
+import patternsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-patterns.json';
+import kameletsCatalog from '@kaoto-next/camel-catalog/kamelets-aggregate.json';
+import kameletsBoundariesCatalog from '@kaoto-next/camel-catalog/kamelets-boundaries.json';
+import { act, render, screen } from '@testing-library/react';
+import { camelComponentToTile, camelProcessorToTile, kameletToTile } from '../camel-utils';
+import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition, IKameletDefinition } from '../models';
+import { CamelCatalogService } from '../models/visualization/flows/camel-catalog.service';
+import { CatalogTilesProvider } from './catalog-tiles.provider';
+
+jest.mock('../camel-utils', () => {
+  const actual = jest.requireActual('../camel-utils');
+
+  return {
+    ...actual,
+    camelComponentToTile: jest.fn(),
+    camelProcessorToTile: jest.fn(),
+    kameletToTile: jest.fn(),
+  };
+});
+
+describe('CatalogTilesProvider', () => {
+  let getCatalogByKeySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getCatalogByKeySpy = jest.spyOn(CamelCatalogService, 'getCatalogByKey');
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Component,
+      componentsCatalog as unknown as Record<string, ICamelComponentDefinition>,
+    );
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Pattern,
+      patternsCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+    );
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Kamelet,
+      kameletsCatalog as unknown as Record<string, IKameletDefinition>,
+    );
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.KameletBoundary,
+      kameletsBoundariesCatalog as unknown as Record<string, IKameletDefinition>,
+    );
+  });
+
+  it('should render children', async () => {
+    await act(async () => {
+      render(
+        <CatalogTilesProvider>
+          <span data-testid="tiles-loaded">Loaded</span>
+        </CatalogTilesProvider>,
+      );
+    });
+
+    expect(screen.getByTestId('tiles-loaded')).toBeInTheDocument();
+  });
+
+  it('should query the catalog to build the tiles', async () => {
+    await act(async () => {
+      render(
+        <CatalogTilesProvider>
+          <span data-testid="tiles-loaded">Loaded</span>
+        </CatalogTilesProvider>,
+      );
+    });
+
+    expect(getCatalogByKeySpy).toHaveBeenCalledTimes(4);
+    expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Component);
+    expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Pattern);
+    expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Kamelet);
+    expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.KameletBoundary);
+  });
+
+  it('should build the tiles', async () => {
+    await act(async () => {
+      render(
+        <CatalogTilesProvider>
+          <span data-testid="tiles-loaded">Loaded</span>
+        </CatalogTilesProvider>,
+      );
+    });
+
+    expect(camelComponentToTile).toHaveBeenCalled();
+    expect(camelProcessorToTile).toHaveBeenCalled();
+    expect(kameletToTile).toHaveBeenCalled();
+  });
+
+  it('should avoid building the tiles if the catalog is empty', async () => {
+    CamelCatalogService.clearCatalogs();
+
+    await act(async () => {
+      render(
+        <CatalogTilesProvider>
+          <span data-testid="tiles-loaded">Loaded</span>
+        </CatalogTilesProvider>,
+      );
+    });
+
+    expect(camelComponentToTile).not.toHaveBeenCalled();
+    expect(camelProcessorToTile).not.toHaveBeenCalled();
+    expect(kameletToTile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/providers/catalog-tiles.provider.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.tsx
@@ -31,6 +31,9 @@ export const CatalogTilesProvider: FunctionComponent<PropsWithChildren> = (props
     Object.values(catalogService.getCatalogByKey(CatalogKind.Kamelet) ?? {}).forEach((kamelet) => {
       combinedTiles.push(kameletToTile(kamelet));
     });
+    Object.values(catalogService.getCatalogByKey(CatalogKind.KameletBoundary) ?? {}).forEach((kamelet) => {
+      combinedTiles.push(kameletToTile(kamelet, CatalogKind.KameletBoundary));
+    });
 
     return combinedTiles;
   }, [catalogService]);

--- a/packages/ui/src/providers/catalog.provider.test.tsx
+++ b/packages/ui/src/providers/catalog.provider.test.tsx
@@ -1,0 +1,171 @@
+import catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import { act, render, screen } from '@testing-library/react';
+import { CamelCatalogService, CatalogKind } from '../models';
+import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
+import { CatalogLoaderProvider } from './catalog.provider';
+
+describe('CatalogLoaderProvider', () => {
+  let fetchMock: jest.SpyInstance;
+  let fetchFileMock: jest.SpyInstance;
+  let setCatalogKeySpy: jest.SpyInstance;
+  let fetchResolve: () => void;
+  let fetchReject: () => void;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(window, 'fetch');
+    fetchMock.mockImplementationOnce((file) => {
+      return new Promise((resolve, reject) => {
+        fetchResolve = () => {
+          resolve({
+            json: () => catalogIndex,
+            url: `http://localhost/${file}`,
+          } as unknown as Response);
+        };
+        fetchReject = () => {
+          reject(new Error('Error'));
+        };
+      });
+    });
+
+    fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
+    fetchFileMock.mockImplementation((uri: string) => {
+      return new Promise((resolve) => {
+        resolve({ body: { uri } });
+      });
+    });
+    setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start in loading mode', async () => {
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    expect(screen.getByTestId('loading-catalogs')).toBeInTheDocument();
+  });
+
+  it('should stay in loading mode when there is an error', async () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchReject();
+    });
+
+    expect(screen.getByTestId('loading-catalogs')).toBeInTheDocument();
+  });
+
+  it('should fetch the index.json catalog file', async () => {
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/index.json`);
+  });
+
+  it('should fetch the subsequent catalog files', async () => {
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-components.json`,
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-models.json`,
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-patterns.json`,
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-languages.json`,
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-dataformats.json`,
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-aggregate.json`);
+    expect(fetchFileMock).toHaveBeenCalledWith(`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-boundaries.json`);
+  });
+
+  it('should set loading to false after fetching the catalogs', async () => {
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(screen.getByTestId('catalogs-loaded')).toBeInTheDocument();
+  });
+
+  it('should load the CamelCatalogService', async () => {
+    await act(async () => {
+      render(
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="catalogs-loaded">Loaded</span>
+        </CatalogLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Component, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-components.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Processor, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-models.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Pattern, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-patterns.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Language, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-languages.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Dataformat, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-dataformats.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Kamelet, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-aggregate.json`,
+    });
+    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.KameletBoundary, {
+      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-boundaries.json`,
+    });
+  });
+});

--- a/packages/ui/src/providers/catalog.provider.tsx
+++ b/packages/ui/src/providers/catalog.provider.tsx
@@ -41,16 +41,28 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
         const kameletsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.kamelets.file}`,
         );
+        /** Camel Kamelets boundaries definitions list (CRDs) */
+        const kameletBoundariesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.KameletBoundary]>(
+          `${props.catalogUrl}/${catalogIndex.catalogs['kamelets-boundaries'].file}`,
+        );
 
-        const [camelComponents, camelModels, camelPatterns, camelLanguages, camelDataformats, kamelets] =
-          await Promise.all([
-            camelComponentsFiles,
-            camelModelsFiles,
-            camelPatternsFiles,
-            camelLanguagesFiles,
-            camelDataformatsFiles,
-            kameletsFiles,
-          ]);
+        const [
+          camelComponents,
+          camelModels,
+          camelPatterns,
+          camelLanguages,
+          camelDataformats,
+          kamelets,
+          kameletBoundaries,
+        ] = await Promise.all([
+          camelComponentsFiles,
+          camelModelsFiles,
+          camelPatternsFiles,
+          camelLanguagesFiles,
+          camelDataformatsFiles,
+          kameletsFiles,
+          kameletBoundariesFiles,
+        ]);
 
         CamelCatalogService.setCatalogKey(CatalogKind.Component, camelComponents.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelModels.body);
@@ -58,9 +70,14 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
         CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, kamelets.body);
+        CamelCatalogService.setCatalogKey(CatalogKind.KameletBoundary, kameletBoundaries.body);
       })
       .then(() => {
         setIsLoading(false);
+      })
+      .catch((error) => {
+        /** TODO: Provide a friendly error message */
+        console.error(error);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/ui/src/providers/schemas.provider.test.tsx
+++ b/packages/ui/src/providers/schemas.provider.test.tsx
@@ -1,0 +1,96 @@
+import catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import { act, render, screen } from '@testing-library/react';
+import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
+import { SchemasLoaderProvider } from './schemas.provider';
+
+describe('SchemasLoaderProvider', () => {
+  let fetchMock: jest.SpyInstance;
+  let getSchemasFilesMock: jest.SpyInstance;
+  let fetchResolve: () => void;
+  let fetchReject: () => void;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(window, 'fetch');
+    fetchMock.mockImplementationOnce((file) => {
+      return new Promise((resolve, reject) => {
+        fetchResolve = () => {
+          resolve({
+            json: () => catalogIndex,
+            url: `http://localhost/${file}`,
+          } as unknown as Response);
+        };
+        fetchReject = () => {
+          reject(new Error('Error'));
+        };
+      });
+    });
+
+    getSchemasFilesMock = jest.spyOn(CatalogSchemaLoader, 'getSchemasFiles');
+    getSchemasFilesMock.mockReturnValueOnce([Promise.resolve]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start in loading mode', async () => {
+    await act(async () => {
+      render(
+        <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="schemas-loaded">Loaded</span>
+        </SchemasLoaderProvider>,
+      );
+    });
+
+    expect(screen.getByTestId('loading-schemas')).toBeInTheDocument();
+  });
+
+  it('should stay in loading mode when there is an error', async () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    await act(async () => {
+      render(
+        <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="schemas-loaded">Loaded</span>
+        </SchemasLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchReject();
+    });
+
+    expect(screen.getByTestId('loading-schemas')).toBeInTheDocument();
+  });
+
+  it('should fetch the index.json catalog file', async () => {
+    await act(async () => {
+      render(
+        <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="schemas-loaded">Loaded</span>
+        </SchemasLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/index.json`);
+  });
+
+  it('should fetch the subsequent catalog files', async () => {
+    await act(async () => {
+      render(
+        <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <span data-testid="schemas-loaded">Loaded</span>
+        </SchemasLoaderProvider>,
+      );
+    });
+
+    await act(async () => {
+      fetchResolve();
+    });
+
+    expect(getSchemasFilesMock).toHaveBeenCalledWith(CatalogSchemaLoader.DEFAULT_CATALOG_PATH, catalogIndex.schemas);
+  });
+});

--- a/packages/ui/src/providers/schemas.provider.tsx
+++ b/packages/ui/src/providers/schemas.provider.tsx
@@ -38,6 +38,10 @@ export const SchemasLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
       })
       .then(() => {
         setIsLoading(false);
+      })
+      .catch((error) => {
+        /** TODO: Provide a friendly error message */
+        console.error(error);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
### Changes
This commit loads the Kamelet boundaries catalog, which includes `kamelet:source` and `kamelet:sink`.

Relates to: https://github.com/KaotoIO/kaoto-next/issues/110