### PR TITLE
feat(kamelets): Offer kamelet:source and kamelet:sink as possible steps

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -171,27 +171,6 @@ describe('kameletToTile', () => {
     expect(tile.type).toEqual(CatalogKind.Kamelet);
   });
 
-  it('should use the selected CatalogKind', () => {
-    const kameletDef = {
-      metadata: {
-        labels: {
-          'camel.apache.org/kamelet.type': 'source',
-        },
-        annotations: {},
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
-        },
-      },
-    } as IKameletDefinition;
-
-    const tile = kameletToTile(kameletDef, CatalogKind.KameletBoundary);
-
-    expect(tile.type).toEqual(CatalogKind.KameletBoundary);
-  });
-
   it('should populate the version for annotations', () => {
     const kameletDef = {
       metadata: {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -47,10 +47,7 @@ export const camelProcessorToTile = (processorDef: ICamelProcessorDefinition): I
   };
 };
 
-export const kameletToTile = (
-  kameletDef: IKameletDefinition,
-  type: CatalogKind.Kamelet | CatalogKind.KameletBoundary = CatalogKind.Kamelet,
-): ITile => {
+export const kameletToTile = (kameletDef: IKameletDefinition): ITile => {
   const headerTags: string[] = [];
   if (kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']) {
     headerTags.push(kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']);
@@ -67,7 +64,7 @@ export const kameletToTile = (
   }
 
   return {
-    type,
+    type: CatalogKind.Kamelet,
     name: kameletDef.metadata.name,
     title: kameletDef.spec.definition.title,
     description: kameletDef.spec.definition.description,

--- a/packages/ui/src/components/IconResolver/IconResolver.tsx
+++ b/packages/ui/src/components/IconResolver/IconResolver.tsx
@@ -11,7 +11,6 @@ interface IconResolverProps {
 export const IconResolver: FunctionComponent<PropsWithChildren<IconResolverProps>> = (props) => {
   switch (props.tile.type) {
     case CatalogKind.Kamelet:
-    case CatalogKind.KameletBoundary:
       return (
         <img
           className={props.className}

--- a/packages/ui/src/models/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel-catalog-index.ts
@@ -50,5 +50,4 @@ export interface ComponentsCatalog {
   [CatalogKind.Language]?: Record<string, ICamelLanguageDefinition>;
   [CatalogKind.Dataformat]?: Record<string, ICamelDataformatDefinition>;
   [CatalogKind.Kamelet]?: Record<string, IKameletDefinition>;
-  [CatalogKind.KameletBoundary]?: Record<string, IKameletDefinition>;
 }

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -148,7 +148,7 @@ describe('CamelRouteResource', () => {
 
   describe('getCompatibleComponents', () => {
     it('should delegate to the CamelComponentFilterService', () => {
-      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getCompatibleComponents');
+      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getCamelCompatibleComponents');
 
       const resource = createCamelResource(camelRouteJson);
       resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' });

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -89,7 +89,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {
-    return CamelComponentFilterService.getCompatibleComponents(mode, visualEntityData, definition);
+    return CamelComponentFilterService.getCamelCompatibleComponents(mode, visualEntityData, definition);
   }
 
   private getEntity(rawItem: unknown): BaseCamelEntity | undefined {

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -77,7 +77,7 @@ describe('KameletResource', () => {
 
   describe('getCompatibleComponents', () => {
     it('should delegate to the CamelComponentFilterService', () => {
-      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getCompatibleComponents');
+      const filterSpy = jest.spyOn(CamelComponentFilterService, 'getKameletCompatibleComponents');
 
       const resource = createCamelResource(kameletJson);
       resource.getCompatibleComponents(AddStepMode.ReplaceStep, { path: 'from', label: 'timer' });

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -78,6 +78,6 @@ export class KameletResource extends CamelKResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {
-    return CamelComponentFilterService.getCompatibleComponents(mode, visualEntityData, definition);
+    return CamelComponentFilterService.getKameletCompatibleComponents(mode, visualEntityData, definition);
   }
 }

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -5,5 +5,4 @@ export const enum CatalogKind {
   Language = 'language',
   Dataformat = 'dataformat',
   Kamelet = 'kamelet',
-  KameletBoundary = 'kamelet-boundary',
 }

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -1,10 +1,10 @@
 import { ComponentsCatalog, ComponentsCatalogTypes } from '../../camel-catalog-index';
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
+import { ICamelDataformatDefinition } from '../../camel-dataformats-catalog';
+import { ICamelLanguageDefinition } from '../../camel-languages-catalog';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { IKameletDefinition } from '../../kamelets-catalog';
-import { ICamelDataformatDefinition } from '../../camel-dataformats-catalog';
-import { ICamelLanguageDefinition } from '../../camel-languages-catalog';
 
 export class CamelCatalogService {
   private static catalogs: ComponentsCatalog = {};
@@ -28,7 +28,6 @@ export class CamelCatalogService {
     dataformatName?: string,
   ): ICamelDataformatDefinition | undefined;
   static getComponent(catalogKey: CatalogKind.Kamelet, componentName?: string): IKameletDefinition | undefined;
-  static getComponent(catalogKey: CatalogKind.KameletBoundary, componentName?: string): IKameletDefinition | undefined;
   static getComponent(catalogKey: CatalogKind, componentName?: string): ComponentsCatalogTypes | undefined;
   static getComponent(catalogKey: CatalogKind, componentName?: string): ComponentsCatalogTypes | undefined {
     if (componentName === undefined) return undefined;

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
@@ -1,57 +1,203 @@
 import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import {
+  componentCronTile,
+  componentKubernetesSecretsTile,
+  componentSlackTile,
+  kameletBeerSourceTile,
+  kameletSSHSinkTile,
+  kameletSinkTile,
+  kameletSourceTile,
+  processorWhenTile,
+  processorOtherwiseTile,
+  kameletStringTemplateActionTile,
+  processorTile,
+  tiles,
+} from '../../../../stubs';
 import { AddStepMode } from '../../base-visual-entity';
 import { CamelComponentFilterService } from './camel-component-filter.service';
 
 describe('CamelComponentFilterService', () => {
-  describe('getCompatibleComponents', () => {
+  describe('getCamelCompatibleComponents', () => {
     it('should not provide ProducerOnly components', () => {
-      expect(
-        CamelComponentFilterService.getCompatibleComponents(AddStepMode.ReplaceStep, {
-          path: 'from',
-          processorName: 'from' as keyof ProcessorDefinition,
-          label: 'timer',
-        }),
-      ).toBeDefined();
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(AddStepMode.ReplaceStep, {
+        path: 'from',
+        processorName: 'from' as keyof ProcessorDefinition,
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([kameletBeerSourceTile, componentSlackTile, componentCronTile]);
     });
 
     it('should not provide consumerOnly components', () => {
-      expect(
-        CamelComponentFilterService.getCompatibleComponents(AddStepMode.ReplaceStep, {
-          path: 'from.steps.2.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(AddStepMode.ReplaceStep, {
+        path: 'from.steps.2.to',
+        processorName: 'to',
+        label: 'log',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
     });
 
-    it('scenario for InsertSpecialChild', () => {
-      expect(
-        CamelComponentFilterService.getCompatibleComponents(AddStepMode.InsertSpecialChildStep, {
-          path: 'from',
-          processorName: 'from' as keyof ProcessorDefinition,
-          label: 'timer',
-        }),
-      ).toBeDefined();
+    it('should offer applicable processors when requesting special children', () => {
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+        AddStepMode.InsertSpecialChildStep,
+        {
+          path: 'from.steps.0.choice',
+          processorName: 'choice',
+          label: 'Choice',
+        },
+        {},
+      );
+
+      expect(tiles.filter(filterFn)).toEqual([processorWhenTile, processorOtherwiseTile]);
+    });
+
+    it('should NOT offer already defined processors when requesting special children', () => {
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+        AddStepMode.InsertSpecialChildStep,
+        {
+          path: 'from.steps.0.choice',
+          processorName: 'choice',
+          label: 'Choice',
+        },
+        { otherwise: {} },
+      );
+
+      expect(tiles.filter(filterFn)).toEqual([processorWhenTile]);
     });
 
     it('scenario for a new step before an existing step', () => {
-      expect(
-        CamelComponentFilterService.getCompatibleComponents(AddStepMode.PrependStep, {
-          path: 'from.steps.0.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(AddStepMode.PrependStep, {
+        path: 'from.steps.0.to',
+        processorName: 'to',
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
     });
 
     it('scenario for a new step after an existing step', () => {
-      expect(
-        CamelComponentFilterService.getCompatibleComponents(AddStepMode.AppendStep, {
-          path: 'from.steps.1.to',
-          processorName: 'to',
-          label: 'timer',
-        }),
-      ).toBeDefined();
+      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(AddStepMode.AppendStep, {
+        path: 'from.steps.1.to',
+        processorName: 'to',
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
+    });
+  });
+
+  describe('getKameletCompatibleComponents', () => {
+    it('should not provide ProducerOnly components', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(AddStepMode.ReplaceStep, {
+        path: 'from',
+        processorName: 'from' as keyof ProcessorDefinition,
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletSourceTile,
+        kameletBeerSourceTile,
+        componentSlackTile,
+        componentCronTile,
+      ]);
+    });
+
+    it('should not provide consumerOnly components', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(AddStepMode.ReplaceStep, {
+        path: 'from.steps.2.to',
+        processorName: 'to',
+        label: 'log',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletSinkTile,
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
+    });
+
+    it('should offer applicable processors when requesting special children', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(
+        AddStepMode.InsertSpecialChildStep,
+        {
+          path: 'from.steps.0.choice',
+          processorName: 'choice',
+          label: 'Choice',
+        },
+        {},
+      );
+
+      expect(tiles.filter(filterFn)).toEqual([processorWhenTile, processorOtherwiseTile]);
+    });
+
+    it('should NOT offer already defined processors when requesting special children', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(
+        AddStepMode.InsertSpecialChildStep,
+        {
+          path: 'from.steps.0.choice',
+          processorName: 'choice',
+          label: 'Choice',
+        },
+        { otherwise: {} },
+      );
+
+      expect(tiles.filter(filterFn)).toEqual([processorWhenTile]);
+    });
+
+    it('scenario for a new step before an existing step', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(AddStepMode.PrependStep, {
+        path: 'from.steps.0.to',
+        processorName: 'to',
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletSinkTile,
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
+    });
+
+    it('scenario for a new step after an existing step', () => {
+      const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(AddStepMode.AppendStep, {
+        path: 'from.steps.1.to',
+        processorName: 'to',
+        label: 'timer',
+      });
+
+      expect(tiles.filter(filterFn)).toEqual([
+        kameletSinkTile,
+        kameletStringTemplateActionTile,
+        kameletSSHSinkTile,
+        processorTile,
+        componentSlackTile,
+        componentKubernetesSecretsTile,
+      ]);
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -115,13 +115,7 @@ export class CamelComponentSchemaService {
       let catalogKind: CatalogKind = CatalogKind.Component;
       let lookupName: string = camelElementLookup.componentName;
 
-      if (
-        camelElementLookup.componentName === 'kamelet:source' ||
-        camelElementLookup.componentName === 'kamelet:sink'
-      ) {
-        catalogKind = CatalogKind.KameletBoundary;
-        lookupName = camelElementLookup.componentName.replace('kamelet:', '');
-      } else if (camelElementLookup.componentName.startsWith('kamelet:')) {
+      if (camelElementLookup.componentName.startsWith('kamelet:')) {
         catalogKind = CatalogKind.Kamelet;
         lookupName = camelElementLookup.componentName.replace('kamelet:', '');
       }

--- a/packages/ui/src/providers/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.test.tsx
@@ -1,7 +1,7 @@
 import componentsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-components.json';
 import patternsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-patterns.json';
-import kameletsCatalog from '@kaoto-next/camel-catalog/kamelets-aggregate.json';
 import kameletsBoundariesCatalog from '@kaoto-next/camel-catalog/kamelet-boundaries.json';
+import kameletsCatalog from '@kaoto-next/camel-catalog/kamelets-aggregate.json';
 import { act, render, screen } from '@testing-library/react';
 import { camelComponentToTile, camelProcessorToTile, kameletToTile } from '../camel-utils';
 import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition, IKameletDefinition } from '../models';
@@ -32,14 +32,10 @@ describe('CatalogTilesProvider', () => {
       CatalogKind.Pattern,
       patternsCatalog as unknown as Record<string, ICamelProcessorDefinition>,
     );
-    CamelCatalogService.setCatalogKey(
-      CatalogKind.Kamelet,
-      kameletsCatalog as unknown as Record<string, IKameletDefinition>,
-    );
-    CamelCatalogService.setCatalogKey(
-      CatalogKind.KameletBoundary,
-      kameletsBoundariesCatalog as unknown as Record<string, IKameletDefinition>,
-    );
+    CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, {
+      ...(kameletsCatalog as unknown as Record<string, IKameletDefinition>),
+      ...(kameletsBoundariesCatalog as unknown as Record<string, IKameletDefinition>),
+    });
   });
 
   it('should render children', async () => {
@@ -63,11 +59,10 @@ describe('CatalogTilesProvider', () => {
       );
     });
 
-    expect(getCatalogByKeySpy).toHaveBeenCalledTimes(4);
+    expect(getCatalogByKeySpy).toHaveBeenCalledTimes(3);
     expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Component);
     expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Pattern);
     expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.Kamelet);
-    expect(getCatalogByKeySpy).toHaveBeenCalledWith(CatalogKind.KameletBoundary);
   });
 
   it('should build the tiles', async () => {

--- a/packages/ui/src/providers/catalog-tiles.provider.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.tsx
@@ -31,9 +31,6 @@ export const CatalogTilesProvider: FunctionComponent<PropsWithChildren> = (props
     Object.values(catalogService.getCatalogByKey(CatalogKind.Kamelet) ?? {}).forEach((kamelet) => {
       combinedTiles.push(kameletToTile(kamelet));
     });
-    Object.values(catalogService.getCatalogByKey(CatalogKind.KameletBoundary) ?? {}).forEach((kamelet) => {
-      combinedTiles.push(kameletToTile(kamelet, CatalogKind.KameletBoundary));
-    });
 
     return combinedTiles;
   }, [catalogService]);

--- a/packages/ui/src/providers/catalog.provider.test.tsx
+++ b/packages/ui/src/providers/catalog.provider.test.tsx
@@ -30,7 +30,7 @@ describe('CatalogLoaderProvider', () => {
     fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
     fetchFileMock.mockImplementation((uri: string) => {
       return new Promise((resolve) => {
-        resolve({ body: { uri } });
+        resolve({ body: { [uri]: 'dummy-data' } });
       });
     });
     setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
@@ -147,25 +147,23 @@ describe('CatalogLoaderProvider', () => {
     });
 
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Component, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-components.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-components.json`]: 'dummy-data',
     });
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Processor, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-models.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-models.json`]: 'dummy-data',
     });
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Pattern, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-patterns.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-patterns.json`]: 'dummy-data',
     });
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Language, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-languages.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-languages.json`]: 'dummy-data',
     });
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Dataformat, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-dataformats.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/camel-catalog-aggregate-dataformats.json`]: 'dummy-data',
     });
     expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.Kamelet, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-aggregate.json`,
-    });
-    expect(setCatalogKeySpy).toHaveBeenCalledWith(CatalogKind.KameletBoundary, {
-      uri: `${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelet-boundaries.json`,
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelets-aggregate.json`]: 'dummy-data',
+      [`${CatalogSchemaLoader.DEFAULT_CATALOG_PATH}/kamelet-boundaries.json`]: 'dummy-data',
     });
   });
 });

--- a/packages/ui/src/providers/catalog.provider.tsx
+++ b/packages/ui/src/providers/catalog.provider.tsx
@@ -42,7 +42,7 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
           `${props.catalogUrl}/${catalogIndex.catalogs.kamelets.file}`,
         );
         /** Camel Kamelets boundaries definitions list (CRDs) */
-        const kameletBoundariesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.KameletBoundary]>(
+        const kameletBoundariesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.kameletBoundaries.file}`,
         );
 
@@ -69,8 +69,7 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
         CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatterns.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
-        CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, kamelets.body);
-        CamelCatalogService.setCatalogKey(CatalogKind.KameletBoundary, kameletBoundaries.body);
+        CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, { ...kameletBoundaries.body, ...kamelets.body });
       })
       .then(() => {
         setIsLoading(false);

--- a/packages/ui/src/stubs/index.ts
+++ b/packages/ui/src/stubs/index.ts
@@ -2,3 +2,4 @@ export * from './camel-route';
 export * from './kamelet-binding-route';
 export * from './kamelet-route';
 export * from './pipe';
+export * from './tiles';

--- a/packages/ui/src/stubs/tiles.ts
+++ b/packages/ui/src/stubs/tiles.ts
@@ -1,0 +1,93 @@
+import { ITile } from '../components/Catalog/Catalog.models';
+import { CatalogKind } from '../models/catalog-kind';
+
+export const kameletSourceTile: ITile = {
+  type: CatalogKind.Kamelet,
+  name: 'source',
+  title: 'Kamelet Source',
+  tags: ['source'],
+};
+
+export const kameletSinkTile: ITile = {
+  type: CatalogKind.Kamelet,
+  name: 'sink',
+  title: 'Kamelet Sink',
+  tags: ['sink'],
+};
+
+export const kameletBeerSourceTile: ITile = {
+  type: CatalogKind.Kamelet,
+  name: 'beer-source',
+  title: 'Beer source',
+  tags: ['source'],
+};
+
+export const kameletStringTemplateActionTile: ITile = {
+  type: CatalogKind.Kamelet,
+  name: 'string-template-action',
+  title: 'String Template Action',
+  tags: ['action'],
+};
+
+export const kameletSSHSinkTile: ITile = {
+  type: CatalogKind.Kamelet,
+  name: 'ssh-sink',
+  title: 'SSH Sink',
+  tags: ['sink'],
+};
+
+export const processorTile: ITile = {
+  type: CatalogKind.Processor,
+  name: 'choice',
+  title: 'Choice',
+  tags: ['eip', 'routing'],
+};
+
+export const processorWhenTile: ITile = {
+  type: CatalogKind.Processor,
+  name: 'when',
+  title: 'When',
+  tags: ['eip', 'routing'],
+};
+
+export const processorOtherwiseTile: ITile = {
+  type: CatalogKind.Processor,
+  name: 'otherwise',
+  title: 'Otherwise',
+  tags: ['eip', 'routing'],
+};
+
+export const componentSlackTile: ITile = {
+  type: CatalogKind.Component,
+  name: 'slack',
+  title: 'Slack',
+  tags: ['social'],
+};
+
+export const componentKubernetesSecretsTile: ITile = {
+  type: CatalogKind.Component,
+  name: 'kube-secrets',
+  title: 'Kubernetes Secrets',
+  tags: ['container', 'cloud', 'producerOnly'],
+};
+
+export const componentCronTile: ITile = {
+  type: CatalogKind.Component,
+  name: 'cron',
+  title: 'Cron',
+  tags: ['scheduling', 'consumerOnly'],
+};
+
+export const tiles: ITile[] = [
+  kameletSourceTile,
+  kameletSinkTile,
+  kameletBeerSourceTile,
+  kameletStringTemplateActionTile,
+  kameletSSHSinkTile,
+  processorTile,
+  processorWhenTile,
+  processorOtherwiseTile,
+  componentSlackTile,
+  componentKubernetesSecretsTile,
+  componentCronTile,
+];

--- a/packages/ui/src/utils/node-icon-resolver.ts
+++ b/packages/ui/src/utils/node-icon-resolver.ts
@@ -112,14 +112,10 @@ import { CamelCatalogService } from '../models/visualization/flows/camel-catalog
 export class NodeIconResolver {
   static getIcon(elementName: string | undefined): string {
     if (elementName?.startsWith('kamelet:')) {
-      const catalogKind =
-        elementName === 'kamelet:source' || elementName === 'kamelet:sink'
-          ? CatalogKind.KameletBoundary
-          : CatalogKind.Kamelet;
-
-      const kameletDefinition = CamelCatalogService.getComponent(catalogKind, elementName.replace('kamelet:', '')) as
-        | IKameletDefinition
-        | undefined;
+      const kameletDefinition = CamelCatalogService.getComponent(
+        CatalogKind.Kamelet,
+        elementName.replace('kamelet:', ''),
+      ) as IKameletDefinition | undefined;
 
       return kameletDefinition?.metadata.annotations['camel.apache.org/kamelet.icon'] ?? this.getUnknownIcon();
     }


### PR DESCRIPTION
### Note
Screencast updated to showcase `kamelet:source` and `kamelet:sink` inside of the `Kamelet` catalog, as the first Tile, when applicable.

### Demo
[Screencast from 2023-11-30 12-53-51.webm](https://github.com/KaotoIO/kaoto-next/assets/16512618/d1a55bdf-3954-4e8e-a7b1-795d361c6cea)

Relates to: https://github.com/KaotoIO/kaoto-next/issues/110
Fixes: https://github.com/KaotoIO/kaoto-next/issues/462