### PR TITLE
improved the tile information in the catalog with a name

### DIFF
--- a/packages/ui/src/components/Catalog/Tile.scss
+++ b/packages/ui/src/components/Catalog/Tile.scss
@@ -17,6 +17,15 @@
     width: 25px;
   }
 
+  &__name {
+    text-align: center;
+    min-height: 25px;
+    font-size: small;
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+  }
+
   &__title {
     text-align: center;
     display: flex;

--- a/packages/ui/src/components/Catalog/Tile.tsx
+++ b/packages/ui/src/components/Catalog/Tile.tsx
@@ -46,6 +46,7 @@ export const Tile: FunctionComponent<PropsWithChildren<TileProps>> = (props) => 
 
         <CardTitle className="tile__title">
           <span>{props.tile.title}</span>
+          <span className="tile__name">({props.tile.name})</span>
           {props.tile.version && (
             <CatalogTag key={`${props.tile.version}`} tag={props.tile.version} variant="outline" />
           )}

--- a/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
@@ -110,6 +110,13 @@ exports[`Tile renders correctly 1`] = `
           <span>
             tile-title
           </span>
+          <span
+            class="tile__name"
+          >
+            (
+            tile-name
+            )
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Let me know if that looks better:

![grafik](https://github.com/KaotoIO/kaoto-next/assets/435853/126a79f1-a315-4b82-bca2-cedb646862b2)



fixes #453 