### PR TITLE
fix: expression property is unexpectedly added to the other step

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`CanvasForm should render 1`] = `
         >
           <label
             class="pf-v5-c-form__label"
-            for="uniforms-0000-0001"
+            for="uniforms-0000-0003"
           >
             <span
               class="pf-v5-c-form__label-text"
@@ -45,11 +45,11 @@ exports[`CanvasForm should render 1`] = `
             <input
               aria-invalid="false"
               aria-label="uniforms text field"
-              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-2"
               data-ouia-component-type="PF5/TextInput"
               data-ouia-safe="true"
               data-testid="text-field"
-              id="uniforms-0000-0001"
+              id="uniforms-0000-0003"
               label="Name"
               name="name"
               type="text"


### PR DESCRIPTION
Fixes: #385
Fixes: #319

Here is what's happening
https://github.com/KaotoIO/kaoto-next/issues/385#issuecomment-1832627798

So instead of storing model and schema as states and relying on `useEffect()` and the re-render triggered with it, make it local variable and try to cache with `useMemo()`. This way the #385 is addressed. But unfortunately #416 is not, would need to address separately.