### PR TITLE
fix(351) - add option for editing route id's

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -56,7 +56,10 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 onClick={() => {
                   onSelectFlow(flow.id);
                 }}
-                onChange={(_name) => {}}
+                onChange={(name) => {
+                  flow.setId(name);
+                  updateEntitiesFromCamelResource();
+                }}
               />
               {/*TODO add description*/}
             </Td>

--- a/packages/ui/src/models/camel/entities/base-entity.ts
+++ b/packages/ui/src/models/camel/entities/base-entity.ts
@@ -14,7 +14,7 @@ export const enum EntityType {
 
 export interface BaseCamelEntity {
   /** Internal API fields */
-  readonly id: string;
+  id: string;
   readonly type: EntityType;
 
   /** Retrieve the model from the underlying Camel entity */

--- a/packages/ui/src/models/camel/entities/pipe-overrides.ts
+++ b/packages/ui/src/models/camel/entities/pipe-overrides.ts
@@ -1,6 +1,7 @@
 import { Pipe } from '@kaoto-next/camel-catalog/types';
 
 export type PipeSpec = NonNullable<Pipe['spec']>;
+export type PipeMetadata = NonNullable<Pipe['metadata']>;
 export type PipeSource = NonNullable<Pipe['spec']>['source'];
 export type PipeSink = NonNullable<Pipe['spec']>['sink'];
 export type PipeSteps = NonNullable<Pipe['spec']>['steps'];

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -25,7 +25,7 @@ export class PipeResource extends CamelKResource {
     if (!this.pipe.spec) {
       this.pipe.spec = {};
     }
-    this.flow = new PipeVisualEntity(this.pipe.spec);
+    this.flow = new PipeVisualEntity(this.pipe.metadata, this.pipe.spec);
     this.errorHandler =
       this.pipe.spec.errorHandler && new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler);
   }

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -15,6 +15,8 @@ export interface BaseVisualCamelEntity extends BaseCamelEntity {
 
   getId: () => string;
 
+  setId: (id: string) => void;
+
   /** Given a path, get the component type and definition */
   getComponentSchema: (path?: string) => VisualComponentSchema | undefined;
 

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -68,6 +68,11 @@ describe('Camel Route', () => {
     it('should return the id', () => {
       expect(camelEntity.getId()).toEqual(expect.any(String));
     });
+
+    it('should change the id', () => {
+      camelEntity.setId('camelEntity-12345');
+      expect(camelEntity.getId()).toEqual('camelEntity-12345');
+    });
   });
 
   describe('getComponentSchema', () => {

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -55,15 +55,19 @@ export const isCamelFrom = (rawEntity: unknown): rawEntity is { from: FromDefini
 };
 
 export class CamelRouteVisualEntity implements BaseVisualCamelEntity {
-  readonly id: string;
+  id: string;
   readonly type = EntityType.Route;
 
   constructor(public route: RouteDefinition) {
     this.id = route.id ?? getCamelRandomId('route');
     this.route.id = this.id;
   }
-
   /** Internal API methods */
+  setId(routeId: string): void {
+    this.id = routeId;
+    this.route.id = this.id;
+  }
+
   getId(): string {
     return this.id;
   }

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { EntityType } from '../../camel/entities';
 import {
   BaseVisualCamelEntity,
@@ -8,9 +7,10 @@ import {
   VisualComponentSchema,
 } from '../base-visual-entity';
 import { createVisualizationNode } from '../visualization-node';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 
 export class KameletVisualEntity implements BaseVisualCamelEntity {
-  readonly id = uuidv4();
+  id = getCamelRandomId('kamelet');
   type = EntityType.Kamelet;
 
   constructor(json: unknown) {
@@ -25,6 +25,11 @@ export class KameletVisualEntity implements BaseVisualCamelEntity {
 
   getId(): string {
     return ''; // TODO
+  }
+
+  setId(routeId: string): void {
+    this.id = routeId;
+    // TODO
   }
 
   getNodeInteraction(_data: IVisualizationNodeData): NodeInteraction {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -2,17 +2,18 @@ import { Pipe } from '@kaoto-next/camel-catalog/types';
 import { JSONSchemaType } from 'ajv';
 import cloneDeep from 'lodash/cloneDeep';
 import { pipeJson } from '../../../stubs/pipe';
-import { EntityType } from '../../camel/entities';
+import { EntityType, PipeMetadata } from '../../camel/entities';
 import { PipeVisualEntity } from './';
 import { KameletSchemaService } from './support/kamelet-schema.service';
 
 describe('Pipe', () => {
   let pipeCR: Pipe;
   let pipe: PipeVisualEntity;
+  let metadata: PipeMetadata;
 
   beforeEach(() => {
     pipeCR = cloneDeep(pipeJson);
-    pipe = new PipeVisualEntity(pipeCR.spec!);
+    pipe = new PipeVisualEntity(metadata, pipeCR.spec!);
   });
 
   describe('id', () => {
@@ -27,6 +28,11 @@ describe('Pipe', () => {
 
     it('should return the id', () => {
       expect(pipe.getId()).toEqual(expect.any(String));
+    });
+
+    it('should change the id', () => {
+      pipe.setId('pipe-12345');
+      expect(pipe.getId()).toEqual('pipe-12345');
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -1,12 +1,11 @@
 import { Pipe } from '@kaoto-next/camel-catalog/types';
 import get from 'lodash.get';
 import set from 'lodash.set';
-import { v4 as uuidv4 } from 'uuid';
 import { getArrayProperty } from '../../../utils';
 import { NodeIconResolver } from '../../../utils/node-icon-resolver';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
-import { PipeSpec, PipeStep, PipeSteps } from '../../camel/entities/pipe-overrides';
+import { PipeMetadata, PipeSpec, PipeStep, PipeSteps } from '../../camel/entities/pipe-overrides';
 import {
   AddStepMode,
   BaseVisualCamelEntity,
@@ -17,13 +16,17 @@ import {
 } from '../base-visual-entity';
 import { createVisualizationNode } from '../visualization-node';
 import { KameletSchemaService } from './support/kamelet-schema.service';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 
 export class PipeVisualEntity implements BaseVisualCamelEntity {
-  readonly id = uuidv4();
+  id: string;
   type = EntityType.Pipe;
   spec: PipeSpec;
+  metadata: PipeMetadata;
 
-  constructor(spec?: PipeSpec) {
+  constructor(metadata?: PipeMetadata, spec?: PipeSpec) {
+    this.id = (metadata?.name as string) ?? getCamelRandomId('pipe');
+    this.metadata = metadata ?? { name: this.id };
     this.spec = spec ?? {
       source: {},
       steps: [],
@@ -34,6 +37,11 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
   /** Internal API methods */
   getId(): string {
     return this.id;
+  }
+
+  setId(routeId: string): void {
+    this.id = routeId;
+    this.metadata.name = this.id;
   }
 
   getComponentSchema(path?: string): VisualComponentSchema | undefined {


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/351

@lordrip I know you recommended another approach in your [comment](https://github.com/KaotoIO/kaoto-next/issues/351#issuecomment-1827488779). 
What I did works too, updating the ID in the visual entity. For pipe - the "metadata: name: " was used, similar to kaoto-ui.

I was also thinking, whether the BaseCamelEntity "id" field is maybe redundant and should be removed.