### PR TITLE
chore(catalog): Rename `model` to `processor`

### DIFF
--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -1,6 +1,6 @@
 export const enum CatalogKind {
   Component = 'component',
-  Processor = 'model',
+  Processor = 'processor',
   Pattern = 'pattern',
   Language = 'language',
   Dataformat = 'dataformat',


### PR DESCRIPTION
### Changes
Rename `model` to `processor` in the Components catalog.

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/1270e903-a3b2-4bb2-899f-55e01413b3c4) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/f0d18aab-2586-40a6-804f-556520d62ead) |
