### PR TITLE
fix: This node cannot be configured yet "sticks" to other node config…

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -55,7 +55,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   }, [schema]);
 
   return schema?.schema === undefined ? null : (
-    <ErrorBoundary fallback={<p>This node cannot be configured yet</p>}>
+    <ErrorBoundary key={props.selectedNode.id} fallback={<p>This node cannot be configured yet</p>}>
       <Title headingLevel="h1">{componentName}</Title>
       {isExpressionAwareStep && <ExpressionEditor selectedNode={props.selectedNode} />}
       {isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}


### PR DESCRIPTION
…urations, even though these can be configured

Fixes: #416

@lordrip Although this fixes the issue, I don't feel like this is the best way, isn't there a way to not hold the error as a state and evaluate for every render?