### PR TITLE
Fix(280): Respect and preset default values for parameters in the con…

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -14,18 +14,21 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
   "schema": {
     "properties": {
       "description": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the description of this node",
         "title": "Description",
         "type": "string",
       },
       "disabled": {
+        "default": false,
         "deprecated": false,
         "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
         "title": "Disabled",
         "type": "boolean",
       },
       "id": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the id of this node",
         "title": "Id",
@@ -35,42 +38,49 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "description": "Endpoint properties description",
         "properties": {
           "exchangeFormatter": {
+            "default": undefined,
             "deprecated": false,
             "description": "To use a custom exchange formatter",
             "title": "Exchange Formatter",
             "type": "object",
           },
           "groupActiveOnly": {
+            "default": "true",
             "deprecated": false,
             "description": "If true, will hide stats when no new messages have been received for a time interval, if false, show stats regardless of message traffic.",
             "title": "Group Active Only",
             "type": "boolean",
           },
           "groupDelay": {
+            "default": undefined,
             "deprecated": false,
             "description": "Set the initial delay for stats (in millis)",
             "title": "Group Delay",
             "type": "integer",
           },
           "groupInterval": {
+            "default": undefined,
             "deprecated": false,
             "description": "If specified will group message stats by this time interval (in millis)",
             "title": "Group Interval",
             "type": "integer",
           },
           "groupSize": {
+            "default": undefined,
             "deprecated": false,
             "description": "An integer that specifies a group size for throughput logging.",
             "title": "Group Size",
             "type": "integer",
           },
           "lazyStartProducer": {
+            "default": false,
             "deprecated": false,
             "description": "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing.",
             "title": "Lazy Start Producer",
             "type": "boolean",
           },
           "level": {
+            "default": "INFO",
             "deprecated": false,
             "description": "Logging level to use. The default value is INFO.",
             "enum": [
@@ -85,144 +95,168 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
             "type": undefined,
           },
           "logMask": {
+            "default": undefined,
             "deprecated": false,
             "description": "If true, mask sensitive information like password or passphrase in the log.",
             "title": "Log Mask",
             "type": "boolean",
           },
           "loggerName": {
+            "default": undefined,
             "deprecated": false,
             "description": "Name of the logging category to use",
             "title": "Logger Name",
             "type": "string",
           },
           "marker": {
+            "default": undefined,
             "deprecated": false,
             "description": "An optional Marker name to use.",
             "title": "Marker",
             "type": "string",
           },
           "maxChars": {
+            "default": 10000,
             "deprecated": false,
             "description": "Limits the number of characters logged per line.",
             "title": "Max Chars",
             "type": "integer",
           },
           "multiline": {
+            "default": false,
             "deprecated": false,
             "description": "If enabled then each information is outputted on a newline.",
             "title": "Multiline",
             "type": "boolean",
           },
           "plain": {
+            "default": false,
             "deprecated": false,
             "description": "If enabled only the body will be printed out",
             "title": "Plain",
             "type": "boolean",
           },
           "showAll": {
+            "default": false,
             "deprecated": false,
             "description": "Quick option for turning all options on. (multiline, maxChars has to be manually set if to be used)",
             "title": "Show All",
             "type": "boolean",
           },
           "showAllProperties": {
+            "default": false,
             "deprecated": false,
             "description": "Show all of the exchange properties (both internal and custom).",
             "title": "Show All Properties",
             "type": "boolean",
           },
           "showBody": {
+            "default": true,
             "deprecated": false,
             "description": "Show the message body.",
             "title": "Show Body",
             "type": "boolean",
           },
           "showBodyType": {
+            "default": true,
             "deprecated": false,
             "description": "Show the body Java type.",
             "title": "Show Body Type",
             "type": "boolean",
           },
           "showCachedStreams": {
+            "default": true,
             "deprecated": false,
             "description": "Whether Camel should show cached stream bodies or not (org.apache.camel.StreamCache).",
             "title": "Show Cached Streams",
             "type": "boolean",
           },
           "showCaughtException": {
+            "default": false,
             "deprecated": false,
             "description": "If the exchange has a caught exception, show the exception message (no stack trace). A caught exception is stored as a property on the exchange (using the key org.apache.camel.Exchange#EXCEPTION_CAUGHT) and for instance a doCatch can catch exceptions.",
             "title": "Show Caught Exception",
             "type": "boolean",
           },
           "showException": {
+            "default": false,
             "deprecated": false,
             "description": "If the exchange has an exception, show the exception message (no stacktrace)",
             "title": "Show Exception",
             "type": "boolean",
           },
           "showExchangeId": {
+            "default": false,
             "deprecated": false,
             "description": "Show the unique exchange ID.",
             "title": "Show Exchange Id",
             "type": "boolean",
           },
           "showExchangePattern": {
+            "default": false,
             "deprecated": false,
             "description": "Shows the Message Exchange Pattern (or MEP for short).",
             "title": "Show Exchange Pattern",
             "type": "boolean",
           },
           "showFiles": {
+            "default": false,
             "deprecated": false,
             "description": "If enabled Camel will output files",
             "title": "Show Files",
             "type": "boolean",
           },
           "showFuture": {
+            "default": false,
             "deprecated": false,
             "description": "If enabled Camel will on Future objects wait for it to complete to obtain the payload to be logged.",
             "title": "Show Future",
             "type": "boolean",
           },
           "showHeaders": {
+            "default": false,
             "deprecated": false,
             "description": "Show the message headers.",
             "title": "Show Headers",
             "type": "boolean",
           },
           "showProperties": {
+            "default": false,
             "deprecated": false,
             "description": "Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.",
             "title": "Show Properties",
             "type": "boolean",
           },
           "showStackTrace": {
+            "default": false,
             "deprecated": false,
             "description": "Show the stack trace, if an exchange has an exception. Only effective if one of showAll, showException or showCaughtException are enabled.",
             "title": "Show Stack Trace",
             "type": "boolean",
           },
           "showStreams": {
+            "default": false,
             "deprecated": false,
             "description": "Whether Camel should show stream bodies or not (eg such as java.io.InputStream). Beware if you enable this option then you may not be able later to access the message body as the stream have already been read by this logger. To remedy this you will have to use Stream Caching.",
             "title": "Show Streams",
             "type": "boolean",
           },
           "skipBodyLineSeparator": {
+            "default": true,
             "deprecated": false,
             "description": "Whether to skip line separators when logging the message body. This allows to log the message body in one line, setting this option to false will preserve any line separators from the body, which then will log the body as is.",
             "title": "Skip Body Line Separator",
             "type": "boolean",
           },
           "sourceLocationLoggerName": {
+            "default": false,
             "deprecated": false,
             "description": "If enabled then the source location of where the log endpoint is used in Camel routes, would be used as logger name, instead of the given name. However, if the source location is disabled or not possible to resolve then the existing logger name will be used.",
             "title": "Source Location Logger Name",
             "type": "boolean",
           },
           "style": {
+            "default": "Default",
             "deprecated": false,
             "description": "Sets the outputs style to use.",
             "enum": [
@@ -241,6 +275,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": "object",
       },
       "pattern": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the optional ExchangePattern used to invoke this endpoint",
         "enum": [
@@ -251,6 +286,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": undefined,
       },
       "uri": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the uri of the endpoint to send to.",
         "title": "Uri",
@@ -274,36 +310,42 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
   "schema": {
     "properties": {
       "description": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the description of this node",
         "title": "Description",
         "type": "string",
       },
       "disabled": {
+        "default": false,
         "deprecated": false,
         "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
         "title": "Disabled",
         "type": "boolean",
       },
       "id": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the id of this node",
         "title": "Id",
         "type": "string",
       },
       "logName": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the name of the logger",
         "title": "Log Name",
         "type": "string",
       },
       "logger": {
+        "default": undefined,
         "deprecated": false,
         "description": "To refer to a custom logger instance to lookup from the registry.",
         "title": "Logger",
         "type": "object",
       },
       "loggingLevel": {
+        "default": "INFO",
         "deprecated": false,
         "description": "Sets the logging level. The default value is INFO",
         "enum": [
@@ -318,12 +360,14 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": undefined,
       },
       "marker": {
+        "default": undefined,
         "deprecated": false,
         "description": "To use slf4j marker",
         "title": "Marker",
         "type": "string",
       },
       "message": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the log message (uses simple language)",
         "title": "Message",
@@ -351,24 +395,28 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should not build a
   "schema": {
     "properties": {
       "description": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the description of this node",
         "title": "Description",
         "type": "string",
       },
       "disabled": {
+        "default": false,
         "deprecated": false,
         "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
         "title": "Disabled",
         "type": "boolean",
       },
       "id": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the id of this node",
         "title": "Id",
         "type": "string",
       },
       "pattern": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the optional ExchangePattern used to invoke this endpoint",
         "enum": [
@@ -379,6 +427,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should not build a
         "type": undefined,
       },
       "uri": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the uri of the endpoint to send to.",
         "title": "Uri",
@@ -402,36 +451,42 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
   "schema": {
     "properties": {
       "description": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the description of this node",
         "title": "Description",
         "type": "string",
       },
       "disabled": {
+        "default": false,
         "deprecated": false,
         "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
         "title": "Disabled",
         "type": "boolean",
       },
       "id": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the id of this node",
         "title": "Id",
         "type": "string",
       },
       "logName": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the name of the logger",
         "title": "Log Name",
         "type": "string",
       },
       "logger": {
+        "default": undefined,
         "deprecated": false,
         "description": "To refer to a custom logger instance to lookup from the registry.",
         "title": "Logger",
         "type": "object",
       },
       "loggingLevel": {
+        "default": "INFO",
         "deprecated": false,
         "description": "Sets the logging level. The default value is INFO",
         "enum": [
@@ -446,12 +501,14 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "type": undefined,
       },
       "marker": {
+        "default": undefined,
         "deprecated": false,
         "description": "To use slf4j marker",
         "title": "Marker",
         "type": "string",
       },
       "message": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the log message (uses simple language)",
         "title": "Message",
@@ -475,24 +532,28 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
   "schema": {
     "properties": {
       "description": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the description of this node",
         "title": "Description",
         "type": "string",
       },
       "disabled": {
+        "default": false,
         "deprecated": false,
         "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
         "title": "Disabled",
         "type": "boolean",
       },
       "id": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the id of this node",
         "title": "Id",
         "type": "string",
       },
       "pattern": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the optional ExchangePattern used to invoke this endpoint",
         "enum": [
@@ -503,6 +564,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "type": undefined,
       },
       "uri": {
+        "default": undefined,
         "deprecated": false,
         "description": "Sets the uri of the endpoint to send to.",
         "title": "Uri",

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/node-definition.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/node-definition.service.test.ts.snap
@@ -4,36 +4,42 @@ exports[`NodeDefinitionService getSchemaFromCamelCommonProperties should return 
 {
   "properties": {
     "description": {
+      "default": undefined,
       "deprecated": false,
       "description": "Sets the description of this node",
       "title": "Description",
       "type": "string",
     },
     "disabled": {
+      "default": false,
       "deprecated": false,
       "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
       "title": "Disabled",
       "type": "boolean",
     },
     "id": {
+      "default": undefined,
       "deprecated": false,
       "description": "Sets the id of this node",
       "title": "Id",
       "type": "string",
     },
     "logName": {
+      "default": undefined,
       "deprecated": false,
       "description": "Sets the name of the logger",
       "title": "Log Name",
       "type": "string",
     },
     "logger": {
+      "default": undefined,
       "deprecated": false,
       "description": "To refer to a custom logger instance to lookup from the registry.",
       "title": "Logger",
       "type": "object",
     },
     "loggingLevel": {
+      "default": "INFO",
       "deprecated": false,
       "description": "Sets the logging level. The default value is INFO",
       "enum": [
@@ -48,12 +54,14 @@ exports[`NodeDefinitionService getSchemaFromCamelCommonProperties should return 
       "type": undefined,
     },
     "marker": {
+      "default": undefined,
       "deprecated": false,
       "description": "To use slf4j marker",
       "title": "Marker",
       "type": "string",
     },
     "message": {
+      "default": undefined,
       "deprecated": false,
       "description": "Sets the log message (uses simple language)",
       "title": "Message",

--- a/packages/ui/src/models/visualization/flows/support/node-definition.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/node-definition.service.test.ts
@@ -70,7 +70,7 @@ describe('NodeDefinitionService', () => {
     expect(jsonType.properties.durationProperty.type).toEqual('string');
   });
 
-  it('should return the JSON type for a duration field', () => {
+  it('should return the JSON type for a object', () => {
     const objectProperty: ICamelProcessorProperty = {
       index: 0,
       kind: 'expression',
@@ -87,6 +87,25 @@ describe('NodeDefinitionService', () => {
 
     const jsonType = NodeDefinitionService.getSchemaFromCamelCommonProperties({ objectProperty });
     expect(jsonType.properties.objectProperty.type).toEqual('object');
+  });
+
+  it('should return the default value for the property', () => {
+    const durationProperty: ICamelProcessorProperty = {
+      index: 1,
+      kind: 'attribute',
+      displayName: 'Batch Timeout',
+      required: false,
+      type: 'duration',
+      javaType: 'java.lang.String',
+      deprecated: false,
+      autowired: false,
+      secret: false,
+      defaultValue: '1000',
+      description: 'Sets the timeout for collecting elements to be re-ordered. The default timeout is 1000 msec.',
+    };
+
+    const jsonType = NodeDefinitionService.getSchemaFromCamelCommonProperties({ durationProperty });
+    expect(jsonType.properties.durationProperty.default).toEqual('1000');
   });
 
   describe('getSchemaFromKameletDefinition', () => {

--- a/packages/ui/src/models/visualization/flows/support/node-definition.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/node-definition.service.ts
@@ -29,6 +29,7 @@ export class NodeDefinitionService {
         title: property.displayName,
         description: property.description,
         deprecated: property.deprecated,
+        default: property.defaultValue,
       } as unknown as JSONSchemaType<unknown>;
 
       if (property.enum !== undefined) {


### PR DESCRIPTION
Fixes: #280 

Now when we add a CouchDB component to the canvas and click it to open the config panel, we see the default values preset in the form:
![image](https://github.com/KaotoIO/kaoto-next/assets/73224329/baeb4493-410e-4ff8-93b3-a0c61f2b119a)


