### PR TITLE
fix(vscode): Zoom collapse tabs

### DIFF
--- a/packages/ui/src/components/MetadataEditor/MetadataEditor.scss
+++ b/packages/ui/src/components/MetadataEditor/MetadataEditor.scss
@@ -4,9 +4,9 @@
 }
 
 .metadata-editor-modal-list-view {
-  width: 50vw;
+  width: 50%;
 }
 
 .metadata-editor-modal-details-view {
-  width: 50vw;
+  width: 50%;
 }

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -6,20 +6,19 @@
   position: relative;
   padding-top: 15px;
 
+  // Tab header shouldn't grow or shrink
+  > div[role='region'] {
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
+
+  // Tab content is scrollable
   section#{&}__tab-content {
     flex-grow: 1;
+    flex-shrink: 1;
     position: relative;
     padding: 0 15px 15px;
-  }
-}
-
-.canvas-page {
-  height: 100%;
-  display: flex;
-  flex-flow: column;
-
-  &__canvas {
-    flex-grow: 1;
+    overflow: scroll;
   }
 }
 

--- a/packages/ui/src/multiplying-architecture/Tabs/DesignTab.scss
+++ b/packages/ui/src/multiplying-architecture/Tabs/DesignTab.scss
@@ -1,0 +1,9 @@
+.canvas-page {
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+
+  &__canvas {
+    flex-grow: 1;
+  }
+}

--- a/packages/ui/src/multiplying-architecture/Tabs/DesignTab.tsx
+++ b/packages/ui/src/multiplying-architecture/Tabs/DesignTab.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useContext } from 'react';
 import { Visualization } from '../../components/Visualization';
 import { EntitiesContext } from '../../providers';
+import './DesignTab.scss';
 
 export const DesignTab: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);


### PR DESCRIPTION
### Context
This commit fixes a styling issue that forces the tabs header to collapse when there is much zoom in VSCode

### Screenshots
#### Canvas
![Screenshot from 2023-12-08 06-14-23](https://github.com/KaotoIO/kaoto-next/assets/16512618/3132a3d5-4626-4773-b630-65fc0606d44e)

#### Beans
![Screenshot from 2023-12-08 06-14-26](https://github.com/KaotoIO/kaoto-next/assets/16512618/cc16fabc-f256-475c-9cb4-071a26408846)

#### Metadata editor
![Screenshot from 2023-12-08 06-14-29](https://github.com/KaotoIO/kaoto-next/assets/16512618/836e18ff-7a84-4079-8f8d-153aa1f59de0)

#### Error handler
![Screenshot from 2023-12-08 06-14-32](https://github.com/KaotoIO/kaoto-next/assets/16512618/082f47dd-21ae-472b-9659-794ad017b6f9)

fix: https://github.com/KaotoIO/kaoto-next/issues/530