### PR TITLE
feat(catalog): Focus on search text field after switching groups

### DIFF
--- a/packages/ui/src/components/Catalog/CatalogFilter.tsx
+++ b/packages/ui/src/components/Catalog/CatalogFilter.tsx
@@ -67,6 +67,7 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
                   isSelected={props.activeGroup === key}
                   onChange={() => {
                     props.setActiveGroup(key);
+                    inputRef.current?.focus();
                   }}
                 />
               ))}


### PR DESCRIPTION
### Context
Focus on search bar when switching between catalogs

### Before
https://github.com/KaotoIO/kaoto-next/assets/16512618/c99fb75e-addc-4e4a-acc8-c2936840ad3d

### After
https://github.com/KaotoIO/kaoto-next/assets/16512618/a950f3e1-2075-4288-8209-607249489446

