### PR TITLE
fix(e2e) - edge failing due to multiple quotation marks

### DIFF
--- a/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
@@ -67,12 +67,7 @@ describe('source code and drag and drop', () => {
   it('User Add a new branch in the YAML', () => {
     cy.uploadFixture('flows/ComplexKamelet.yaml');
 
-    // CHECK atlasmap step is not
-    // cy.openDesignPage();
-    // cy.get('[data-type="node"][data-id^="atlasmap"]').should('have.length', 0);
-    // cy.openSourceCode();
-
-    const stepToInsert = `\n              - simple: '{{}{{}?test}}'
+    const stepToInsert = `\n              - simple: {{}{{}?test}}
                 steps:
                   - to:
                       uri: atlasmap:null`;


### PR DESCRIPTION
On edge (saw also one case with chrome) - there were for some reason second quotation mark added in the end of the line with ` - simple: '{{?test}}'`, causing failures. Removed the quotation marks, as these are not mandatory. 

(sorry for the bad image quality - just a screen from the GH recording)
![Screenshot from 2023-12-08 08-27-23](https://github.com/KaotoIO/kaoto-next/assets/4180208/b0cf5baf-e623-406e-be99-e1991b70766e)
