### PR TITLE
fix(vscode): Fix VSCode switching integration type

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
@@ -59,7 +59,6 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
             data-testid="confirmation-modal-confirm"
             onClick={() => {
               if (proposedFlowType) {
-                entitiesContext.setCurrentSchemaType(proposedFlowType);
                 sourceCodeContextApi.setCodeAndNotify(FlowTemplateService.getFlowYamlTemplate(proposedFlowType));
                 setIsConfirmationModalOpen(false);
               }

--- a/packages/ui/src/models/visualization/flows/templates/kamelet.ts
+++ b/packages/ui/src/models/visualization/flows/templates/kamelet.ts
@@ -3,8 +3,7 @@ import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
 export const kameletTemplate = () => {
   const kameletId = getCamelRandomId('kamelet');
 
-  return `
-apiVersion: camel.apache.org/v1alpha1
+  return `apiVersion: camel.apache.org/v1alpha1
 kind: Kamelet
 metadata:
   name: ${kameletId}

--- a/packages/ui/src/models/visualization/flows/templates/pipe.ts
+++ b/packages/ui/src/models/visualization/flows/templates/pipe.ts
@@ -1,22 +1,21 @@
 import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
 
 export const pipeTemplate = () => {
-  return `
-  apiVersion: camel.apache.org/v1
-  kind: Pipe
-  metadata:
-    name: ${getCamelRandomId('pipe')}
-  spec:
-    source:
-      ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: timer-source
-        properties:
-          message: hello
-    sink:
-      ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: log-sink`;
+  return `apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: ${getCamelRandomId('pipe')}
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: timer-source
+      properties:
+        message: hello
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink`;
 };

--- a/packages/ui/src/models/visualization/flows/templates/route.ts
+++ b/packages/ui/src/models/visualization/flows/templates/route.ts
@@ -1,16 +1,15 @@
 import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
 
 export const routeTemplate = () => {
-  return `
-  - route:
-      id: ${getCamelRandomId('route')}
-      from:
-        id: ${getCamelRandomId('from')}
-        uri: timer:template
-        parameters:
-          period: "1000"
-        steps:
-          - log:
-              id: ${getCamelRandomId('log')}
-              message: template message`;
+  return `- route:
+    id: ${getCamelRandomId('route')}
+    from:
+      id: ${getCamelRandomId('from')}
+      uri: timer:template
+      parameters:
+        period: "1000"
+      steps:
+        - log:
+            id: ${getCamelRandomId('log')}
+            message: template message`;
 };

--- a/packages/ui/src/providers/source-code.provider.tsx
+++ b/packages/ui/src/providers/source-code.provider.tsx
@@ -9,12 +9,13 @@ import {
 } from 'react';
 import { EventNotifier } from '../utils';
 
-export const SourceCodeContext = createContext<string>('');
-
-export const SourceCodeApiContext = createContext<{
+interface ISourceCodeApi {
   /** Set the Source Code and notify subscribers */
   setCodeAndNotify: (sourceCode: string) => void;
-}>({ setCodeAndNotify: () => {} });
+}
+
+export const SourceCodeContext = createContext<string>('');
+export const SourceCodeApiContext = createContext<ISourceCodeApi>({ setCodeAndNotify: () => {} });
 
 export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) => {
   const eventNotifier = EventNotifier.getInstance();
@@ -34,7 +35,7 @@ export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) 
     [eventNotifier],
   );
 
-  const sourceCodeApi = useMemo(
+  const sourceCodeApi: ISourceCodeApi = useMemo(
     () => ({
       setCodeAndNotify,
     }),


### PR DESCRIPTION
### Context
Currently, when VSCode switch from one integration type to another, for instance, going from a Camel Route to a Kamelet, this change is not persisted until a property is changed.

This happens because the `KaotoBridge` is not subscribed to the `code:updated` event and this is used when changing from one integration type to another.

### Changes
The fix is to subscribe to that envent. In addition to that, since [this PR](https://github.com/KaotoIO/kaoto-next/pull/541), the `VisibleFlowsProvider` was removed from the `Visualization` component, hence it was breaking the VSCode integration. This PR also adds it to the `KaotoBridge`

fixes: https://github.com/KaotoIO/kaoto-next/issues/402