### PR TITLE
fix: Create entity catalog

### DIFF
--- a/packages/camel-catalog/assembly/pom.xml
+++ b/packages/camel-catalog/assembly/pom.xml
@@ -176,6 +176,7 @@
               <camelVersion>${version.camel}</camelVersion>
               <camelKCRDVersion>${version.camel-k-crds}</camelKCRDVersion>
               <kameletsVersion>${version.camel-kamelets}</kameletsVersion>
+              <generateSubSchema>true</generateSubSchema>
               <kubernetesDefinitions>
                 <kubernetesDefinition>io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta</kubernetesDefinition>
                 <kubernetesDefinition>io.k8s.api.core.v1.ObjectReference</kubernetesDefinition>

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.kaoto.camelcatalog;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.kaoto.camelcatalog.CamelCatalogProcessor;
@@ -35,6 +37,7 @@ public class CamelCatalogProcessorTest {
     private final ObjectNode languageCatalog;
     private final ObjectNode modelCatalog;
     private final ObjectNode processorCatalog;
+    private final ObjectNode entityCatalog;
 
     public CamelCatalogProcessorTest() throws Exception {
         this.jsonMapper = new ObjectMapper();
@@ -47,6 +50,7 @@ public class CamelCatalogProcessorTest {
         this.languageCatalog = (ObjectNode) jsonMapper.readTree(this.processor.getLanguageCatalog());
         this.modelCatalog = (ObjectNode) jsonMapper.readTree(this.processor.getModelCatalog());
         this.processorCatalog = (ObjectNode) jsonMapper.readTree(this.processor.getPatternCatalog());
+        this.entityCatalog = (ObjectNode) jsonMapper.readTree(this.processor.getEntityCatalog());
     }
 
     @Test
@@ -220,5 +224,50 @@ public class CamelCatalogProcessorTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testGetEntityCatalog() throws Exception {
+        List.of(
+                "bean",
+                "beans",
+                "errorHandler",
+                "from",
+                "intercept",
+                "interceptFrom",
+                "interceptSendToEndpoint",
+                "onCompletion",
+                "onException",
+                "routeConfiguration",
+                "route",
+                "routeTemplate",
+                "templatedRoute",
+                "restConfiguration",
+                "rest",
+                "routeTemplateBean",
+                "templatedRouteBean"
+        ).forEach(name -> assertTrue(entityCatalog.has(name), name));
+        var bean = entityCatalog.withObject("/bean");
+        var beanScriptLanguage = bean.withObject("/propertiesSchema")
+                .withObject("/properties")
+                .withObject("/scriptLanguage");
+        assertEquals("Script Language", beanScriptLanguage.get("title").asText());
+        var beans = entityCatalog.withObject("/beans");
+        var beansScript = beans.withObject("/propertiesSchema")
+                .withObject("/definitions")
+                .withObject("/org.apache.camel.model.app.RegistryBeanDefinition")
+                .withObject("/properties")
+                .withObject("/script");
+        assertEquals("Script", beansScript.get("title").asText());
+        var routeTemplateBean = entityCatalog.withObject("/routeTemplateBean");
+        var routeTemplateBeanType = routeTemplateBean.withObject("/propertiesSchema")
+                .withObject("/properties")
+                .withObject("/type");
+        assertEquals("Type", routeTemplateBeanType.get("title").asText());
+        var templatedRouteBean = entityCatalog.withObject("/templatedRouteBean");
+        var templatedRouteBeanProperties = templatedRouteBean.withObject("/propertiesSchema")
+                .withObject("/properties")
+                .withObject("/properties");
+        assertEquals("Properties", templatedRouteBeanProperties.get("title").asText());
     }
 }

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.kaoto.camelcatalog;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.kaoto.camelcatalog.CamelYamlDslSchemaProcessor;
 import org.apache.camel.dsl.yaml.CamelYamlRoutesBuilderLoader;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -118,7 +121,7 @@ public class CamelYamlDslSchemaProcessorTest {
 
         var loadBalance = processorMap.get("org.apache.camel.model.LoadBalanceDefinition");
         assertFalse(loadBalance.has("anyOf"));
-        assertEquals("loadbalance", loadBalance.get("$comment").asText());
+        assertEquals("loadbalance,steps", loadBalance.get("$comment").asText());
 
         var saga = processorMap.get("org.apache.camel.model.SagaDefinition");
         var sagaCompensation = saga.withObject("/properties").withObject("/compensation");
@@ -129,5 +132,40 @@ public class CamelYamlDslSchemaProcessorTest {
         var propExpDef = saga.withObject("/definitions").withObject("/org.apache.camel.model.PropertyExpressionDefinition");
         assertEquals("object", propExpDef.withObject("/properties").withObject("/expression").get("type").asText());
         assertEquals("expression", propExpDef.withObject("/properties").withObject("/expression").get("$comment").asText());
+    }
+
+    @Test
+    public void testGetEntities() throws Exception {
+        var entityMap = processor.getEntities();
+        List.of(
+                "beans",
+                "errorHandler",
+                "from",
+                "intercept",
+                "interceptFrom",
+                "interceptSendToEndpoint",
+                "onCompletion",
+                "onException",
+                "routeConfiguration",
+                "route",
+                "routeTemplate",
+                "templatedRoute",
+                "restConfiguration",
+                "rest"
+        ).forEach(name -> assertTrue(entityMap.containsKey(name), name));
+    }
+
+    @Test
+    public void testGetRouteTemplateBean() {
+        var rtb = processor.getRouteTemplateBean();
+        assertNotNull(rtb);
+        assertNotNull(rtb.withObject("/definitions").withObject("/org.apache.camel.model.PropertyDefinition"));
+    }
+
+    @Test
+    public void testGetTemplatedRouteBean() {
+        var trb = processor.getTemplatedRouteBean();
+        assertNotNull(trb);
+        assertNotNull(trb.withObject("/definitions").withObject("/org.apache.camel.model.PropertyDefinition"));
     }
 }

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/K8sSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/K8sSchemaProcessorTest.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.kaoto.camelcatalog;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.kaoto.camelcatalog.K8sSchemaProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/KameletProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/KameletProcessorTest.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kaoto.camelcatalog;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.kaoto.camelcatalog.KameletProcessor;
 import org.junit.jupiter.api.Test;
 
 import java.net.JarURLConnection;

--- a/packages/ui/src/components/Form/bean/BeanReferenceField.test.tsx
+++ b/packages/ui/src/components/Form/bean/BeanReferenceField.test.tsx
@@ -1,4 +1,3 @@
-import * as beansSchema from '@kaoto-next/camel-catalog/camelYamlDsl-beans.json';
 import { AutoField, AutoForm } from '@kaoto-next/uniforms-patternfly';
 import { screen } from '@testing-library/dom';
 import { fireEvent, render } from '@testing-library/react';
@@ -6,17 +5,21 @@ import { act } from 'react-dom/test-utils';
 import { EntitiesContextResult } from '../../../hooks';
 import { BeansEntity } from '../../../models/visualization/metadata';
 import { EntitiesContext } from '../../../providers';
-import { useSchemasStore } from '../../../store';
 import { CustomAutoFieldDetector } from '../CustomAutoField';
 import { SchemaService } from '../schema.service';
 import { BeanReferenceField } from './BeanReferenceField';
 import { BeansAwareResource, CamelRouteResource } from '../../../models/camel';
-
-useSchemasStore.setState({
-  schemas: { beans: { name: 'beans', tags: [], version: '0', uri: '', schema: beansSchema } },
-});
+import * as entitiesCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-entities.json';
+import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition } from '../../../models';
 
 describe('BeanReferenceField', () => {
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  delete (entitiesCatalog as any).default;
+  CamelCatalogService.setCatalogKey(
+    CatalogKind.Entity,
+    entitiesCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+  );
+
   const mockSchema = {
     title: 'Single Bean',
     description: 'Single Bean Configuration',

--- a/packages/ui/src/components/Form/bean/NewBeanModal.test.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.test.tsx
@@ -1,12 +1,15 @@
 import { NewBeanModal } from './NewBeanModal';
 import { fireEvent, render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { useSchemasStore } from '../../../store';
-import * as beansSchema from '@kaoto-next/camel-catalog/camelYamlDsl-beans.json';
+import * as entitiesCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-entities.json';
+import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition } from '../../../models';
 describe('NewBeanModal', () => {
-  useSchemasStore.setState({
-    schemas: { beans: { name: 'beans', tags: [], version: '0', uri: '', schema: beansSchema } },
-  });
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  delete (entitiesCatalog as any).default;
+  CamelCatalogService.setCatalogKey(
+    CatalogKind.Entity,
+    entitiesCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+  );
 
   it('should render', () => {
     const mockOnCreate = jest.fn();

--- a/packages/ui/src/components/Form/bean/NewBeanModal.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.tsx
@@ -1,8 +1,8 @@
 import { MetadataEditor } from '../../MetadataEditor';
 import { Button, Modal } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
-import { useSchemasStore } from '../../../store';
 import { RegistryBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { CamelCatalogService, CatalogKind } from '../../../models';
 
 export type NewBeanModalProps = {
   beanName?: string;
@@ -14,23 +14,10 @@ export type NewBeanModalProps = {
 };
 
 export const NewBeanModal: FunctionComponent<NewBeanModalProps> = (props: NewBeanModalProps) => {
-  const schemaMap = useSchemasStore((state) => state.schemas);
   const beanSchema = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const beansSchema = schemaMap['beans']?.schema as any;
-    const beanDefinition = beansSchema?.definitions['org.apache.camel.model.app.RegistryBeanDefinition'];
-    if (!beanDefinition) {
-      return undefined;
-    }
-    return {
-      title: beansSchema.title,
-      description: beansSchema.description,
-      additionalProperties: false,
-      type: 'object',
-      properties: beanDefinition.properties,
-      required: beanDefinition.required,
-    };
-  }, [schemaMap]);
+    const beanCatalog = CamelCatalogService.getComponent(CatalogKind.Entity, 'bean');
+    return beanCatalog?.propertiesSchema;
+  }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [beanModel, setBeanModel] = useState<any>();

--- a/packages/ui/src/components/Form/expression/expression.service.test.ts
+++ b/packages/ui/src/components/Form/expression/expression.service.test.ts
@@ -1,5 +1,4 @@
 import { ExpressionService } from './expression.service';
-import * as yamlDslSchema from '@kaoto-next/camel-catalog/camelYamlDsl.json';
 import * as languageCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-languages.json';
 import { CatalogKind, ICamelLanguageDefinition } from '../../../models';
 import { CamelCatalogService } from '../../../models/visualization/flows';
@@ -7,7 +6,6 @@ import { CamelCatalogService } from '../../../models/visualization/flows';
 describe('ExpressionService', () => {
   beforeAll(() => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
-    delete (yamlDslSchema as any).default;
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Language,

--- a/packages/ui/src/components/Visualization/Canvas/DataFormatEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/DataFormatEditor.test.tsx
@@ -1,4 +1,3 @@
-import * as yamlDslSchema from '@kaoto-next/camel-catalog/camelYamlDsl.json';
 import * as dataformatCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-dataformats.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { CamelCatalogService } from '../../../models/visualization/flows';
@@ -6,8 +5,6 @@ import { CatalogKind, ICamelDataformatDefinition } from '../../../models';
 import { CanvasNode } from './canvas.models';
 import { JSONSchemaType } from 'ajv';
 import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { useSchemasStore } from '../../../store';
-import { act } from 'react-dom/test-utils';
 import { DataFormatEditor } from './DataFormatEditor';
 import { MetadataEditor } from '../../MetadataEditor';
 
@@ -15,26 +12,11 @@ describe('DataFormatEditor', () => {
   let mockNode: CanvasNode;
   beforeAll(() => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
-    delete (yamlDslSchema as any).default;
     delete (dataformatCatalog as any).default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Dataformat,
       dataformatCatalog as unknown as Record<string, ICamelDataformatDefinition>,
     );
-
-    act(() => {
-      useSchemasStore.setState({
-        schemas: {
-          camelYamlDsl: {
-            name: 'camelYamlDsl',
-            tags: ['camel'],
-            version: '1.0.0',
-            uri: '',
-            schema: yamlDslSchema as unknown as Record<string, unknown>,
-          },
-        },
-      });
-    });
 
     const visualComponentSchema: VisualComponentSchema = {
       title: 'My Node',

--- a/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.test.tsx
@@ -1,4 +1,3 @@
-import * as yamlDslSchema from '@kaoto-next/camel-catalog/camelYamlDsl.json';
 import * as languageCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-languages.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StepExpressionEditor } from './StepExpressionEditor';
@@ -7,34 +6,17 @@ import { CatalogKind, ICamelLanguageDefinition } from '../../../models';
 import { CanvasNode } from './canvas.models';
 import { JSONSchemaType } from 'ajv';
 import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { useSchemasStore } from '../../../store';
-import { act } from 'react-dom/test-utils';
 import { MetadataEditor } from '../../MetadataEditor';
 
 describe('StepExpressionEditor', () => {
   let mockNode: CanvasNode;
   beforeAll(() => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
-    delete (yamlDslSchema as any).default;
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Language,
       languageCatalog as unknown as Record<string, ICamelLanguageDefinition>,
     );
-
-    act(() => {
-      useSchemasStore.setState({
-        schemas: {
-          camelYamlDsl: {
-            name: 'camelYamlDsl',
-            tags: ['camel'],
-            version: '1.0.0',
-            uri: '',
-            schema: yamlDslSchema as unknown as Record<string, unknown>,
-          },
-        },
-      });
-    });
 
     const visualComponentSchema: VisualComponentSchema = {
       title: 'My Node',

--- a/packages/ui/src/components/Visualization/Canvas/dataformat.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/dataformat.service.test.ts
@@ -1,4 +1,3 @@
-import * as yamlDslSchema from '@kaoto-next/camel-catalog/camelYamlDsl.json';
 import * as dataformatCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-dataformats.json';
 import { CatalogKind, ICamelDataformatDefinition, ICamelLanguageDefinition } from '../../../models';
 import { CamelCatalogService } from '../../../models/visualization/flows';
@@ -7,7 +6,6 @@ import { DataFormatService } from './dataformat.service';
 describe('DataFormatService', () => {
   beforeAll(() => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
-    delete (yamlDslSchema as any).default;
     delete (dataformatCatalog as any).default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Dataformat,

--- a/packages/ui/src/models/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel-catalog-index.ts
@@ -18,6 +18,7 @@ export interface Catalogs {
   kamelets: CatalogEntry;
   kameletBoundaries: CatalogEntry;
   patterns: CatalogEntry;
+  entities: CatalogEntry;
 }
 
 export interface CatalogEntry {
@@ -47,6 +48,7 @@ export interface ComponentsCatalog {
   [CatalogKind.Component]?: Record<string, ICamelComponentDefinition>;
   [CatalogKind.Processor]?: Record<string, ICamelProcessorDefinition>;
   [CatalogKind.Pattern]?: Record<string, ICamelProcessorDefinition>;
+  [CatalogKind.Entity]?: Record<string, ICamelProcessorDefinition>;
   [CatalogKind.Language]?: Record<string, ICamelLanguageDefinition>;
   [CatalogKind.Dataformat]?: Record<string, ICamelDataformatDefinition>;
   [CatalogKind.Kamelet]?: Record<string, IKameletDefinition>;

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -2,6 +2,7 @@ export const enum CatalogKind {
   Component = 'component',
   Processor = 'processor',
   Pattern = 'pattern',
+  Entity = 'entity',
   Language = 'language',
   Dataformat = 'dataformat',
   Kamelet = 'kamelet',

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -22,6 +22,8 @@ export class CamelCatalogService {
 
   static getComponent(catalogKey: CatalogKind.Component, componentName?: string): ICamelComponentDefinition | undefined;
   static getComponent(catalogKey: CatalogKind.Processor, componentName?: string): ICamelProcessorDefinition | undefined;
+  static getComponent(catalogKey: CatalogKind.Pattern, patternName?: string): ICamelProcessorDefinition | undefined;
+  static getComponent(catalogKey: CatalogKind.Entity, entityName?: string): ICamelProcessorDefinition | undefined;
   static getComponent(catalogKey: CatalogKind.Language, languageName?: string): ICamelLanguageDefinition | undefined;
   static getComponent(
     catalogKey: CatalogKind.Dataformat,

--- a/packages/ui/src/pages/Beans/BeansPage.tsx
+++ b/packages/ui/src/pages/Beans/BeansPage.tsx
@@ -1,21 +1,21 @@
 import { TextContent } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { MetadataEditor } from '../../components/MetadataEditor';
-import { useSchemasStore } from '../../store';
 import { EntitiesContext } from '../../providers/entities.provider';
 import { BeansDeserializer } from '@kaoto-next/camel-catalog/types';
 import { EntityType } from '../../models/camel/entities';
 import { BeansEntity } from '../../models/visualization/metadata';
 import { BeansAwareResource } from '../../models/camel';
+import { CamelCatalogService, CatalogKind } from '../../models';
 
 export const BeansPage: FunctionComponent = () => {
-  const schemaMap = useSchemasStore((state) => state.schemas);
   const entitiesContext = useContext(EntitiesContext);
   const camelResource = entitiesContext?.camelResource;
 
   const beansSchema = useMemo(() => {
-    return schemaMap['beans'].schema;
-  }, [schemaMap]);
+    const beanCatalog = CamelCatalogService.getComponent(CatalogKind.Entity, 'beans');
+    return beanCatalog?.propertiesSchema;
+  }, []);
 
   const isSupported = useMemo(() => {
     return (camelResource as unknown as BeansAwareResource).createBeansEntity !== undefined;

--- a/packages/ui/src/providers/catalog.provider.tsx
+++ b/packages/ui/src/providers/catalog.provider.tsx
@@ -29,6 +29,10 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
         const camelPatternsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Pattern]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.patterns.file}`,
         );
+        /** Short list of entities to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
+        const camelEntitiesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Entity]>(
+          `${props.catalogUrl}/${catalogIndex.catalogs.entities.file}`,
+        );
         /** Camel Languages list */
         const camelLanguagesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Language]>(
           `${props.catalogUrl}/${catalogIndex.catalogs.languages.file}`,
@@ -50,6 +54,7 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
           camelComponents,
           camelModels,
           camelPatterns,
+          camelEntities,
           camelLanguages,
           camelDataformats,
           kamelets,
@@ -58,6 +63,7 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
           camelComponentsFiles,
           camelModelsFiles,
           camelPatternsFiles,
+          camelEntitiesFiles,
           camelLanguagesFiles,
           camelDataformatsFiles,
           kameletsFiles,
@@ -67,6 +73,7 @@ export const CatalogLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
         CamelCatalogService.setCatalogKey(CatalogKind.Component, camelComponents.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelModels.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatterns.body);
+        CamelCatalogService.setCatalogKey(CatalogKind.Entity, camelEntities.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
         CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, { ...kameletBoundaries.body, ...kamelets.body });


### PR DESCRIPTION
Fixes: #564

Also
- Remove unused schema usage in ui tests
- Let beans related component use entity catalog instead of the camelYamlDsl sub schema
- Introduced a flag to disable sub schema generation