### PR TITLE
fix: Missing expression editor for setHeaders EIP

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/stepConfiguration.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/stepConfiguration.cy.ts
@@ -36,10 +36,12 @@ describe('Tests for Design page', () => {
     cy.openDesignPage();
     // Configure setHeader expression
     cy.openStepConfigurationTab('setHeader');
+    cy.openExpressionModal();
     cy.selectExpression('Simple');
     cy.interactWithExpressinInputObject('expression', `{{}{{}header.baz}}`);
     cy.interactWithExpressinInputObject('id', 'simpleExpressionId');
     cy.interactWithExpressinInputObject('resultType', 'java.lang.String');
+    cy.confirmExpressionModal();
 
     // CHECK they are reflected in the code editor
     cy.openSourceCode();
@@ -82,11 +84,13 @@ describe('Tests for Design page', () => {
     cy.openDesignPage();
 
     cy.openStepConfigurationTab('setHeader');
+    cy.openExpressionModal();
     cy.selectExpression('JQ');
     cy.interactWithConfigInputObject('expression', '.id');
     cy.interactWithConfigInputObject('resultType', 'java.lang.String');
     cy.interactWithConfigInputObject('headerName', 'id');
     cy.interactWithConfigInputObject('trim');
+    cy.confirmExpressionModal();
 
     cy.selectAppendNode('setHeader');
     cy.get('[data-testid="processor-catalog-tab"]').click();
@@ -99,26 +103,32 @@ describe('Tests for Design page', () => {
     cy.checkNodeExist('setHeader', 2);
 
     cy.openStepConfigurationTab('setHeader', 1);
+    cy.openExpressionModal();
     cy.selectExpression('JQ');
     cy.interactWithConfigInputObject('expression', '.name');
     cy.interactWithConfigInputObject('resultType', 'java.lang.String');
     cy.interactWithConfigInputObject('headerName', 'name');
     cy.interactWithConfigInputObject('trim');
+    cy.confirmExpressionModal();
 
     cy.openStepConfigurationTab('setHeader', 0);
 
     // Check the configured fields didn't disappear from the first node
+    cy.openExpressionModal();
     cy.checkConfigCheckboxObject('trim', true);
     cy.checkConfigInputObject('headerName', 'id');
     cy.checkConfigInputObject('resultType', 'java.lang.String');
     cy.checkConfigInputObject('expression', '.id');
+    cy.cancelExpressionModal();
 
     // Check the configured fields didn't disappear from the second node
     cy.openStepConfigurationTab('setHeader', 0);
+    cy.openExpressionModal();
     cy.checkConfigCheckboxObject('trim', true);
     cy.checkConfigInputObject('headerName', 'name');
     cy.checkConfigInputObject('resultType', 'java.lang.String');
     cy.checkConfigInputObject('expression', '.name');
+    cy.cancelExpressionModal();
 
     // CHECK they are reflected in the code editor
     cy.openSourceCode();

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -46,6 +46,9 @@ declare global {
       checkEdgeExists(sourceName: string, targetName: string): Chainable<JQuery<Element>>;
       deleteBranch(branchIndex: number): Chainable<JQuery<Element>>;
       selectDataformat(dataformat: string): Chainable<JQuery<Element>>;
+      openExpressionModal(): Chainable<JQuery<Element>>;
+      confirmExpressionModal(): Chainable<JQuery<Element>>;
+      cancelExpressionModal(): Chainable<JQuery<Element>>;
       selectExpression(expression: string): Chainable<JQuery<Element>>;
       configureNewBeanReference(inputName: string): Chainable<JQuery<Element>>;
       configureBeanReference(inputName: string, value: string): Chainable<JQuery<Element>>;

--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -13,7 +13,7 @@ Cypress.Commands.add('closeStepConfigurationTab', () => {
 });
 
 Cypress.Commands.add('interactWithExpressinInputObject', (inputName: string, value?: string) => {
-  cy.get('[data-testid="expression-config-card"]').within(() => {
+  cy.get('[data-testid="expression-modal"]').within(() => {
     cy.interactWithConfigInputObject(inputName, value);
   });
 });
@@ -98,8 +98,22 @@ Cypress.Commands.add('deleteBranch', (branchIndex) => {
   cy.get('[data-testid="confirmDeleteBranchDialog__btn"]').click();
 });
 
+Cypress.Commands.add('openExpressionModal', () => {
+  cy.get('[data-testid="launch-expression-modal-btn"]').should('be.visible').click();
+});
+
+Cypress.Commands.add('confirmExpressionModal', () => {
+  cy.get('[data-testid="confirm-expression-modal-btn"]').should('be.visible').click();
+});
+
+Cypress.Commands.add('cancelExpressionModal', () => {
+  cy.get('[data-testid="cancel-expression-modal-btn"]').should('be.visible').click();
+});
+
 Cypress.Commands.add('selectExpression', (expression: string) => {
-  cy.selectCustomMetadataEditor('expression', expression);
+  cy.get('div[data-testid="expression-modal"] button.pf-v5-c-menu-toggle').should('be.visible').click();
+  const regex = new RegExp(`^${expression}$`);
+  cy.get('span.pf-v5-c-menu__item-text').contains(regex).should('exist').scrollIntoView().click();
 });
 
 Cypress.Commands.add('selectDataformat', (dataformat: string) => {

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -12,6 +12,7 @@ import { DisabledField } from './DisabledField';
 import { PropertiesField } from './properties/PropertiesField';
 import { BeanReferenceField } from './bean/BeanReferenceField';
 import { ExpressionField } from './expression/ExpressionField';
+import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly
@@ -30,6 +31,10 @@ export const CustomAutoField = createAutoField((props) => {
       return ExpressionField;
     }
     return PropertiesField;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (props.fieldType === Object && (props.field as any)?.type === 'object' && comment === 'expression') {
+    // The property which supports inlined expression such as `/setHeaders/headers[n]
+    return ExpressionAwareNestField;
   }
 
   switch (props.fieldType) {

--- a/packages/ui/src/components/Form/expression/ExpressionAwareNestField.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionAwareNestField.test.tsx
@@ -1,0 +1,105 @@
+import { SchemaService } from '../schema.service';
+import * as languageCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-languages.json';
+import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
+import { AutoField } from '@kaoto-next/uniforms-patternfly';
+import { AutoForm } from 'uniforms';
+import { CustomAutoFieldDetector } from '../CustomAutoField';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { ExpressionAwareNestField } from './ExpressionAwareNestField';
+
+describe('ExpressionAwareNestField', () => {
+  const mockSchema = {
+    title: 'setHeaders',
+    description: 'setHeaders',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      headers: {
+        type: 'array',
+        items: {
+          type: 'object',
+          $comment: 'expression',
+          properties: {
+            other: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  };
+  const schemaService = new SchemaService();
+  const schemaBridge = schemaService.getSchemaBridge(mockSchema);
+
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  delete (languageCatalog as any).default;
+  CamelCatalogService.setCatalogKey(
+    CatalogKind.Language,
+    languageCatalog as unknown as Record<string, ICamelLanguageDefinition>,
+  );
+
+  it('should render with a modal closed, open by click, then close by cancel button', () => {
+    render(
+      <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+        <AutoForm schema={schemaBridge!} model={{ headers: [{ expression: {} }] }}>
+          <ExpressionAwareNestField name={'headers.$'}></ExpressionAwareNestField>
+        </AutoForm>
+      </AutoField.componentDetectorContext.Provider>,
+    );
+    const link = screen.getByRole('button', { name: 'Configure Expression' });
+    expect(link).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    act(() => {
+      fireEvent.click(link);
+    });
+    expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    const cancelBtn = screen.getAllByRole('button').filter((button) => button.textContent === 'Cancel');
+    expect(cancelBtn).toHaveLength(1);
+    act(() => {
+      fireEvent.click(cancelBtn[0]);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('should render with parameters filled with passed in model, emit onChange with apply button', () => {
+    const mockOnChange = jest.fn();
+    const fieldProperties = {
+      value: { simple: { expression: '${body}', resultType: 'string' } },
+      onChange: mockOnChange,
+      field: {
+        type: 'object',
+        title: 'expression field title',
+        $comment: 'expression',
+      },
+    };
+    render(
+      <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+        <AutoForm schema={schemaBridge!} model={{}}>
+          <ExpressionAwareNestField name="headers.$" {...fieldProperties}></ExpressionAwareNestField>
+        </AutoForm>
+      </AutoField.componentDetectorContext.Provider>,
+    );
+    const link = screen.getByRole('button', { name: 'Configure Expression' });
+    act(() => {
+      fireEvent.click(link);
+    });
+
+    const expressionInput = screen
+      .getAllByRole('textbox')
+      .filter((textbox) => textbox.getAttribute('label') === 'Expression');
+    expect(expressionInput).toHaveLength(1);
+    expect(expressionInput[0].getAttribute('value')).toEqual('${body}');
+    act(() => {
+      fireEvent.input(expressionInput[0], { target: { value: '${header.foo}' } });
+    });
+
+    const applyBtn = screen.getAllByRole('button').filter((button) => button.textContent === 'Apply');
+    expect(applyBtn).toHaveLength(1);
+    expect(mockOnChange.mock.calls).toHaveLength(0);
+    act(() => {
+      fireEvent.click(applyBtn[0]);
+    });
+    expect(mockOnChange.mock.calls).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/components/Form/expression/ExpressionAwareNestField.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionAwareNestField.tsx
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
+import { Card, CardBody } from '@patternfly/react-core';
+import { AutoField, wrapField } from '@kaoto-next/uniforms-patternfly';
+import { ExpressionModalLauncher } from './ExpressionModalLauncher';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ICamelLanguageDefinition } from '../../../models';
+import { ExpressionService } from './expression.service';
+
+export type NestFieldProps = HTMLFieldProps<object, HTMLDivElement, { helperText?: string; itemProps?: object }>;
+
+export const ExpressionAwareNestField = connectField(
+  ({
+    children,
+    error,
+    errorMessage,
+    fields,
+    itemProps,
+    label,
+    name,
+    showInlineError,
+    disabled,
+    ...props
+  }: NestFieldProps) => {
+    const languageCatalogMap = useMemo(() => {
+      return ExpressionService.getLanguageMap();
+    }, []);
+    const [preparedLanguage, setPreparedLanguage] = useState<ICamelLanguageDefinition>();
+    const [preparedModel, setPreparedModel] = useState<Record<string, unknown>>({});
+
+    const resetModel = useCallback(() => {
+      const { language, model: expressionModel } = ExpressionService.parseStepExpressionModel(
+        languageCatalogMap,
+        props.value as Record<string, unknown>,
+      );
+      setPreparedLanguage(language);
+      setPreparedModel(expressionModel);
+    }, [languageCatalogMap, props.value]);
+
+    useEffect(() => {
+      resetModel();
+    }, [resetModel]);
+
+    const handleChange = useCallback(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (languageName: string, model: any) => {
+        const language = ExpressionService.getDefinitionFromModelName(languageCatalogMap, languageName);
+        setPreparedLanguage(language);
+        setPreparedModel(model);
+      },
+      [languageCatalogMap],
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleConfirm = useCallback(() => {
+      if (preparedLanguage && preparedModel) {
+        ExpressionService.setStepExpressionModel(
+          languageCatalogMap,
+          props.value as Record<string, unknown>,
+          preparedLanguage?.model.name,
+          preparedModel,
+        );
+        props.onChange(props.value);
+      }
+    }, [languageCatalogMap, preparedLanguage, preparedModel, props]);
+
+    const handleCancel = useCallback(() => {
+      resetModel();
+    }, [resetModel]);
+
+    return (
+      <Card data-testid={'nest-field'} {...filterDOMProps(props)}>
+        <CardBody className="pf-c-form">
+          {label && (
+            <label>
+              <b>{label}</b>
+            </label>
+          )}
+          {wrapField(
+            { id: 'expression-wrapper', ...itemProps },
+            <ExpressionModalLauncher
+              name={name}
+              title={label?.toString() || name}
+              language={preparedLanguage}
+              model={preparedModel}
+              onChange={handleChange}
+              onConfirm={handleConfirm}
+              onCancel={handleCancel}
+            />,
+          )}
+          {children ||
+            fields?.map((field) => <AutoField key={field} disabled={disabled} name={field} {...itemProps} />)}
+        </CardBody>
+      </Card>
+    );
+  },
+);

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
@@ -44,6 +44,7 @@ describe('ExpressionModalLauncher', () => {
       fireEvent.click(link);
     });
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    screen.debug(screen.getByRole('dialog'));
     const cancelBtn = screen.getAllByRole('button').filter((button) => button.textContent === 'Cancel');
     expect(cancelBtn).toHaveLength(1);
     act(() => {

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
@@ -1,0 +1,100 @@
+import { ExpressionModalLauncher } from './ExpressionModalLauncher';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import * as languageCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-languages.json';
+import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
+import { ExpressionService } from './expression.service';
+
+describe('ExpressionModalLauncher', () => {
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  delete (languageCatalog as any).default;
+  CamelCatalogService.setCatalogKey(
+    CatalogKind.Language,
+    languageCatalog as unknown as Record<string, ICamelLanguageDefinition>,
+  );
+
+  it('should render', () => {
+    render(
+      <ExpressionModalLauncher
+        name="test"
+        title="test"
+        language={undefined}
+        model={{}}
+        onCancel={jest.fn()}
+        onChange={jest.fn()}
+        onConfirm={jest.fn()}
+      />,
+    );
+  });
+
+  it('should render with a modal closed, open by click, then close by cancel button', () => {
+    render(
+      <ExpressionModalLauncher
+        name="expression"
+        model={{}}
+        onCancel={jest.fn()}
+        onChange={jest.fn()}
+        onConfirm={jest.fn()}
+      ></ExpressionModalLauncher>,
+    );
+    const link = screen.getByRole('button', { name: 'Configure Expression' });
+    expect(link).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    act(() => {
+      fireEvent.click(link);
+    });
+    expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    const cancelBtn = screen.getAllByRole('button').filter((button) => button.textContent === 'Cancel');
+    expect(cancelBtn).toHaveLength(1);
+    act(() => {
+      fireEvent.click(cancelBtn[0]);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('should render with parameters filled with passed in model, emit onChange with apply button', () => {
+    const model = { expression: '${body}', resultType: 'string' };
+    const language = ExpressionService.getDefinitionFromModelName(
+      languageCatalog as unknown as Record<string, ICamelLanguageDefinition>,
+      'simple',
+    );
+    const mockOnChange = jest.fn();
+    const mockOnConfirm = jest.fn();
+    const mockOnCancel = jest.fn();
+    render(
+      <ExpressionModalLauncher
+        name="expression"
+        language={language}
+        model={model}
+        onCancel={mockOnCancel}
+        onChange={mockOnChange}
+        onConfirm={mockOnConfirm}
+      ></ExpressionModalLauncher>,
+    );
+    const link = screen.getByRole('button', { name: 'Configure Expression' });
+    act(() => {
+      fireEvent.click(link);
+    });
+
+    const expressionInput = screen
+      .getAllByRole('textbox')
+      .filter((textbox) => textbox.getAttribute('label') === 'Expression');
+    expect(expressionInput).toHaveLength(1);
+    expect(expressionInput[0].getAttribute('value')).toEqual('${body}');
+    expect(mockOnChange.mock.calls).toHaveLength(0);
+    expect(mockOnConfirm.mock.calls).toHaveLength(0);
+    act(() => {
+      fireEvent.input(expressionInput[0], { target: { value: '${header.foo}' } });
+    });
+    expect(mockOnChange.mock.calls).toHaveLength(1);
+    expect(mockOnConfirm.mock.calls).toHaveLength(0);
+
+    const applyBtn = screen.getAllByRole('button').filter((button) => button.textContent === 'Apply');
+    expect(applyBtn).toHaveLength(1);
+    act(() => {
+      fireEvent.click(applyBtn[0]);
+    });
+    expect(mockOnChange.mock.calls).toHaveLength(1);
+    expect(mockOnConfirm.mock.calls).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
@@ -53,6 +53,7 @@ export const ExpressionModalLauncher = ({
         </SplitItem>
         <SplitItem>
           <Button
+            data-testid="launch-expression-modal-btn"
             variant="link"
             aria-label="Configure Expression"
             icon={<PencilAltIcon />}
@@ -63,17 +64,17 @@ export const ExpressionModalLauncher = ({
       <Modal
         isOpen={isModalOpen}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        data-testid={`ExpressionModal-${name}`}
+        data-testid={`expression-modal`}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         title={title ? `${title}` : 'Expression'}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         description={description}
         onClose={onCancel}
         actions={[
-          <Button key="confirm" variant="primary" onClick={handleOnConfirm}>
+          <Button data-testid="confirm-expression-modal-btn" key="confirm" variant="primary" onClick={handleOnConfirm}>
             Apply
           </Button>,
-          <Button key="cancel" variant="link" onClick={handleOnCancel}>
+          <Button data-testid="cancel-expression-modal-btn" key="cancel" variant="link" onClick={handleOnCancel}>
             Cancel
           </Button>,
         ]}

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
@@ -1,0 +1,90 @@
+import { Button, Modal, Split, SplitItem, TextInput } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { ExpressionEditor } from './ExpressionEditor';
+import { useState } from 'react';
+import { ICamelLanguageDefinition } from '../../../models';
+
+export type ExpressionModalLauncherProps = {
+  name: string;
+  title?: string;
+  language?: ICamelLanguageDefinition;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onChange: (languageName: string, model: any) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export const ExpressionModalLauncher = ({
+  name,
+  title,
+  language,
+  model,
+  onChange,
+  onConfirm,
+  onCancel,
+}: ExpressionModalLauncherProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOnConfirm = () => {
+    setIsModalOpen(false);
+    onConfirm();
+  };
+
+  const handleOnCancel = () => {
+    setIsModalOpen(false);
+    onCancel();
+  };
+
+  const description = title ? `Configure expression for "${title}" parameter` : 'Configure expression';
+  const expressionLabel = language && model?.expression ? language.model.name + ': ' + model.expression : '';
+
+  return (
+    <>
+      <Split>
+        <SplitItem>
+          <TextInput
+            id={'expression-preview-' + name}
+            placeholder="Not configured"
+            readOnlyVariant="default"
+            value={expressionLabel}
+          ></TextInput>
+        </SplitItem>
+        <SplitItem>
+          <Button
+            variant="link"
+            aria-label="Configure Expression"
+            icon={<PencilAltIcon />}
+            onClick={() => setIsModalOpen(true)}
+          ></Button>
+        </SplitItem>
+      </Split>
+      <Modal
+        isOpen={isModalOpen}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data-testid={`ExpressionModal-${name}`}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        title={title ? `${title}` : 'Expression'}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        description={description}
+        onClose={onCancel}
+        actions={[
+          <Button key="confirm" variant="primary" onClick={handleOnConfirm}>
+            Apply
+          </Button>,
+          <Button key="cancel" variant="link" onClick={handleOnCancel}>
+            Cancel
+          </Button>,
+        ]}
+        ouiaId="ExpressionModal"
+      >
+        <ExpressionEditor
+          expressionModel={model}
+          language={language}
+          onChangeExpressionModel={onChange}
+        ></ExpressionEditor>
+      </Modal>
+    </>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.test.tsx
@@ -65,8 +65,10 @@ describe('StepExpressionEditor', () => {
 
   it('should render', () => {
     render(<StepExpressionEditor selectedNode={mockNode} />);
-    const buttons = screen.getAllByRole('button');
-    fireEvent.click(buttons[1]);
+    const launcherButton = screen.getAllByRole('button', { name: 'Configure Expression' });
+    fireEvent.click(launcherButton[0]);
+    const dropdownButton = screen.getAllByRole('button').filter((button) => button.textContent === 'Simple');
+    fireEvent.click(dropdownButton[0]);
     const jsonpath = screen.getByTestId('expression-dropdownitem-jsonpath');
     fireEvent.click(jsonpath.getElementsByTagName('button')[0]);
     const form = screen.getByTestId('metadata-editor-form-expression');

--- a/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepExpressionEditor.tsx
@@ -1,10 +1,9 @@
-import { Card, CardBody, CardExpandableContent, CardHeader, CardTitle } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { EntitiesContext } from '../../../providers';
 import { CanvasNode } from './canvas.models';
 import { ExpressionService } from '../../Form/expression/expression.service';
-import { ExpressionEditor } from '../../Form/expression/ExpressionEditor';
 import { ICamelLanguageDefinition } from '../../../models';
+import { ExpressionModalLauncher } from '../../Form/expression/ExpressionModalLauncher';
 
 interface StepExpressionEditorProps {
   selectedNode: CanvasNode;
@@ -12,7 +11,6 @@ interface StepExpressionEditorProps {
 
 export const StepExpressionEditor: FunctionComponent<StepExpressionEditorProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
-  const [isExpanded, setIsExpanded] = useState(true);
   const languageCatalogMap = useMemo(() => {
     return ExpressionService.getLanguageMap();
   }, []);
@@ -20,7 +18,7 @@ export const StepExpressionEditor: FunctionComponent<StepExpressionEditorProps> 
   const [preparedLanguage, setPreparedLanguage] = useState<ICamelLanguageDefinition>();
   const [preparedModel, setPreparedModel] = useState<Record<string, unknown>>({});
 
-  useEffect(() => {
+  const resetModel = useCallback(() => {
     const visualComponentSchema = props.selectedNode.data?.vizNode?.getComponentSchema();
     if (visualComponentSchema) {
       if (!visualComponentSchema.definition) {
@@ -33,39 +31,45 @@ export const StepExpressionEditor: FunctionComponent<StepExpressionEditorProps> 
     );
     setPreparedLanguage(language);
     setPreparedModel(expressionModel);
-  }, [languageCatalogMap, props.selectedNode]);
+  }, [languageCatalogMap, props.selectedNode.data?.vizNode]);
+
+  useEffect(() => {
+    resetModel();
+  }, [resetModel]);
 
   const handleOnChange = useCallback(
     (selectedLanguage: string, newExpressionModel: Record<string, unknown>) => {
       const language = ExpressionService.getDefinitionFromModelName(languageCatalogMap, selectedLanguage);
       setPreparedLanguage(language);
       setPreparedModel(newExpressionModel);
-      const model = props.selectedNode.data?.vizNode?.getComponentSchema()?.definition;
-      if (!model) return;
-      ExpressionService.setStepExpressionModel(languageCatalogMap, model, selectedLanguage, newExpressionModel);
-      props.selectedNode.data?.vizNode?.updateModel(model);
-      entitiesContext?.updateSourceCodeFromEntities();
     },
-    [entitiesContext, languageCatalogMap, props.selectedNode.data?.vizNode],
+    [languageCatalogMap],
   );
 
+  const handleConfirm = useCallback(() => {
+    const model = props.selectedNode.data?.vizNode?.getComponentSchema()?.definition || {};
+    if (preparedLanguage && preparedModel) {
+      ExpressionService.setStepExpressionModel(languageCatalogMap, model, preparedLanguage.model.name, preparedModel);
+      props.selectedNode.data?.vizNode?.updateModel(model);
+      entitiesContext?.updateSourceCodeFromEntities();
+    }
+  }, [entitiesContext, languageCatalogMap, preparedLanguage, preparedModel, props.selectedNode.data?.vizNode]);
+
+  const handleCancel = useCallback(() => {
+    resetModel();
+  }, [resetModel]);
+
   return (
-    languageCatalogMap &&
-    preparedLanguage && (
-      <Card isCompact={true} isExpanded={isExpanded}>
-        <CardHeader onExpand={() => setIsExpanded(!isExpanded)}>
-          <CardTitle>Expression</CardTitle>
-        </CardHeader>
-        <CardExpandableContent>
-          <CardBody data-testid={'expression-config-card'}>
-            <ExpressionEditor
-              expressionModel={preparedModel}
-              language={preparedLanguage}
-              onChangeExpressionModel={handleOnChange}
-            ></ExpressionEditor>
-          </CardBody>
-        </CardExpandableContent>
-      </Card>
+    languageCatalogMap && (
+      <ExpressionModalLauncher
+        name={props.selectedNode.id}
+        title={props.selectedNode.label}
+        language={preparedLanguage}
+        model={preparedModel}
+        onChange={handleOnChange}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
     )
   );
 };


### PR DESCRIPTION
Fixes: #577

fix: Align Step expression configuration to be modal style
Fixes: #523

fix: Expression property: Show expression string in main config form
Fixes: #568

https://github.com/KaotoIO/kaoto-next/assets/265462/45089899-c8cf-45c9-9a2e-e7130681f0bf


