### PR TITLE
add new bean modal story

### DIFF
--- a/packages/ui-tests/stories/canvas/NewBeanModal.stories.tsx
+++ b/packages/ui-tests/stories/canvas/NewBeanModal.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryFn } from '@storybook/react';
+import {
+  CatalogLoaderProvider,
+  CatalogSchemaLoader,
+  SchemasLoaderProvider,
+  NewBeanModal,
+} from '@kaoto-next/ui/testing';
+
+export default {
+  title: 'Canvas/NewBeanModal',
+  component: NewBeanModal,
+  decorators: [
+    (Story: StoryFn) => (
+      <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <Story />
+        </CatalogLoaderProvider>
+      </SchemasLoaderProvider>
+    ),
+  ],
+} as Meta<typeof NewBeanModal>;
+
+const Template: StoryFn<typeof NewBeanModal> = (args) => {
+  return <NewBeanModal {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  isOpen: true,
+  onCancelCreateBean: () => {},
+  onCreateBean: () => {},
+  propertyTitle: 'sample',
+  javaType: 'org.apache.camel.spi.ExceptionHandler',
+};

--- a/packages/ui/src/components/Form/bean/index.ts
+++ b/packages/ui/src/components/Form/bean/index.ts
@@ -1,0 +1,1 @@
+export * from './NewBeanModal';

--- a/packages/ui/src/components/Form/index.ts
+++ b/packages/ui/src/components/Form/index.ts
@@ -1,1 +1,2 @@
 export * from './schema.service';
+export * from './bean';

--- a/packages/ui/src/public-api.ts
+++ b/packages/ui/src/public-api.ts
@@ -1,6 +1,7 @@
 /** Public components */
 export * from './components/Catalog';
 export * from './components/InlineEdit';
+export * from './components/Form';
 export * from './components/PropertiesModal';
 export * from './components/Visualization';
 export * from './components/Visualization/Canvas';


### PR DESCRIPTION
Add storybook story for the new bean modal, which can be now used from the design view for adding new beans.