### PR TITLE
fix(windows): Copying Catalog on Windows is not working

### DIFF
--- a/packages/ui/scripts/get-camel-catalog-files.js
+++ b/packages/ui/scripts/get-camel-catalog-files.js
@@ -41,7 +41,7 @@ export const getCamelCatalogFiles = () => {
   /** List all the JSON files in the Camel Catalog folder */
   const jsonFiles = readdirSync(camelCatalogPath)
     .filter((file) => file.endsWith('.json'))
-    .map((file) => join(camelCatalogPath, file));
+    .map((file) => normalizePath(join(camelCatalogPath, file)));
 
   return jsonFiles;
 };


### PR DESCRIPTION
fix: https://github.com/KaotoIO/kaoto-next/issues/598