### PR TITLE
chore: mention requirements to Java 21 in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Before you start contributing, ensure that you have the following installed:
 
 - NodeJS (>v18.x)
 - yarn (>v3.x)
+- Java 21+
 
 ### Setting Up the Project
 


### PR DESCRIPTION
Java 21 is required when building the project. It is used to create the Camel catalog at build time.