### PR TITLE
fix(windows): Fix running unit tests in Windows

### DIFF
--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -191,7 +191,11 @@ export default {
   // transform: undefined,
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['\\\\node_modules\\\\'],
+  transformIgnorePatterns: [
+    // A RegExp to exclude `@patternfly/*` and `yaml` packages from the transformation ignore
+    // This means that both packages will be transformed by babel to support ES modules
+    '\\\\node_modules/(?!(@patternfly|yaml)/)\\\\',
+  ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -22,6 +22,8 @@
     /* Typings */
     "types": [
       "@testing-library/jest-dom",
+      "@types/jest",
+      "@types/node",
     ]
   },
   "include": ["src"],

--- a/packages/ui/tsconfig.node.json
+++ b/packages/ui/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.cjs"]
+  "include": ["vite.config.js"]
 }


### PR DESCRIPTION
Currently, the `yaml` package is written using ESM modules. This seems to cause an error in Windows environment during unit tests, requiring to transform said modules into CJS modules.

The workaround is to ignore the babel transform for the `yaml` package, effectively parsing it with babel.