### PR TITLE
fix(603) - e2e stability improvement. cy -breaking up a chain

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -127,7 +127,8 @@ Cypress.Commands.add('selectCustomMetadataEditor', (type: string, format: string
 });
 
 Cypress.Commands.add('configureNewBeanReference', (inputName: string) => {
-  cy.get(`[data-fieldname="${inputName}"]`).scrollIntoView().click();
+  cy.get(`[data-fieldname="${inputName}"]`).scrollIntoView();
+  cy.get(`[data-fieldname="${inputName}"]`).click();
   cy.get('#select-typeahead-kaoto-create-new').click();
 });
 


### PR DESCRIPTION
should improve e2e stability - related to https://github.com/KaotoIO/kaoto-next/issues/603 

based on cy recommendation:

```
...

You can typically solve this by breaking up a chain. For example, rewrite:

> `cy.get('button').click().click()`

to

> `cy.get('button').as('btn').click()`
> `cy.get('@btn').click()`
...
```