### PR TITLE
fix(619): Update onClose event handler in ExpressionModalLauncher

### DIFF
--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
@@ -99,3 +99,26 @@ describe('ExpressionModalLauncher', () => {
     expect(mockOnConfirm.mock.calls).toHaveLength(1);
   });
 });
+
+it('should close the modal when the close button is clicked', () => {
+  render(
+    <ExpressionModalLauncher
+      name="test"
+      title="test"
+      language={undefined}
+      model={{}}
+      onCancel={jest.fn()}
+      onChange={jest.fn()}
+      onConfirm={jest.fn()}
+    />,
+  );
+  const link = screen.getByRole('button', { name: 'Configure Expression' });
+  act(() => {
+    fireEvent.click(link);
+  });
+  const closeButton = screen.getByLabelText('Close');
+  act(() => {
+    fireEvent.click(closeButton);
+  });
+  expect(screen.queryByRole('dialog')).toBeNull();
+});

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
@@ -69,7 +69,7 @@ export const ExpressionModalLauncher = ({
         title={title ? `${title}` : 'Expression'}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         description={description}
-        onClose={onCancel}
+        onClose={handleOnCancel}
         actions={[
           <Button data-testid="confirm-expression-modal-btn" key="confirm" variant="primary" onClick={handleOnConfirm}>
             Apply


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/619