### PR TITLE
chore(viz-entity): Restore class hierarchy between Abstract and implementation

### DIFF
--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -7,6 +7,7 @@ import { NodeIconResolver } from '../../../utils/node-icon-resolver';
 import { DefinedComponent } from '../../camel-catalog-index';
 import {
   AddStepMode,
+  BaseVisualCamelEntity,
   IVisualizationNode,
   IVisualizationNodeData,
   NodeInteraction,
@@ -20,9 +21,19 @@ import {
   CamelRouteVisualEntityData,
   ICamelElementLookupResult,
 } from './support/camel-component-types';
+import { EntityType } from '../../camel/entities';
 
-export abstract class AbstractCamelVisualEntity {
+export abstract class AbstractCamelVisualEntity implements BaseVisualCamelEntity {
   constructor(public route: RouteDefinition) {}
+
+  abstract id: string;
+  abstract type: EntityType;
+  abstract setId(id: string): void;
+  protected abstract getRootUri(): string | undefined;
+
+  getId(): string {
+    return this.id;
+  }
 
   getNodeLabel(path?: string): string {
     if (!path) return '';
@@ -196,7 +207,21 @@ export abstract class AbstractCamelVisualEntity {
     };
   }
 
-  getVizNodeFromProcessor(path: string, componentLookup: ICamelElementLookupResult): IVisualizationNode {
+  toVizNode(): IVisualizationNode {
+    const rootNode = this.getVizNodeFromProcessor('from', {
+      processorName: 'from' as keyof ProcessorDefinition,
+      componentName: CamelComponentSchemaService.getComponentNameFromUri(this.getRootUri()!),
+    });
+    rootNode.data.entity = this;
+
+    if (!this.getRootUri()) {
+      rootNode.data.icon = NodeIconResolver.getPlaceholderIcon();
+    }
+
+    return rootNode;
+  }
+
+  private getVizNodeFromProcessor(path: string, componentLookup: ICamelElementLookupResult): IVisualizationNode {
     const data: CamelRouteVisualEntityData = {
       path,
       icon: NodeIconResolver.getIcon(CamelComponentSchemaService.getIconName(componentLookup)),

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-case-declarations */
-import { FromDefinition, ProcessorDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { FromDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
-import { NodeIconResolver, isDefined } from '../../../utils';
+import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities';
-import { BaseVisualCamelEntity, IVisualizationNode } from '../base-visual-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 
 /** Very basic check to determine whether this object is a Camel Route */
@@ -37,7 +35,7 @@ export const isCamelFrom = (rawEntity: unknown): rawEntity is { from: FromDefini
   return isFromHolder && isValidUriField && isValidStepsArray;
 };
 
-export class CamelRouteVisualEntity extends AbstractCamelVisualEntity implements BaseVisualCamelEntity {
+export class CamelRouteVisualEntity extends AbstractCamelVisualEntity {
   id: string;
   readonly type = EntityType.Route;
 
@@ -46,27 +44,14 @@ export class CamelRouteVisualEntity extends AbstractCamelVisualEntity implements
     this.id = route.id ?? getCamelRandomId('route');
     this.route.id = this.id;
   }
+
   /** Internal API methods */
   setId(routeId: string): void {
     this.id = routeId;
     this.route.id = this.id;
   }
 
-  getId(): string {
-    return this.id;
-  }
-
-  toVizNode(): IVisualizationNode {
-    const rootNode = this.getVizNodeFromProcessor('from', {
-      processorName: 'from' as keyof ProcessorDefinition,
-      componentName: CamelComponentSchemaService.getComponentNameFromUri(this.route.from!.uri),
-    });
-    rootNode.data.entity = this;
-
-    if (!this.route.from?.uri) {
-      rootNode.data.icon = NodeIconResolver.getPlaceholderIcon();
-    }
-
-    return rootNode;
+  protected getRootUri(): string | undefined {
+    return this.route.from?.uri;
   }
 }

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,16 +1,12 @@
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 /* eslint-disable no-case-declarations */
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
 import { IKameletDefinition, IKameletMetadata, IKameletSpec } from '../..';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
-import { NodeIconResolver } from '../../../utils';
 import { EntityType } from '../../camel/entities';
-import { BaseVisualCamelEntity, IVisualizationNode } from '../base-visual-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
-export class KameletVisualEntity extends AbstractCamelVisualEntity implements BaseVisualCamelEntity {
+export class KameletVisualEntity extends AbstractCamelVisualEntity {
   id: string;
-  type = EntityType.Kamelet;
+  readonly type = EntityType.Kamelet;
   spec: IKameletSpec;
   metadata: IKameletMetadata;
 
@@ -22,25 +18,12 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity implements Ba
   }
 
   /** Internal API methods */
-  getId(): string {
-    return this.id;
-  }
-
   setId(routeId: string): void {
     this.id = routeId;
     this.metadata.name = this.id;
   }
 
-  toVizNode(): IVisualizationNode {
-    const rootNode = this.getVizNodeFromProcessor('from', {
-      processorName: 'from' as keyof ProcessorDefinition,
-      componentName: CamelComponentSchemaService.getComponentNameFromUri(this.spec.template.from!.uri),
-    });
-    rootNode.data.entity = this;
-
-    if (!this.spec.template.from?.uri) {
-      rootNode.data.icon = NodeIconResolver.getPlaceholderIcon();
-    }
-    return rootNode;
+  protected getRootUri(): string | undefined {
+    return this.spec.template.from?.uri;
   }
 }


### PR DESCRIPTION
### Context
After creating the AbstractCamelVisualEntiy class, the connection between the BaseVisualCamelEntity and its implementation has been lost due to the Abstract class not implementing the said interface.

This PR updates the Abstract class to implement the interface and also consolidates the `toVizNode` method since it's the same between both `CamelRouteVisualEntity` and `KameletVisualEntity`.