### PR TITLE
feat(form): Parse URI field upon configuring step

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -56,7 +56,17 @@ export function getNonEmptyProperties(obj: Record<string, unknown>): Record<stri
   return { ...obj, parameters: Object.fromEntries(result) };
 }
 
-const omitFields = ['expression', 'dataFormatType', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally'];
+const omitFields = [
+  'expression',
+  'dataFormatType',
+  'outputs',
+  'steps',
+  'when',
+  'otherwise',
+  'doCatch',
+  'doFinally',
+  'uri',
+];
 
 export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -477,7 +477,11 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
 exports[`CamelComponentSchemaService getVisualComponentSchema should transform a string-based \`To\` processor 1`] = `
 {
   "definition": {
-    "uri": "bean:myBean?method=hello",
+    "parameters": {
+      "beanName": "myBean",
+      "method": "hello",
+    },
+    "uri": "bean",
   },
   "schema": {
     "additionalProperties": false,
@@ -497,6 +501,53 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "description": "Sets the id of this node",
         "title": "Id",
         "type": "string",
+      },
+      "parameters": {
+        "description": "Endpoint properties description",
+        "properties": {
+          "beanName": {
+            "deprecated": false,
+            "description": "Sets the name of the bean to invoke",
+            "title": "Bean Name",
+            "type": "string",
+          },
+          "lazyStartProducer": {
+            "default": false,
+            "deprecated": false,
+            "description": "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing.",
+            "title": "Lazy Start Producer",
+            "type": "boolean",
+          },
+          "method": {
+            "deprecated": false,
+            "description": "Sets the name of the method to invoke on the bean",
+            "title": "Method",
+            "type": "string",
+          },
+          "parameters": {
+            "deprecated": false,
+            "description": "Used for configuring additional properties on the bean",
+            "title": "Parameters",
+            "type": "object",
+          },
+          "scope": {
+            "default": "Singleton",
+            "deprecated": false,
+            "description": "Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you want to store state on a bean while processing a request and you want to call the same bean instance multiple times while processing the request. The bean does not have to be thread-safe as the instance is only called from the same request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act as either singleton or prototype scope. so when using prototype then this depends on the delegated registry.",
+            "enum": [
+              "Singleton",
+              "Request",
+              "Prototype",
+            ],
+            "title": "Scope",
+            "type": "string",
+          },
+        },
+        "required": [
+          "beanName",
+        ],
+        "title": "Endpoint Properties",
+        "type": "object",
       },
       "pattern": {
         "description": "Sets the optional ExchangePattern used to invoke this endpoint",
@@ -518,9 +569,116 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
 exports[`CamelComponentSchemaService getVisualComponentSchema should transform a string-based \`ToD\` processor 1`] = `
 {
   "definition": {
-    "uri": "bean:myBean?method=hello",
+    "parameters": {
+      "beanName": "myBean",
+      "method": "hello",
+    },
+    "uri": "bean",
   },
-  "schema": {},
+  "schema": {
+    "additionalProperties": false,
+    "description": "Sends the message to a dynamic endpoint",
+    "properties": {
+      "allowOptimisedComponents": {
+        "description": "Whether to allow components to optimise toD if they are org.apache.camel.spi.SendDynamicAware .",
+        "title": "Allow Optimised Components",
+        "type": "boolean",
+      },
+      "autoStartComponents": {
+        "description": "Whether to auto startup components when toD is starting up.",
+        "title": "Auto Start Components",
+        "type": "boolean",
+      },
+      "cacheSize": {
+        "description": "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this recipient list, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers.",
+        "title": "Cache Size",
+        "type": "number",
+      },
+      "description": {
+        "description": "Sets the description of this node",
+        "title": "Description",
+        "type": "string",
+      },
+      "disabled": {
+        "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime.",
+        "title": "Disabled",
+        "type": "boolean",
+      },
+      "id": {
+        "description": "Sets the id of this node",
+        "title": "Id",
+        "type": "string",
+      },
+      "ignoreInvalidEndpoint": {
+        "description": "Whether to ignore invalid endpoint URIs and skip sending the message.",
+        "title": "Ignore Invalid Endpoint",
+        "type": "boolean",
+      },
+      "parameters": {
+        "description": "Endpoint properties description",
+        "properties": {
+          "beanName": {
+            "deprecated": false,
+            "description": "Sets the name of the bean to invoke",
+            "title": "Bean Name",
+            "type": "string",
+          },
+          "lazyStartProducer": {
+            "default": false,
+            "deprecated": false,
+            "description": "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing.",
+            "title": "Lazy Start Producer",
+            "type": "boolean",
+          },
+          "method": {
+            "deprecated": false,
+            "description": "Sets the name of the method to invoke on the bean",
+            "title": "Method",
+            "type": "string",
+          },
+          "parameters": {
+            "deprecated": false,
+            "description": "Used for configuring additional properties on the bean",
+            "title": "Parameters",
+            "type": "object",
+          },
+          "scope": {
+            "default": "Singleton",
+            "deprecated": false,
+            "description": "Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you want to store state on a bean while processing a request and you want to call the same bean instance multiple times while processing the request. The bean does not have to be thread-safe as the instance is only called from the same request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act as either singleton or prototype scope. so when using prototype then this depends on the delegated registry.",
+            "enum": [
+              "Singleton",
+              "Request",
+              "Prototype",
+            ],
+            "title": "Scope",
+            "type": "string",
+          },
+        },
+        "required": [
+          "beanName",
+        ],
+        "title": "Endpoint Properties",
+        "type": "object",
+      },
+      "pattern": {
+        "description": "Sets the optional ExchangePattern used to invoke this endpoint",
+        "enum": [
+          "InOnly",
+          "InOut",
+        ],
+        "title": "Pattern",
+        "type": "string",
+      },
+      "uri": {
+        "description": "The uri of the endpoint to send to. The uri can be dynamic computed using the org.apache.camel.language.simple.SimpleLanguage expression.",
+        "title": "Uri",
+        "type": "string",
+      },
+    },
+    "title": "To D",
+    "type": "object",
+  },
   "title": "toD",
 }
 `;

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -23,8 +23,13 @@ describe('CamelUriHelper', () => {
 
   describe('uriSyntaxToParameters', () => {
     it.each([
+      { syntax: undefined, uri: undefined, result: {} },
+      { syntax: 'log:loggerName', uri: undefined, result: {} },
+      { syntax: undefined, uri: 'log:myLogger', result: {} },
       { syntax: 'log:loggerName', uri: 'log:myLogger', result: { loggerName: 'myLogger' } },
+      { syntax: 'log:loggerName', uri: 'log', result: {} },
       { syntax: 'log', uri: 'log:myLogger', result: {} },
+      { syntax: 'as2:apiName/methodName', uri: 'as2', result: {} },
       {
         syntax: 'timer:timerName',
         uri: 'timer:timer-1?period=5000&delay=5&synchronous=true',
@@ -63,7 +68,7 @@ describe('CamelUriHelper', () => {
       {
         syntax: 'avro:transport:host:port/messageName',
         uri: 'avro:::/',
-        result: { transport: '', host: '', port: '', messageName: '' },
+        result: {},
       },
       {
         syntax: 'aws2-eventbridge://eventbusNameOrArn',

--- a/packages/ui/src/utils/get-parsed-value.test.ts
+++ b/packages/ui/src/utils/get-parsed-value.test.ts
@@ -4,6 +4,8 @@ describe('getParsedValue', () => {
   it.each([
     ['true', true],
     ['false', false],
+    [undefined, ''],
+    ['undefined', 'undefined'],
     ['1', 1],
     ['0', 0],
     ['1.5', 1.5],

--- a/packages/ui/src/utils/get-parsed-value.ts
+++ b/packages/ui/src/utils/get-parsed-value.ts
@@ -1,7 +1,12 @@
-export const getParsedValue = (value: string): string | boolean | number => {
+export const getParsedValue = (value?: string): string | boolean | number => {
   /** Try to parse the boolean values */
   if (value === 'true' || value === 'false') {
     return value === 'true';
+  }
+
+  /** Undefined values gets transformed into an empty string */
+  if (value === undefined) {
+    return '';
   }
 
   /** Try to parse the number values */


### PR DESCRIPTION
## To ease testing, this pull request [is deployed here](https://lordrip.github.io/kaoto-next)

### Context
Currently, we're not parsing the URI field from the `from`, `to`, and the `toD` Camel processors.

### Changes
This pull request adds support for the URI field in the following fashion:
Considering the following `URI`: `timer:timer-1?period=5000&delay=5&synchronous=true`, when configuring the `timer` component, we parse the `URI` using the component's syntax (in this case is `timer:timerName`) and set those values in the parameter object. After the parsing, the `URI` field is cleaned to avoid overriding the parameter's value again. The result of this parsing is: `{ timerName: 'timer-1', period: 5000, delay: 5, synchronous: true }`.

In addition to that, we're hiding the URI field to prevent the user from manipulating it for the time being. This decision needs to be revisited later to check how can dynamic expressions be supported.

In a more practical example, given this `yaml` route example:
```yaml
- from:
    uri: timer:timer-1?period=5000&delay=5&synchronous=true
    steps: []
```

after configuring the `timer` component, we'll end up with the following route:
```yaml
- route:
    from:
      uri: timer
      steps: []
      parameters:
        period: 5000
        delay: "50"
        synchronous: true
    id: route-3338
```

fix: https://github.com/KaotoIO/kaoto-next/issues/274