### PR TITLE
fix(form): Improve vertical spacing for form

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.scss
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.scss
@@ -1,0 +1,12 @@
+/*
+  This is required since there's a div between the form
+  element and its children that breaks the following styles
+    - display: grid
+    - gap: var(--pf-c-form--GridGap)
+  from @patternfly and making the fields very close to
+  each other
+*/
+form[data-testid='autoform'] > div {
+  display: inherit;
+  gap: inherit;
+}

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -10,6 +10,7 @@ import { DataFormatEditor } from './DataFormatEditor';
 import { StepExpressionEditor } from './StepExpressionEditor';
 import { CanvasNode } from './canvas.models';
 import { LoadBalancerEditor } from './LoadBalancerEditor';
+import './CanvasForm.scss';
 
 interface CanvasFormProps {
   selectedNode: CanvasNode;
@@ -118,7 +119,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
         {isExpressionAwareStep && <StepExpressionEditor selectedNode={props.selectedNode} />}
         {isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}
         {isLoadBalanceAwareStep && <LoadBalancerEditor selectedNode={props.selectedNode} />}
-        <AutoForm ref={formRef} schema={schema} model={model} onChangeModel={handleOnChange}>
+        <AutoForm ref={formRef} schema={schema} model={model} onChangeModel={handleOnChange} data-testid="autoform">
           <AutoFields omitFields={omitFields} />
           <ErrorsField />
         </AutoForm>

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`CanvasForm should render 1`] = `
   </h1>
   <form
     class="pf-v5-c-form"
-    data-testid="base-form"
+    data-testid="autoform"
     novalidate=""
   >
     <div>


### PR DESCRIPTION
### Context
Currently, there's not much spacing between form fields for processors.

### Changes
This commit adds more spacing between them by enforcing the patternfly form spacing.

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/3e5153e5-021a-4700-8d23-7074413f4711) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/6e9b21f8-0a59-48fa-a4d1-30ac8cd7c6f4) |

### Notes
There's a different situation for the nested parameters (forms like `to: timer:myTimer`) since they are not individual forms but rather a child of the main one, so the layout mechanism is different. This will be improved in an upcoming PR.

fix: https://github.com/KaotoIO/kaoto-next/issues/618