### PR TITLE
feat(sourcecode): Sort Camel Routes parameters

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/branchingStepAddition.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/branchingStepAddition.cy.ts
@@ -51,6 +51,7 @@ describe('Test for Branching actions from the canvas', () => {
     cy.checkNodeExist('otherwise', 1);
 
     cy.openSourceCode();
+    cy.editorScrollToTop();
     cy.checkCodeSpanLine('choice:', 1);
     cy.checkCodeSpanLine('otherwise:', 1);
   });

--- a/packages/ui/src/hooks/entities.ts
+++ b/packages/ui/src/hooks/entities.ts
@@ -57,7 +57,7 @@ export const useEntities = (): EntitiesContextResult => {
   }, [eventNotifier]);
 
   const updateSourceCodeFromEntities = useCallback(() => {
-    const code = stringify(camelResource) || '';
+    const code = stringify(camelResource, { sortMapEntries: camelResource.sortFn }) || '';
     eventNotifier.next('entities:updated', code);
   }, [camelResource, eventNotifier]);
 

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -10,6 +10,7 @@ import { MetadataEntity } from '../visualization/metadata';
 import { CamelResource } from './camel-resource';
 import { BaseCamelEntity } from './entities';
 import { SourceSchemaType } from './source-schema-type';
+import { createCamelPropertiesSorter } from '../../utils';
 
 export type CamelKType = IntegrationType | IKameletDefinition | KameletBindingType | PipeType;
 
@@ -23,6 +24,8 @@ export enum CamelKResourceKinds {
 export const CAMEL_K_K8S_API_VERSION_V1 = 'camel.apache.org/v1';
 
 export abstract class CamelKResource implements CamelResource {
+  static readonly PARAMETERS_ORDER = ['apiVersion', 'kind', 'metadata', 'spec', 'source', 'steps', 'sink'];
+  readonly sortFn = createCamelPropertiesSorter(CamelKResource.PARAMETERS_ORDER) as (a: unknown, b: unknown) => number;
   protected resource: CamelKType;
   private metadata?: MetadataEntity;
 

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -31,6 +31,8 @@ export interface CamelResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter | undefined;
+
+  sortFn?: (a: unknown, b: unknown) => number;
 }
 
 export interface BeansAwareResource {

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -1,6 +1,6 @@
 import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
-import { isDefined } from '../../utils';
+import { createCamelPropertiesSorter, isDefined } from '../../utils';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from '../visualization/flows';
 import { FlowTemplateService } from '../visualization/flows/flow-templates-service';
@@ -13,6 +13,11 @@ import { SourceSchemaType } from './source-schema-type';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
 
 export class CamelRouteResource implements CamelResource, BeansAwareResource {
+  static readonly PARAMETERS_ORDER = ['id', 'description', 'uri', 'parameters', 'steps'];
+  readonly sortFn = createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (
+    a: unknown,
+    b: unknown,
+  ) => number;
   private entities: BaseCamelEntity[] = [];
 
   constructor(json?: unknown) {

--- a/packages/ui/src/utils/__snapshots__/create-camel-properties-sorter.test.ts.snap
+++ b/packages/ui/src/utils/__snapshots__/create-camel-properties-sorter.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`camelPropertiesSorter should sort Pipes 1`] = `
+"apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: pipe-1748
+spec:
+  source:
+    ref:
+      apiVersion: camel.apache.org/v1
+      kind: Kamelet
+      name: timer-source
+      properties:
+        message: hello
+        repeatCount: jjj
+  steps:
+    - ref:
+        apiVersion: camel.apache.org/v1
+        kind: Kamelet
+        name: delay-action
+        properties:
+          milliseconds: "100"
+  sink:
+    ref:
+      apiVersion: camel.apache.org/v1
+      kind: Kamelet
+      name: log-sink
+"
+`;
+
+exports[`camelPropertiesSorter should sort the Camel Route 1`] = `
+"- route:
+    id: route-1398
+    from:
+      id: "1"
+      description: my descriptio
+      uri: timer
+      parameters:
+        delay: "{{delay}}"
+        fixedRate: true
+        includeMetadata: true
+        period: 50.75
+        synchronous: true
+        timerName: timer-1-1
+      steps:
+        - to:
+            id: to-8385
+            uri: amqp
+            parameters:
+              disableReplyTo: true
+              synchronous: true
+              transferException: true
+        - to:
+            id: to-2786
+            uri: whatsapp
+            parameters:
+              baseUri: /
+              lazyStartProducer: true
+"
+`;

--- a/packages/ui/src/utils/create-camel-properties-sorter.test.ts
+++ b/packages/ui/src/utils/create-camel-properties-sorter.test.ts
@@ -1,0 +1,81 @@
+import { Pair, parse, stringify } from 'yaml';
+import { CamelRouteResource } from '../models/camel';
+import { CamelKResource } from '../models/camel/camel-k-resource';
+import { createCamelPropertiesSorter } from './create-camel-properties-sorter';
+
+describe('camelPropertiesSorter', () => {
+  it('should sort the Camel Route', () => {
+    const camelRouteYaml = `
+- route:
+    id: route-1398
+    from:
+      description: my descriptio
+      uri: timer
+      id: "1"
+      steps:
+        - to:
+            parameters:
+              disableReplyTo: true
+              synchronous: true
+              transferException: true
+            uri: amqp
+            id: to-8385
+        - to:
+            id: to-2786
+            uri: whatsapp
+            parameters:
+              baseUri: /
+              lazyStartProducer: true
+      parameters:
+        delay: "{{delay}}"
+        fixedRate: true
+        includeMetadata: true
+        period: 50.75
+        synchronous: true
+        timerName: timer-1-1`;
+
+    const rawObject = parse(camelRouteYaml);
+
+    const result = stringify(rawObject, {
+      sortMapEntries: createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (a: Pair, b: Pair) => number,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should sort Pipes', () => {
+    const pipeYaml = `
+    spec:
+      steps:
+        - ref:
+            apiVersion: camel.apache.org/v1
+            kind: Kamelet
+            name: delay-action
+            properties:
+              milliseconds: "100"
+      sink:
+        ref:
+          apiVersion: camel.apache.org/v1
+          kind: Kamelet
+          name: log-sink
+      source:
+        ref:
+          apiVersion: camel.apache.org/v1
+          kind: Kamelet
+          name: timer-source
+          properties:
+            message: hello
+            repeatCount: jjj
+    kind: Pipe
+    metadata:
+      name: pipe-1748
+    apiVersion: camel.apache.org/v1`;
+
+    const rawObject = parse(pipeYaml);
+    const result = stringify(rawObject, {
+      sortMapEntries: createCamelPropertiesSorter(CamelKResource.PARAMETERS_ORDER) as (a: Pair, b: Pair) => number,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/utils/create-camel-properties-sorter.ts
+++ b/packages/ui/src/utils/create-camel-properties-sorter.ts
@@ -1,0 +1,33 @@
+import { Pair } from 'yaml';
+
+export type PairKey = { value: string };
+/**
+ * Sort properties in a Apache Camel friendly format.
+ *
+ * The order goes as follows:
+ *   1. `id` prop
+ *   2. `description` prop
+ *   3. `uri` prop
+ *   4. `parameters` prop
+ *   5. `steps` prop
+ *   6. the remaining properties in alphabetical order
+ */
+export const createCamelPropertiesSorter =
+  (order: string[]) => (a: Pair<PairKey, unknown>, b: Pair<PairKey, unknown>) => {
+    const aIndex = order.indexOf(a.key.value);
+    const bIndex = order.indexOf(b.key.value);
+
+    if (aIndex === -1 && bIndex === -1) {
+      return a.key.value.localeCompare(b.key.value);
+    }
+
+    if (aIndex === -1) {
+      return 1;
+    }
+
+    if (bIndex === -1) {
+      return -1;
+    }
+
+    return aIndex - bIndex;
+  };

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './create-camel-properties-sorter';
 export * from './camel-uri-helper';
 export * from './catalog-schema-loader';
 export * from './event-notifier';


### PR DESCRIPTION
### Context
Currently, the order assigned to the YAML output is determined through the order of the properties' definition, meaning that for an object with a single `id` property, after creating another property, the order will be:

```yaml
id: something
anotherProperty: something else
```

Ideally, we should follow a consistent order to simplify the diffing between the route's versions.

### Changes
This commit adds an intermediate step that sorts the parameters in the following order:

```
 *   1. `id` prop
 *   2. `description` prop
 *   3. `uri` prop
 *   4. `parameters` prop
 *   5. `steps` prop
 *   6. the remaining properties in alphabetical order
```

Later on, we might want to sort the `parameters` object using the order defined in the Camel Catalog.

### Notes
* Inspired by: https://github.com/eemeli/yaml/issues/44

fix: https://github.com/KaotoIO/kaoto-next/issues/639