### PR TITLE
fix(309): Add codeblock to unknown node

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -1,15 +1,16 @@
 import { AutoField, AutoFields, AutoForm, ErrorsField } from '@kaoto-next/uniforms-patternfly';
-import { Title } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockCode, Title } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { stringify } from 'yaml';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import { ErrorBoundary } from '../../ErrorBoundary';
 import { SchemaService } from '../../Form';
 import { CustomAutoFieldDetector } from '../../Form/CustomAutoField';
+import './CanvasForm.scss';
 import { DataFormatEditor } from './DataFormatEditor';
+import { LoadBalancerEditor } from './LoadBalancerEditor';
 import { StepExpressionEditor } from './StepExpressionEditor';
 import { CanvasNode } from './canvas.models';
-import { LoadBalancerEditor } from './LoadBalancerEditor';
-import './CanvasForm.scss';
 
 interface CanvasFormProps {
   selectedNode: CanvasNode;
@@ -70,18 +71,28 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
     return schema?.schema && schema.schema['$comment']?.includes('loadbalance');
   }, [schema]);
 
-  return schema?.schema === undefined ? null : (
+  const isUnknownComponent = useMemo(() => {
+    return schema?.schema === undefined || Object.keys(schema?.schema).length === 0;
+  }, [schema]);
+
+  return (
     <ErrorBoundary key={props.selectedNode.id} fallback={<p>This node cannot be configured yet</p>}>
-      <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
-        <Title headingLevel="h1">{componentName}</Title>
-        {isExpressionAwareStep && <StepExpressionEditor selectedNode={props.selectedNode} />}
-        {isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}
-        {isLoadBalanceAwareStep && <LoadBalancerEditor selectedNode={props.selectedNode} />}
-        <AutoForm ref={formRef} schema={schema} model={model} onChangeModel={handleOnChange} data-testid="autoform">
-          <AutoFields omitFields={omitFields} />
-          <ErrorsField />
-        </AutoForm>
-      </AutoField.componentDetectorContext.Provider>
+      <Title headingLevel="h1">{componentName}</Title>
+      {isUnknownComponent ? (
+        <CodeBlock>
+          <CodeBlockCode>{stringify(model)}</CodeBlockCode>
+        </CodeBlock>
+      ) : (
+        <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+          {isExpressionAwareStep && <StepExpressionEditor selectedNode={props.selectedNode} />}
+          {isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}
+          {isLoadBalanceAwareStep && <LoadBalancerEditor selectedNode={props.selectedNode} />}
+          <AutoForm ref={formRef} schema={schema} model={model} onChangeModel={handleOnChange} data-testid="autoform">
+            <AutoFields omitFields={omitFields} />
+            <ErrorsField />
+          </AutoForm>
+        </AutoField.componentDetectorContext.Provider>
+      )}
     </ErrorBoundary>
   );
 };

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -78,6 +78,59 @@ exports[`CanvasForm should render 1`] = `
 </div>
 `;
 
-exports[`CanvasForm should render nothing if no schema and no definition is available 1`] = `<div />`;
+exports[`CanvasForm should render nothing if no schema and no definition is available 1`] = `
+<div>
+  <h1
+    class="pf-v5-c-title pf-m-2xl"
+    data-ouia-component-id="OUIA-Generated-Title-3"
+    data-ouia-component-type="PF5/Title"
+    data-ouia-safe="true"
+  >
+    My Node
+  </h1>
+  <div
+    class="pf-v5-c-code-block"
+  >
+    <div
+      class="pf-v5-c-code-block__content"
+    >
+      <pre
+        class="pf-v5-c-code-block__pre"
+      >
+        <code
+          class="pf-v5-c-code-block__code"
+        >
+          null
 
-exports[`CanvasForm should render nothing if no schema is available 1`] = `<div />`;
+        </code>
+      </pre>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CanvasForm should render nothing if no schema is available 1`] = `
+<div>
+  <h1
+    class="pf-v5-c-title pf-m-2xl"
+    data-ouia-component-id="OUIA-Generated-Title-2"
+    data-ouia-component-type="PF5/Title"
+    data-ouia-safe="true"
+  />
+  <div
+    class="pf-v5-c-code-block"
+  >
+    <div
+      class="pf-v5-c-code-block__content"
+    >
+      <pre
+        class="pf-v5-c-code-block__pre"
+      >
+        <code
+          class="pf-v5-c-code-block__code"
+        />
+      </pre>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/309

@lordrip I tried both - the `<pre>` with `<code>` and the PF `CodeBlock` - I believe using `CodeBlock` the yaml code gets more highlighted, but I can change to the originally proposed solution.

Also I wanted to ask, whether we should add some info, regarding the displayed block of code - I was thinking about, to be consistent - something like [FieldLabelIcon](https://github.com/KaotoIO/kaoto-next/blob/091655c5f92744596d96173885d34fefeab53539/packages/ui/src/components/Form/FieldLabelIcon.tsx#L17) qestionmark with popover, containing information, regarding the displayed yaml and some info, regarding the node itself - that the name is not correct and needs to be changed in source code, or replaced in the canvas. 
Let me know, what do you think.