### PR TITLE
fix(kamelets): Edit Kamelets' nodes properties

### DIFF
--- a/packages/ui/src/models/camel/__snapshots__/camel-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/camel-resource.test.ts.snap
@@ -6,10 +6,20 @@ exports[`createCamelResource should create an empty KameletResource if no args i
     "route": {
       "from": {
         "id": "from-1234",
-        "steps": [],
-        "uri": "kamelet:source",
+        "parameters": {
+          "period": "{{period}}",
+        },
+        "steps": [
+          {
+            "to": "https://random-data-api.com/api/v2/users",
+          },
+          {
+            "to": "kamelet:sink",
+          },
+        ],
+        "uri": "timer:user",
       },
-      "id": undefined,
+      "id": "kamelet-1234",
     },
   },
 ]

--- a/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
@@ -4,18 +4,58 @@ exports[`KameletResource should convert to JSON 1`] = `
 {
   "apiVersion": "camel.apache.org/v1",
   "kind": "Kamelet",
+  "metadata": {
+    "annotations": {
+      "camel.apache.org/catalog.version": "main-SNAPSHOT",
+      "camel.apache.org/kamelet.group": "Users",
+      "camel.apache.org/kamelet.icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K",
+      "camel.apache.org/kamelet.support.level": "Stable",
+      "camel.apache.org/provider": "Apache Software Foundation",
+    },
+    "labels": {
+      "camel.apache.org/kamelet.type": "source",
+    },
+    "name": "kamelet-1234",
+  },
   "spec": {
     "definition": {
+      "description": "Produces periodic events about random users!",
+      "properties": {
+        "period": {
+          "default": 5000,
+          "description": "The time interval between two events",
+          "title": "Period",
+          "type": "integer",
+        },
+      },
       "title": "kamelet-1234",
-      "type": "source",
+      "type": "object",
     },
-    "dependencies": [],
+    "dependencies": [
+      "camel:timer",
+      "camel:http",
+      "camel:kamelet",
+    ],
     "template": {
-      "beans": {},
       "from": {
         "id": "from-1234",
-        "steps": [],
-        "uri": "kamelet:source",
+        "parameters": {
+          "period": "{{period}}",
+        },
+        "steps": [
+          {
+            "to": "https://random-data-api.com/api/v2/users",
+          },
+          {
+            "to": "kamelet:sink",
+          },
+        ],
+        "uri": "timer:user",
+      },
+    },
+    "types": {
+      "out": {
+        "mediaType": "application/json",
       },
     },
   },
@@ -26,18 +66,58 @@ exports[`KameletResource should create a new KameletResource 1`] = `
 {
   "apiVersion": "camel.apache.org/v1",
   "kind": "Kamelet",
+  "metadata": {
+    "annotations": {
+      "camel.apache.org/catalog.version": "main-SNAPSHOT",
+      "camel.apache.org/kamelet.group": "Users",
+      "camel.apache.org/kamelet.icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K",
+      "camel.apache.org/kamelet.support.level": "Stable",
+      "camel.apache.org/provider": "Apache Software Foundation",
+    },
+    "labels": {
+      "camel.apache.org/kamelet.type": "source",
+    },
+    "name": "kamelet-1234",
+  },
   "spec": {
     "definition": {
+      "description": "Produces periodic events about random users!",
+      "properties": {
+        "period": {
+          "default": 5000,
+          "description": "The time interval between two events",
+          "title": "Period",
+          "type": "integer",
+        },
+      },
       "title": "kamelet-1234",
-      "type": "source",
+      "type": "object",
     },
-    "dependencies": [],
+    "dependencies": [
+      "camel:timer",
+      "camel:http",
+      "camel:kamelet",
+    ],
     "template": {
-      "beans": {},
       "from": {
         "id": "from-1234",
-        "steps": [],
-        "uri": "kamelet:source",
+        "parameters": {
+          "period": "{{period}}",
+        },
+        "steps": [
+          {
+            "to": "https://random-data-api.com/api/v2/users",
+          },
+          {
+            "to": "kamelet:sink",
+          },
+        ],
+        "uri": "timer:user",
+      },
+    },
+    "types": {
+      "out": {
+        "mediaType": "application/json",
       },
     },
   },
@@ -85,10 +165,20 @@ exports[`KameletResource should get the visual entities (Camel Route Visual Enti
     "route": {
       "from": {
         "id": "from-1234",
-        "steps": [],
-        "uri": "kamelet:source",
+        "parameters": {
+          "period": "{{period}}",
+        },
+        "steps": [
+          {
+            "to": "https://random-data-api.com/api/v2/users",
+          },
+          {
+            "to": "kamelet:sink",
+          },
+        ],
+        "uri": "timer:user",
       },
-      "id": undefined,
+      "id": "kamelet-1234",
     },
   },
 ]

--- a/packages/ui/src/models/visualization/flows/templates/kamelet.ts
+++ b/packages/ui/src/models/visualization/flows/templates/kamelet.ts
@@ -3,7 +3,7 @@ import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
 export const kameletTemplate = () => {
   const kameletId = getCamelRandomId('kamelet');
 
-  return `apiVersion: camel.apache.org/v1alpha1
+  return `apiVersion: camel.apache.org/v1
 kind: Kamelet
 metadata:
   name: ${kameletId}


### PR DESCRIPTION
### Context
Currently, Kamelets' nodes can't be edited using the Canvas Form, causing the changes made by the user, are not serialized into the source code.

This bug was caused due to a problem in the serialization of the `KameletResource`, because despite the `Canvas Form` editing the `KameletVisualEntity` correctly, what ultimately was serialized was the original `Kamelet` without changes.

### Changes
The fix is to ensure that we're serializing the
`KameletVisualEntity.from` as part of the resulting `KameletResource.toJSON()` method.

### Notes
This change opens up a more broad topic about `Kamelets`, at this moment, the `KameletVisualEntity` class has knowledge about the underlying flow (`kamelet.spec.template.from`) and its metadata (`kamelet.metadata`), and this shouldn't be the case.

Ideally, `KameletVisualEntity` would have knowledge about the flow only but the issue with this is that it will close the possibility of renaming the flow, as the `setId` method is defined in the `KameletVisualEntity` class. A solution for this could be to create an intermediate `setId` functionality in the `CamelResource` interface itself which will later on delegate the change to the underlying `VisualEntities.setId()` method if necessary, this way, in case of `Kamelets` and `Pipes`, we have the chance to update its metadata and also the underlying flow.

In addition to that, it would be convenient to offer a mechanism to sort the properties of the underlying `VisualEntities`, this way we could sort the entire `Kamelet` in a `kubernetes` friendly way and also keep the underlying `Camel Route` sorted differently. This will be discussed in: https://github.com/KaotoIO/kaoto-next/issues/652

fix: https://github.com/KaotoIO/kaoto-next/issues/594