### PR TITLE
fix(pipe): Set Pipe's properties in the right place

### DIFF
--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -75,9 +75,17 @@ describe('Pipe', () => {
     it('should update the model', () => {
       const name = 'webhook-source';
 
-      pipe.updateModel('source.ref.name', name);
+      pipe.updateModel('source', { name });
 
-      expect(pipe.spec?.source?.ref?.name).toEqual(name);
+      expect(pipe.spec?.source?.properties?.name).toEqual(name);
+    });
+
+    it('should not update the model if the path is not correct', () => {
+      const name = 'webhook-source';
+
+      pipe.updateModel('nonExistingPath', { name });
+
+      expect(pipe.spec?.source?.properties).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -65,7 +65,7 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
     if (!path) return;
 
     const stepModel = get(this.spec, path) as PipeStep;
-    if (stepModel) set(stepModel, 'ref.properties', value);
+    if (stepModel) set(stepModel, 'properties', value);
   }
 
   getSteps() {

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/kamelet-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/kamelet-schema.service.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KameletSchemaService should build the appropriate schema for kamelets 1`] = `
+exports[`KameletSchemaService getVisualComponentSchema should build the appropriate schema for kamelets 1`] = `
 {
   "definition": {},
   "schema": {
@@ -21,7 +21,7 @@ exports[`KameletSchemaService should build the appropriate schema for kamelets 1
 }
 `;
 
-exports[`KameletSchemaService should build the appropriate schema for kamelets with required properties 1`] = `
+exports[`KameletSchemaService getVisualComponentSchema should build the appropriate schema for kamelets with required properties 1`] = `
 {
   "definition": {},
   "schema": {
@@ -54,7 +54,7 @@ exports[`KameletSchemaService should build the appropriate schema for kamelets w
 }
 `;
 
-exports[`KameletSchemaService should provide a default empty string if the kamelet name is not found 1`] = `
+exports[`KameletSchemaService getVisualComponentSchema should provide a default empty string if the kamelet name is not found 1`] = `
 {
   "definition": {},
   "schema": {
@@ -72,5 +72,11 @@ exports[`KameletSchemaService should provide a default empty string if the kamel
     "type": "object",
   },
   "title": "",
+}
+`;
+
+exports[`KameletSchemaService getVisualComponentSchema should retrieve the properties from the step 1`] = `
+{
+  "foo": "bar",
 }
 `;

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
@@ -19,74 +19,93 @@ describe('KameletSchemaService', () => {
     CamelCatalogService.clearCatalogs();
   });
 
-  it('should return undefined when step is undefined', () => {
-    expect(KameletSchemaService.getVisualComponentSchema(undefined)).toBeUndefined();
-  });
-
-  it('should build the appropriate schema for kamelets', () => {
-    const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
-
-    const result = KameletSchemaService.getVisualComponentSchema({
-      ref: {
-        kind: 'Kamelet',
-        apiVersion: 'camel.apache.org/v1',
-        name: 'beer-source',
-      },
+  describe('getVisualComponentSchema', () => {
+    it('should return undefined when step is undefined', () => {
+      expect(KameletSchemaService.getVisualComponentSchema(undefined)).toBeUndefined();
     });
 
-    expect(camelCatalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source');
-    expect(result).toMatchSnapshot();
-  });
+    it('should build the appropriate schema for kamelets', () => {
+      const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
 
-  it('should build the appropriate schema for kamelets with required properties', () => {
-    const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
-
-    const result = KameletSchemaService.getVisualComponentSchema({
-      ref: {
-        kind: 'Kamelet',
-        apiVersion: 'camel.apache.org/v1',
-        name: 'xj-template-action',
-      },
-    });
-
-    expect(camelCatalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Kamelet, 'xj-template-action');
-    expect(result).toMatchSnapshot();
-  });
-
-  it('should provide a default empty string if the kamelet name is not found', () => {
-    const namelessKamelet = cloneDeep((kameletCatalogMap as any)['beer-source']);
-    namelessKamelet.metadata.name = undefined as unknown as string;
-    jest.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce(namelessKamelet);
-
-    const result = KameletSchemaService.getVisualComponentSchema({
-      ref: {
-        kind: 'Kamelet',
-        apiVersion: 'camel.apache.org/v1',
-        name: 'beer-source',
-      },
-    });
-
-    expect(result).toMatchSnapshot();
-  });
-
-  it('should return the Kamelet name as the node label', () => {
-    const result = KameletSchemaService.getNodeLabel(
-      {
+      const result = KameletSchemaService.getVisualComponentSchema({
         ref: {
           kind: 'Kamelet',
           apiVersion: 'camel.apache.org/v1',
           name: 'beer-source',
         },
-      },
-      'source',
-    );
+      });
 
-    expect(result).toEqual('beer-source');
+      expect(camelCatalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should build the appropriate schema for kamelets with required properties', () => {
+      const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
+
+      const result = KameletSchemaService.getVisualComponentSchema({
+        ref: {
+          kind: 'Kamelet',
+          apiVersion: 'camel.apache.org/v1',
+          name: 'xj-template-action',
+        },
+      });
+
+      expect(camelCatalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Kamelet, 'xj-template-action');
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should provide a default empty string if the kamelet name is not found', () => {
+      const namelessKamelet = cloneDeep((kameletCatalogMap as any)['beer-source']);
+      namelessKamelet.metadata.name = undefined as unknown as string;
+      jest.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce(namelessKamelet);
+
+      const result = KameletSchemaService.getVisualComponentSchema({
+        ref: {
+          kind: 'Kamelet',
+          apiVersion: 'camel.apache.org/v1',
+          name: 'beer-source',
+        },
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should retrieve the properties from the step', () => {
+      const result = KameletSchemaService.getVisualComponentSchema({
+        ref: {
+          kind: 'Kamelet',
+          apiVersion: 'camel.apache.org/v1',
+          name: 'beer-source',
+        },
+        properties: {
+          foo: 'bar',
+        },
+      });
+
+      expect(result?.definition).toMatchSnapshot();
+    });
   });
 
-  it('should return the Kamelet name as the node label', () => {
-    const result = KameletSchemaService.getNodeLabel(undefined, 'sink');
+  describe('getNodeLabel', () => {
+    it('should return the Kamelet name as the node label', () => {
+      const result = KameletSchemaService.getNodeLabel(
+        {
+          ref: {
+            kind: 'Kamelet',
+            apiVersion: 'camel.apache.org/v1',
+            name: 'beer-source',
+          },
+        },
+        'source',
+      );
 
-    expect(result).toEqual('sink: Unknown');
+      expect(result).toEqual('beer-source');
+    });
+
+    it('should return the Kamelet name as the node label', () => {
+      const result = KameletSchemaService.getNodeLabel(undefined, 'sink');
+
+      expect(result).toEqual('sink: Unknown');
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
@@ -16,7 +16,7 @@ export class KameletSchemaService {
     return {
       title: definition?.metadata.name || '',
       schema: definition?.propertiesSchema || ({} as JSONSchemaType<unknown>),
-      definition: stepModel?.ref?.properties || {},
+      definition: stepModel?.properties || {},
     };
   }
 


### PR DESCRIPTION
### Context
Currently, `Pipe`'s properties are being set inside the `ref` property, which is not correct.

### Changes
This commit updates the logic to set the `properties` in the root `properties` property.

fix: https://github.com/KaotoIO/kaoto-next/issues/653