### PR TITLE
fix(form): Ignore non-required URI parameters

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -266,12 +266,23 @@ export class CamelComponentSchemaService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static applyParametersFromSyntax(componentName: string, definition: any) {
     const componentDefinition = CamelCatalogService.getComponent(CatalogKind.Component, componentName);
-    const parametersFromSynax = CamelUriHelper.uriSyntaxToParameters(
+
+    const requiredParameters: string[] = [];
+    if (componentDefinition?.properties !== undefined) {
+      Object.entries(componentDefinition.properties).forEach(([key, value]) => {
+        if (value.required) {
+          requiredParameters.push(key);
+        }
+      });
+    }
+
+    const parametersFromSyntax = CamelUriHelper.uriSyntaxToParameters(
       componentDefinition?.component.syntax,
       definition?.uri,
+      { requiredParameters },
     );
     definition.parameters = definition.parameters ?? {};
     definition.uri = this.getComponentNameFromUri(definition.uri);
-    Object.assign(definition.parameters, parametersFromSynax);
+    Object.assign(definition.parameters, parametersFromSyntax);
   }
 }

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -75,8 +75,29 @@ describe('CamelUriHelper', () => {
         uri: 'aws2-eventbridge://arn:aws:iam::123456789012:user/johndoe',
         result: { eventbusNameOrArn: 'arn:aws:iam::123456789012:user/johndoe' },
       },
-    ])('for an URI: `$uri`, using the syntax: `$syntax`, should return `$result`', ({ syntax, uri, result }) => {
-      expect(CamelUriHelper.uriSyntaxToParameters(syntax, uri)).toEqual(result);
-    });
+      {
+        syntax: 'jms:destinationType:destinationName',
+        uri: 'jms:queue:myQueue?selector=foo',
+        result: { destinationType: 'queue', destinationName: 'myQueue', selector: 'foo' },
+        requiredParameters: ['destinationName'],
+      },
+      {
+        syntax: 'jms:destinationType:destinationName',
+        uri: 'jms:myQueue',
+        result: { destinationName: 'myQueue' },
+        requiredParameters: ['destinationName'],
+      },
+      {
+        syntax: 'jms:destinationType:destinationName',
+        uri: 'jms:myQueue?selector=foo',
+        result: { destinationName: 'myQueue', selector: 'foo' },
+        requiredParameters: ['destinationName'],
+      },
+    ])(
+      'for an URI: `$uri`, using the syntax: `$syntax`, should return `$result`',
+      ({ syntax, uri, result, requiredParameters }) => {
+        expect(CamelUriHelper.uriSyntaxToParameters(syntax, uri, { requiredParameters })).toEqual(result);
+      },
+    );
   });
 });


### PR DESCRIPTION
### Context
There are special cases where some URI parameters are not required, so the user didn't provide them.

This is the case for the `jms`, `amqp`, and `activemq` components, where the `destinationType` is not required so that the user can provide the `destinationName` directly.

### Changes
In this situation, if the values array length matches the required parameters array length, we can remove the non-required keys to match the values with the keys.

fix: https://github.com/KaotoIO/kaoto-next/issues/654