### PR TITLE
Add help fields for error handler

### DIFF
--- a/packages/camel-catalog/assembly/src/main/resources/schemas/PipeErrorHandler.json
+++ b/packages/camel-catalog/assembly/src/main/resources/schemas/PipeErrorHandler.json
@@ -24,10 +24,12 @@
             "type": "object",
             "properties": {
               "maximumRedeliveries": {
-                "type": "number"
+                "type": "number",
+                "description" : "Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever"
               },
               "redeliveryDelay": {
-                "type": "number"
+                "type": "number",
+                "description" : "Sets the maximum delay between redelivery"
               }
             },
             "additionalProperties": {
@@ -83,10 +85,12 @@
             "type": "object",
             "properties": {
               "maximumRedeliveries": {
-                "type": "number"
+                "type": "number",
+                "description" : "Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever"
               },
               "redeliveryDelay": {
-                "type": "number"
+                "type": "number",
+                "description" : "Sets the maximum delay between redelivery"
               }
             },
             "additionalProperties": {


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/656

descriptions used from `camelYamlDsl-errorHandler.json`

```
        "maximumRedeliveries" : {
          "type" : "number",
          "title" : "Maximum Redeliveries",
          "description" : "Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever"
        },
        "maximumRedeliveryDelay" : {
          "type" : "string",
          "title" : "Maximum Redelivery Delay",
          "description" : "Sets the maximum delay between redelivery"
```