### PR TITLE
feat: Hide navigation items

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
     "@types/uuid": "^9.0.2",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
+    "clsx": "^2.1.0",
     "html-to-image": "^1.11.11",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",

--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -1,9 +1,9 @@
 import { Nav, NavExpandable, NavItem, NavList, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
+import clsx from 'clsx';
 import { FunctionComponent } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Links } from '../router/links.models';
 import { NavElements } from './navigation.models';
-
 interface INavigationSidebar {
   isNavOpen: boolean;
 }
@@ -22,6 +22,7 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
                   <NavExpandable
                     id={nav.title}
                     key={nav.title}
+                    className={clsx({ 'pf-v5-u-hidden': nav.hidden })}
                     title={nav.title}
                     groupId={nav.title}
                     isActive={nav.children.some((child) => child.to === currentLocation.pathname)}
@@ -32,6 +33,7 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
                         id={child.title}
                         key={child.title}
                         itemId={index}
+                        className={clsx({ 'pf-v5-u-hidden': child.hidden })}
                         isActive={currentLocation.pathname === child.to}
                       >
                         <Link data-testid={child.title} to={child.to}>
@@ -44,7 +46,13 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
               }
 
               return (
-                <NavItem id={nav.title} key={nav.title} itemId={index} isActive={currentLocation.pathname === nav.to}>
+                <NavItem
+                  id={nav.title}
+                  className={clsx({ 'pf-v5-u-hidden': nav.hidden })}
+                  key={nav.title}
+                  itemId={index}
+                  isActive={currentLocation.pathname === nav.to}
+                >
                   <Link data-testid={nav.title} to={nav.to}>
                     {nav.title}
                   </Link>
@@ -67,7 +75,7 @@ const navElements: NavElements = [
     ],
   },
   { title: 'Beans', to: Links.Beans },
-  { title: 'Rest', to: Links.Rest },
+  { title: 'Rest', to: Links.Rest, hidden: true },
   { title: 'Metadata', to: Links.Metadata },
   { title: 'Pipe ErrorHandler', to: Links.PipeErrorHandler },
   { title: 'Catalog', to: Links.Catalog },

--- a/packages/ui/src/layout/navigation.models.ts
+++ b/packages/ui/src/layout/navigation.models.ts
@@ -9,11 +9,13 @@ export interface SelectedNavItem {
 interface SingleNavElement {
   title: string;
   to: Links;
+  hidden?: boolean;
 }
 
 interface NestedNavElement {
   title: string;
   children: SingleNavElement[];
+  hidden?: boolean;
 }
 
 export type NavElements = Array<SingleNavElement | NestedNavElement>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,6 +2651,7 @@ __metadata:
     ajv: ^8.12.0
     ajv-formats: ^2.1.1
     babel-jest: ^29.4.2
+    clsx: ^2.1.0
     copyfiles: ^2.4.1
     eslint: ^8.45.0
     eslint-config-prettier: ^9.0.0
@@ -8280,6 +8281,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "clsx@npm:2.1.0"
+  checksum: 43fefc29b6b49c9476fbce4f8b1cc75c27b67747738e598e6651dd40d63692135dc60b18fa1c5b78a2a9ba8ae6fd2055a068924b94e20b42039bd53b78b98e1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Fix**: https://github.com/KaotoIO/kaoto-next/issues/670

This PR adds the functionality to hide elements in the navigation bar.

The following are the screenshots showcasing the implementation:

1. Rest nav item _visible_ - current
<img width="1470" alt="Screenshot 2024-01-18 at 15 47 22" src="https://github.com/KaotoIO/kaoto-next/assets/17992718/056b9a13-4dc3-48d0-8820-011efaf56ee0">

2. Rest nav item _hidden_ - expected
<img width="1470" alt="Screenshot 2024-01-18 at 15 47 06" src="https://github.com/KaotoIO/kaoto-next/assets/17992718/50cdfa79-f567-4742-be60-aed192f4dbfd">

**Additional**
- I also expanded the functionality to hide `NestedNavElement`
<img width="1470" alt="Screenshot 2024-01-18 at 15 47 42" src="https://github.com/KaotoIO/kaoto-next/assets/17992718/b3911459-92e8-44ab-80c8-a0b620551afc">

- and nested elements
<img width="1470" alt="Screenshot 2024-01-18 at 15 47 34" src="https://github.com/KaotoIO/kaoto-next/assets/17992718/a77e4484-cb31-4846-b536-05773e07ff25">

I hope this helps and kindly let me know if there's another preferred approach. 🙏 
