### PR TITLE
fix(form): Improve URI parsing for Kamelets

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -158,7 +158,7 @@ describe('CamelRouteResource', () => {
     });
   });
 
-  describe.only('toJson', () => {
+  describe('toJson', () => {
     it.each([
       [camelRouteJson],
       [camelFromJson],

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -1,11 +1,21 @@
-import { ComponentsCatalog } from '../../camel-catalog-index';
+import componentCatalogMap from '@kaoto-next/camel-catalog/camel-catalog-aggregate-components.json';
+import dataformatsCatalogMap from '@kaoto-next/camel-catalog/camel-catalog-aggregate-dataformats.json';
+import languagesCatalogMap from '@kaoto-next/camel-catalog/camel-catalog-aggregate-languages.json';
+import loadbalancersMap from '@kaoto-next/camel-catalog/camel-catalog-aggregate-loadbalancers.json';
+import kameletCatalogMap from '@kaoto-next/camel-catalog/kamelets-aggregate.json';
+import { ICamelComponentDefinition } from '../../camel-components-catalog';
+import { ICamelLanguageDefinition } from '../../camel-languages-catalog';
 import { CatalogKind } from '../../catalog-kind';
+import { IKameletDefinition } from '../../kamelets-catalog';
 import { CamelCatalogService } from './camel-catalog.service';
 
 describe('CamelCatalogService', () => {
-  const catalog = {
-    'component-1': 'random value',
-  } as unknown as ComponentsCatalog[CatalogKind.Component];
+  beforeEach(() => {
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Component,
+      componentCatalogMap as unknown as Record<string, ICamelComponentDefinition>,
+    );
+  });
 
   afterEach(() => {
     CamelCatalogService.clearCatalogs();
@@ -13,29 +23,106 @@ describe('CamelCatalogService', () => {
 
   describe('getCatalogByKey', () => {
     it('should return the catalog', () => {
-      CamelCatalogService.setCatalogKey(CatalogKind.Component, catalog);
-
       const result = CamelCatalogService.getCatalogByKey(CatalogKind.Component);
 
-      expect(result).toEqual(catalog);
+      expect(result).toEqual(componentCatalogMap);
     });
   });
 
   describe('getComponent', () => {
     it('should return the component', () => {
-      CamelCatalogService.setCatalogKey(CatalogKind.Component, catalog);
+      const component = CamelCatalogService.getComponent(CatalogKind.Component, 'timer');
 
-      const component = CamelCatalogService.getComponent(CatalogKind.Component, 'component-1');
-
-      expect(component).toEqual('random value');
+      expect(component?.component.name).toEqual('timer');
+      expect(component).toEqual((componentCatalogMap as Record<string, unknown>).timer);
     });
 
     it('should return `undefined` for an `undefined` component name', () => {
-      CamelCatalogService.setCatalogKey(CatalogKind.Component, catalog);
-
       const component = CamelCatalogService.getComponent(CatalogKind.Component);
 
       expect(component).toBeUndefined();
+    });
+  });
+
+  describe('getLanguageMap', () => {
+    it('should return an empty object if there is no language map', () => {
+      const map = CamelCatalogService.getLanguageMap();
+      expect(map).toEqual({});
+    });
+
+    it('should return a language map', () => {
+      CamelCatalogService.setCatalogKey(
+        CatalogKind.Language,
+        languagesCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
+      );
+
+      const map = CamelCatalogService.getLanguageMap();
+      expect(map).toEqual(languagesCatalogMap);
+    });
+  });
+
+  describe('getDataFormatMap', () => {
+    it('should return an empty object if there is no data format map', () => {
+      const map = CamelCatalogService.getDataFormatMap();
+      expect(map).toEqual({});
+    });
+
+    it('should return a data format map', () => {
+      CamelCatalogService.setCatalogKey(
+        CatalogKind.Dataformat,
+        dataformatsCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
+      );
+
+      const map = CamelCatalogService.getDataFormatMap();
+      expect(map).toEqual(dataformatsCatalogMap);
+    });
+  });
+
+  describe('getLoadBalancerMap', () => {
+    it('should return an empty object if there is no load balancer map', () => {
+      const map = CamelCatalogService.getLoadBalancerMap();
+      expect(map).toEqual({});
+    });
+
+    it('should return a load balancer map', () => {
+      CamelCatalogService.setCatalogKey(
+        CatalogKind.Loadbalancer,
+        loadbalancersMap as unknown as Record<string, ICamelLanguageDefinition>,
+      );
+
+      const map = CamelCatalogService.getLoadBalancerMap();
+      expect(map).toEqual(loadbalancersMap);
+    });
+  });
+
+  describe('getCatalogLookup', () => {
+    it('should return `undefined` for an empty string component name', () => {
+      const lookup = CamelCatalogService.getCatalogLookup('');
+
+      expect(lookup).toBeUndefined();
+    });
+
+    it('should return a component from the catalog lookup', () => {
+      const lookup = CamelCatalogService.getCatalogLookup('timer');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Component,
+        definition: (componentCatalogMap as Record<string, unknown>).timer,
+      });
+    });
+
+    it('should return a kamelet from the catalog lookup', () => {
+      CamelCatalogService.setCatalogKey(
+        CatalogKind.Kamelet,
+        kameletCatalogMap as unknown as Record<string, IKameletDefinition>,
+      );
+
+      const lookup = CamelCatalogService.getCatalogLookup('kamelet:chuck-norris-source');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Kamelet,
+        definition: (kameletCatalogMap as Record<string, unknown>)['chuck-norris-source'],
+      });
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -2,10 +2,10 @@ import { ComponentsCatalog, ComponentsCatalogTypes } from '../../camel-catalog-i
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
 import { ICamelDataformatDefinition } from '../../camel-dataformats-catalog';
 import { ICamelLanguageDefinition } from '../../camel-languages-catalog';
+import { ICamelLoadBalancerDefinition } from '../../camel-loadbalancers-catalog';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { IKameletDefinition } from '../../kamelets-catalog';
-import { ICamelLoadBalancerDefinition } from '../../camel-loadbalancers-catalog';
 
 export class CamelCatalogService {
   private static catalogs: ComponentsCatalog = {};
@@ -60,5 +60,34 @@ export class CamelCatalogService {
    */
   static clearCatalogs(): void {
     this.catalogs = {};
+  }
+
+  /** Method to return whether this is a Camel Component or a Kamelet */
+  static getCatalogLookup(componentName: string): {
+    catalogKind: CatalogKind.Component;
+    definition?: ICamelComponentDefinition;
+  };
+  static getCatalogLookup(componentName: string): {
+    catalogKind: CatalogKind.Kamelet;
+    definition?: IKameletDefinition;
+  };
+  static getCatalogLookup(
+    componentName: string,
+  ): { catalogKind: CatalogKind; definition?: ComponentsCatalogTypes } | undefined {
+    if (!componentName) {
+      return undefined;
+    }
+
+    if (componentName.startsWith('kamelet:')) {
+      return {
+        catalogKind: CatalogKind.Kamelet,
+        definition: this.getComponent(CatalogKind.Kamelet, componentName.replace('kamelet:', '')),
+      };
+    }
+
+    return {
+      catalogKind: CatalogKind.Component,
+      definition: this.getComponent(CatalogKind.Component, componentName),
+    };
   }
 }

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -67,6 +67,12 @@ describe('CamelComponentSchemaService', () => {
       });
     });
 
+    it('should clone the component processor schema to avoid mutating the original one', () => {
+      const result = CamelComponentSchemaService.getVisualComponentSchema('from', definition);
+
+      expect(result!.schema).not.toBe(modelCatalogMap.from.propertiesSchema);
+    });
+
     it('should build the appropriate schema for standalone processors', () => {
       const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
       const logPath = 'from.steps.0.log';
@@ -213,6 +219,7 @@ describe('CamelComponentSchemaService', () => {
       ['from.steps.3.choice', {}, { processorName: 'choice' }],
       ['from.steps.3.choice.when.0', {}, { processorName: 'when' }],
       ['from.steps.3.choice.otherwise', {}, { processorName: 'otherwise' }],
+      ['from.steps.3.choice.otherwise', undefined, { processorName: 'otherwise' }],
     ])('should return the processor and component name for %s', (path, definition, result) => {
       const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup(path, definition);
 
@@ -354,7 +361,16 @@ describe('CamelComponentSchemaService', () => {
       expect(iconName).toEqual('log');
     });
 
-    it('should return an empty string if not found', () => {
+    it('should return an empty string if the component cannot be found', () => {
+      const iconName = CamelComponentSchemaService.getIconName({
+        processorName: 'to',
+        componentName: 'unknown-component',
+      });
+
+      expect(iconName).toEqual('');
+    });
+
+    it('should return an empty string if the processor cannot be found', () => {
       const iconName = CamelComponentSchemaService.getIconName({
         processorName: 'non-existing-processor' as keyof ProcessorDefinition,
       });
@@ -371,6 +387,12 @@ describe('CamelComponentSchemaService', () => {
 
     it('should return the kamelet component name', () => {
       const uri = 'kamelet:beer-source';
+      const componentName = CamelComponentSchemaService.getComponentNameFromUri(uri);
+      expect(componentName).toEqual('kamelet:beer-source');
+    });
+
+    it('should return the kamelet component name when having query parameters', () => {
+      const uri = 'kamelet:beer-source?foo=bar';
       const componentName = CamelComponentSchemaService.getComponentNameFromUri(uri);
       expect(componentName).toEqual('kamelet:beer-source');
     });

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -21,7 +21,7 @@ describe('CamelUriHelper', () => {
     });
   });
 
-  describe('uriSyntaxToParameters', () => {
+  describe('getParametersFromPathString', () => {
     it.each([
       { syntax: undefined, uri: undefined, result: {} },
       { syntax: 'log:loggerName', uri: undefined, result: {} },
@@ -31,28 +31,16 @@ describe('CamelUriHelper', () => {
       { syntax: 'log', uri: 'log:myLogger', result: {} },
       { syntax: 'as2:apiName/methodName', uri: 'as2', result: {} },
       {
-        syntax: 'timer:timerName',
-        uri: 'timer:timer-1?period=5000&delay=5&synchronous=true',
-        result: { timerName: 'timer-1', period: 5000, delay: 5, synchronous: true },
-      },
-      {
-        syntax: 'timer:timerName',
-        uri: 'timer:timer-1?period=50.75&delay=5,00&synchronous=true',
-        result: { timerName: 'timer-1', period: 50.75, delay: '5,00', synchronous: true },
-      },
-      {
         syntax: 'activemq:destinationType:destinationName',
-        uri: 'activemq:queue:myQueue?selector=foo',
-        result: { destinationType: 'queue', destinationName: 'myQueue', selector: 'foo' },
+        uri: 'activemq:queue:myQueue',
+        result: { destinationType: 'queue', destinationName: 'myQueue' },
       },
       {
         syntax: 'as2:apiName/methodName',
-        uri: 'as2:CLIENT/GET?encryptingAlgorithm=AES256_GCM&signingAlgorithm=MD5WITHRSA',
+        uri: 'as2:CLIENT/GET',
         result: {
           apiName: 'CLIENT',
           methodName: 'GET',
-          encryptingAlgorithm: 'AES256_GCM',
-          signingAlgorithm: 'MD5WITHRSA',
         },
       },
       {
@@ -77,8 +65,8 @@ describe('CamelUriHelper', () => {
       },
       {
         syntax: 'jms:destinationType:destinationName',
-        uri: 'jms:queue:myQueue?selector=foo',
-        result: { destinationType: 'queue', destinationName: 'myQueue', selector: 'foo' },
+        uri: 'jms:queue:myQueue',
+        result: { destinationType: 'queue', destinationName: 'myQueue' },
         requiredParameters: ['destinationName'],
       },
       {
@@ -89,15 +77,29 @@ describe('CamelUriHelper', () => {
       },
       {
         syntax: 'jms:destinationType:destinationName',
-        uri: 'jms:myQueue?selector=foo',
-        result: { destinationName: 'myQueue', selector: 'foo' },
+        uri: 'jms:myQueue',
+        result: { destinationName: 'myQueue' },
         requiredParameters: ['destinationName'],
       },
     ])(
       'for an URI: `$uri`, using the syntax: `$syntax`, should return `$result`',
       ({ syntax, uri, result, requiredParameters }) => {
-        expect(CamelUriHelper.uriSyntaxToParameters(syntax, uri, { requiredParameters })).toEqual(result);
+        expect(CamelUriHelper.getParametersFromPathString(syntax, uri, { requiredParameters })).toEqual(result);
       },
     );
+  });
+
+  describe('getParametersFromQueryString', () => {
+    it.each([
+      { queryString: undefined, result: {} },
+      { queryString: '', result: {} },
+      { queryString: 'period=5000&delay=5&synchronous=true', result: { period: 5000, delay: 5, synchronous: true } },
+      {
+        queryString: 'period=50.75&delay=5,00&synchronous=true',
+        result: { period: 50.75, delay: '5,00', synchronous: true },
+      },
+    ])('should return `$result` for `$queryString`', ({ queryString, result }) => {
+      expect(CamelUriHelper.getParametersFromQueryString(queryString)).toEqual(result);
+    });
   });
 });


### PR DESCRIPTION
Currently, kamelet's are not recognized when they have parameters within URI.

This commit fixes that situation by splitting the query parameters from the name and also parses it to apply it to the parameters object.

fix: https://github.com/KaotoIO/kaoto-next/issues/657
comes from: #664 