### PR TITLE
e2e - try to remove branchingStepAddition test flakiness

### DIFF
--- a/packages/ui-tests/cypress/fixtures/flows/ComplexKamelet.yaml
+++ b/packages/ui-tests/cypress/fixtures/flows/ComplexKamelet.yaml
@@ -61,9 +61,7 @@ spec:
                       log-name: yaml
             otherwise:
               steps:
-                - pipeline:
-                    steps:
-                      - aggregate: {}
+                - aggregate: {}
         - filter:
             simple: "{{?foo}}"
         - to:


### PR DESCRIPTION
Attempt to improve e2e stability. Removed not yet supported `pipeline` nested step from the fixture. Wasn't able to reproduce locally and the failure doesn't tell much, so hope this was the cause.

The random failure occurring in branchingStepAddition test was following:

![Test for Branching actions from the canvas -- User deletes a branch from the canvas (failed)](https://github.com/KaotoIO/kaoto-next/assets/4180208/ba10e7d3-9409-4b38-9ad6-b569435ee526)
