### PR TITLE
fix(canvas): Refresh canvas after error

### DIFF
--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren, ReactNode, useMemo } from 'react';
 import { BaseVisualCamelEntity } from '../../models/visualization/base-visual-entity';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Canvas } from './Canvas';
@@ -13,9 +13,11 @@ interface CanvasProps {
 }
 
 export const Visualization: FunctionComponent<PropsWithChildren<CanvasProps>> = (props) => {
+  const lastUpdate = useMemo(() => Date.now(), [props.entities]);
+
   return (
     <div className={`canvas-surface ${props.className ?? ''}`}>
-      <ErrorBoundary fallback={props.fallback ?? <CanvasFallback />}>
+      <ErrorBoundary key={lastUpdate} fallback={props.fallback ?? <CanvasFallback />}>
         <Canvas contextToolbar={<ContextToolbar />} entities={props.entities} />
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
### Context
Currently, if there's an error during a flow parsing, an error message is shown to the user to explain what happens and suggest checking the source code. In the VSCode extension, the canvas doesn't refresh after an error, causing the editor to be stuck until the user closes the extension and reopens it again or switches to another tab.

This commit addresses this issue by assigning a `key` property to the error boundary component, so it gets refreshed after an entity update that happens only after editing the source code.

fix: https://github.com/KaotoIO/kaoto-next/issues/714