### PR TITLE
fix(716): X icon in New Route modal doesn't close the modal

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.tsx
@@ -52,6 +52,9 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
         data-testid="confirmation-modal"
         titleIconVariant="warning"
         variant="small"
+        onClose={() => {
+          setIsConfirmationModalOpen(false);
+        }}
         actions={[
           <Button
             key="confirm"


### PR DESCRIPTION
fixes #716,