### PR TITLE
feat(canvas): Add root containers for Camel Routes

### DIFF
--- a/packages/ui/src/components/Form/schema.service.ts
+++ b/packages/ui/src/components/Form/schema.service.ts
@@ -4,9 +4,21 @@ import { filterDOMProps, FilterDOMPropsKeys } from 'uniforms';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 
 export class SchemaService {
+  static readonly DROPDOWN_PLACEHOLDER = 'Select an option...';
+  static readonly OMIT_FORM_FIELDS = [
+    'from',
+    'expression',
+    'dataFormatType',
+    'outputs',
+    'steps',
+    'when',
+    'otherwise',
+    'doCatch',
+    'doFinally',
+    'uri',
+  ];
   private readonly ajv: Ajv;
   private readonly FILTER_DOM_PROPS = ['$comment', 'additionalProperties'];
-  static readonly DROPDOWN_PLACEHOLDER = 'Select an option...';
 
   constructor() {
     this.ajv = new Ajv({

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -22,7 +22,6 @@ import { act } from 'react-dom/test-utils';
 import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
 
 describe('CanvasForm', () => {
-  const omitFields = ['expression', 'dataFormatType', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally'];
   const schemaService = new SchemaService();
 
   const schema = {
@@ -179,11 +178,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const setHeaderNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: setHeaderNode,
         },
       };
 
@@ -242,11 +242,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const setHeaderNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: setHeaderNode,
         },
       };
 
@@ -306,11 +307,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const marshalNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: marshalNode,
         },
       };
 
@@ -339,6 +341,7 @@ describe('CanvasForm', () => {
       expect(camelRoute.from.steps[0].marshal!.avro).toBeDefined();
       expect(camelRoute.from.steps[0].marshal!.id).toEqual('modified');
     });
+
     it('main form => dataformat', async () => {
       const camelRoute = {
         from: {
@@ -354,11 +357,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const marshalNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: marshalNode,
         },
       };
 
@@ -405,11 +409,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const loadBalanceNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: loadBalanceNode,
         },
       };
 
@@ -438,6 +443,7 @@ describe('CanvasForm', () => {
       expect(camelRoute.from.steps[0].loadBalance!.weighted).toBeDefined();
       expect(camelRoute.from.steps[0].loadBalance!.id).toEqual('modified');
     });
+
     it('main form => loadbalancer', async () => {
       const camelRoute = {
         from: {
@@ -453,11 +459,12 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
+      const loadBalanceNode = rootNode.getChildren()![0].getChildren()![0];
       const selectedNode = {
         id: '1',
         type: 'node',
         data: {
-          vizNode: rootNode.getChildren()![0],
+          vizNode: loadBalanceNode,
         },
       };
 
@@ -503,7 +510,7 @@ describe('CanvasForm', () => {
         render(
           <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
             <AutoForm schema={schema!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={omitFields} />
+              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
             </AutoForm>
           </AutoField.componentDetectorContext.Provider>,
         );
@@ -526,7 +533,7 @@ describe('CanvasForm', () => {
         render(
           <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
             <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={omitFields} />
+              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
             </AutoForm>
           </AutoField.componentDetectorContext.Provider>,
         );
@@ -549,7 +556,7 @@ describe('CanvasForm', () => {
         render(
           <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
             <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={omitFields} />
+              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
             </AutoForm>
           </AutoField.componentDetectorContext.Provider>,
         );

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -17,19 +17,6 @@ interface CanvasFormProps {
   selectedNode: CanvasNode;
 }
 
-const omitFields = [
-  'from',
-  'expression',
-  'dataFormatType',
-  'outputs',
-  'steps',
-  'when',
-  'otherwise',
-  'doCatch',
-  'doFinally',
-  'uri',
-];
-
 export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
   const formRef = useRef<typeof AutoForm>();
@@ -103,7 +90,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
               onChange={handleOnChangeIndividualProp}
               data-testid="autoform"
             >
-              <AutoFields omitFields={omitFields} />
+              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
               <ErrorsField />
             </AutoForm>
           </AutoField.componentDetectorContext.Provider>

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -613,6 +613,53 @@ exports[`Canvas should render correctly 1`] = `
           <svg
             class="pf-topology-visualization-surface__svg"
           >
+            <defs>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="1"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId--hover"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="3"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="200%"
+                id="NodeShadowsFilterId--danger"
+                width="200%"
+                x="-50%"
+                y="-50%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="0"
+                  flood-color="#DB0000"
+                  flood-opacity="0.5"
+                  stdDeviation="4"
+                />
+              </filter>
+            </defs>
             <g
               data-id="g1"
               data-kind="graph"
@@ -634,7 +681,26 @@ exports[`Canvas should render correctly 1`] = `
                 />
                 <g
                   data-layer-id="groups"
-                />
+                >
+                  <g
+                    data-id="route-8888"
+                    data-kind="node"
+                    data-type="group"
+                    transform="translate(0, 0)"
+                  >
+                    <g
+                      class="pf-topology__group"
+                    >
+                      <rect
+                        class="pf-topology__group__background"
+                        height="150"
+                        width="150"
+                        x="-37.5"
+                        y="-37.5"
+                      />
+                    </g>
+                  </g>
+                </g>
                 <g
                   data-layer-id="default"
                 >
@@ -863,53 +929,123 @@ exports[`Canvas should render correctly 1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="timer-1234"
+                    data-id="route-8888"
                     data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="set-header-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="choice-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="when-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="log-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="otherwise-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="amqp-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="direct-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
+                    data-type="group"
+                  >
+                    <g>
+                      <g
+                        class="pf-topology__group"
+                      >
+                        <g
+                          class="pf-topology__group__label"
+                          transform="translate(NaN, 136.5)"
+                        >
+                          <rect
+                            class="pf-topology__node__label__background"
+                            height="NaN"
+                            rx="4"
+                            ry="4"
+                            width="NaN"
+                            x="0"
+                            y="0"
+                          />
+                          <text
+                            dy="0.35em"
+                            x="8"
+                            y="NaN"
+                          >
+                            route-8888
+                          </text>
+                          <line
+                            class="pf-topology__node__separator"
+                            shape-rendering="crispEdges"
+                            x1="NaN"
+                            x2="NaN"
+                            y1="0"
+                            y2="NaN"
+                          />
+                          <g
+                            class="pf-topology__node__action-icon"
+                          >
+                            <rect
+                              class="pf-topology__node__action-icon__background"
+                              height="NaN"
+                              width="16"
+                              x="NaN"
+                              y="0"
+                            />
+                            <g
+                              class="pf-topology__node__action-icon__icon"
+                              transform="translate(NaN, NaN)"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M4.686 427.314L104 328l-32.922-31.029C55.958 281.851 66.666 256 88.048 256h112C213.303 256 224 266.745 224 280v112c0 21.382-25.803 32.09-40.922 16.971L152 376l-99.314 99.314c-6.248 6.248-16.379 6.248-22.627 0L4.686 449.941c-6.248-6.248-6.248-16.379 0-22.627zM443.314 84.686L344 184l32.922 31.029c15.12 15.12 4.412 40.971-16.97 40.971h-112C234.697 256 224 245.255 224 232V120c0-21.382 25.803-32.09 40.922-16.971L296 136l99.314-99.314c6.248-6.248 16.379-6.248 22.627 0l25.373 25.373c6.248 6.248 6.248 16.379 0 22.627z"
+                                />
+                              </svg>
+                            </g>
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                    <g
+                      data-id="timer-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="set-header-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="choice-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="when-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="log-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="otherwise-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="amqp-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="direct-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                  </g>
                 </g>
                 <g
                   data-layer-id="top"
@@ -1123,6 +1259,53 @@ exports[`Canvas should render correctly with more routes  1`] = `
           <svg
             class="pf-topology-visualization-surface__svg"
           >
+            <defs>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="1"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId--hover"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="3"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="200%"
+                id="NodeShadowsFilterId--danger"
+                width="200%"
+                x="-50%"
+                y="-50%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="0"
+                  flood-color="#DB0000"
+                  flood-opacity="0.5"
+                  stdDeviation="4"
+                />
+              </filter>
+            </defs>
             <g
               data-id="g1"
               data-kind="graph"
@@ -1144,7 +1327,26 @@ exports[`Canvas should render correctly with more routes  1`] = `
                 />
                 <g
                   data-layer-id="groups"
-                />
+                >
+                  <g
+                    data-id="route-8888"
+                    data-kind="node"
+                    data-type="group"
+                    transform="translate(0, 0)"
+                  >
+                    <g
+                      class="pf-topology__group"
+                    >
+                      <rect
+                        class="pf-topology__group__background"
+                        height="150"
+                        width="150"
+                        x="-37.5"
+                        y="-37.5"
+                      />
+                    </g>
+                  </g>
+                </g>
                 <g
                   data-layer-id="default"
                 >
@@ -1373,53 +1575,123 @@ exports[`Canvas should render correctly with more routes  1`] = `
                     </g>
                   </g>
                   <g
-                    data-id="timer-1234"
+                    data-id="route-8888"
                     data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="set-header-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="choice-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="when-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="log-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="otherwise-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="amqp-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="direct-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
+                    data-type="group"
+                  >
+                    <g>
+                      <g
+                        class="pf-topology__group"
+                      >
+                        <g
+                          class="pf-topology__group__label"
+                          transform="translate(NaN, 136.5)"
+                        >
+                          <rect
+                            class="pf-topology__node__label__background"
+                            height="NaN"
+                            rx="4"
+                            ry="4"
+                            width="NaN"
+                            x="0"
+                            y="0"
+                          />
+                          <text
+                            dy="0.35em"
+                            x="8"
+                            y="NaN"
+                          >
+                            route-8888
+                          </text>
+                          <line
+                            class="pf-topology__node__separator"
+                            shape-rendering="crispEdges"
+                            x1="NaN"
+                            x2="NaN"
+                            y1="0"
+                            y2="NaN"
+                          />
+                          <g
+                            class="pf-topology__node__action-icon"
+                          >
+                            <rect
+                              class="pf-topology__node__action-icon__background"
+                              height="NaN"
+                              width="16"
+                              x="NaN"
+                              y="0"
+                            />
+                            <g
+                              class="pf-topology__node__action-icon__icon"
+                              transform="translate(NaN, NaN)"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M4.686 427.314L104 328l-32.922-31.029C55.958 281.851 66.666 256 88.048 256h112C213.303 256 224 266.745 224 280v112c0 21.382-25.803 32.09-40.922 16.971L152 376l-99.314 99.314c-6.248 6.248-16.379 6.248-22.627 0L4.686 449.941c-6.248-6.248-6.248-16.379 0-22.627zM443.314 84.686L344 184l32.922 31.029c15.12 15.12 4.412 40.971-16.97 40.971h-112C234.697 256 224 245.255 224 232V120c0-21.382 25.803-32.09 40.922-16.971L296 136l99.314-99.314c6.248-6.248 16.379-6.248 22.627 0l25.373 25.373c6.248 6.248 6.248 16.379 0 22.627z"
+                                />
+                              </svg>
+                            </g>
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                    <g
+                      data-id="timer-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="set-header-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="choice-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="when-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="log-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="otherwise-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="amqp-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="direct-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                  </g>
                 </g>
                 <g
                   data-layer-id="top"
@@ -1633,6 +1905,53 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
           <svg
             class="pf-topology-visualization-surface__svg"
           >
+            <defs>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="1"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="150%"
+                id="NodeShadowsFilterId--hover"
+                width="150%"
+                x="-25%"
+                y="-25%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="3"
+                  flood-color="#030303"
+                  flood-opacity="0.2"
+                  stdDeviation="2"
+                />
+              </filter>
+              <filter
+                height="200%"
+                id="NodeShadowsFilterId--danger"
+                width="200%"
+                x="-50%"
+                y="-50%"
+              >
+                <fedropshadow
+                  dx="0"
+                  dy="0"
+                  flood-color="#DB0000"
+                  flood-opacity="0.5"
+                  stdDeviation="4"
+                />
+              </filter>
+            </defs>
             <g
               data-id="g1"
               data-kind="graph"
@@ -1654,7 +1973,26 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                 />
                 <g
                   data-layer-id="groups"
-                />
+                >
+                  <g
+                    data-id="route-8888"
+                    data-kind="node"
+                    data-type="group"
+                    transform="translate(0, 0)"
+                  >
+                    <g
+                      class="pf-topology__group"
+                    >
+                      <rect
+                        class="pf-topology__group__background"
+                        height="150"
+                        width="150"
+                        x="-37.5"
+                        y="-37.5"
+                      />
+                    </g>
+                  </g>
+                </g>
                 <g
                   data-layer-id="default"
                 >
@@ -1883,53 +2221,123 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                     </g>
                   </g>
                   <g
-                    data-id="timer-1234"
+                    data-id="route-8888"
                     data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="set-header-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="choice-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="when-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="log-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="otherwise-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="amqp-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
-                  <g
-                    data-id="direct-1234"
-                    data-kind="node"
-                    data-type="node"
-                    transform="translate(0, 0)"
-                  />
+                    data-type="group"
+                  >
+                    <g>
+                      <g
+                        class="pf-topology__group"
+                      >
+                        <g
+                          class="pf-topology__group__label"
+                          transform="translate(NaN, 136.5)"
+                        >
+                          <rect
+                            class="pf-topology__node__label__background"
+                            height="NaN"
+                            rx="4"
+                            ry="4"
+                            width="NaN"
+                            x="0"
+                            y="0"
+                          />
+                          <text
+                            dy="0.35em"
+                            x="8"
+                            y="NaN"
+                          >
+                            route-8888
+                          </text>
+                          <line
+                            class="pf-topology__node__separator"
+                            shape-rendering="crispEdges"
+                            x1="NaN"
+                            x2="NaN"
+                            y1="0"
+                            y2="NaN"
+                          />
+                          <g
+                            class="pf-topology__node__action-icon"
+                          >
+                            <rect
+                              class="pf-topology__node__action-icon__background"
+                              height="NaN"
+                              width="16"
+                              x="NaN"
+                              y="0"
+                            />
+                            <g
+                              class="pf-topology__node__action-icon__icon"
+                              transform="translate(NaN, NaN)"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M4.686 427.314L104 328l-32.922-31.029C55.958 281.851 66.666 256 88.048 256h112C213.303 256 224 266.745 224 280v112c0 21.382-25.803 32.09-40.922 16.971L152 376l-99.314 99.314c-6.248 6.248-16.379 6.248-22.627 0L4.686 449.941c-6.248-6.248-6.248-16.379 0-22.627zM443.314 84.686L344 184l32.922 31.029c15.12 15.12 4.412 40.971-16.97 40.971h-112C234.697 256 224 245.255 224 232V120c0-21.382 25.803-32.09 40.922-16.971L296 136l99.314-99.314c6.248-6.248 16.379-6.248 22.627 0l25.373 25.373c6.248 6.248 6.248 16.379 0 22.627z"
+                                />
+                              </svg>
+                            </g>
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                    <g
+                      data-id="timer-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="set-header-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="choice-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="when-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="log-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="otherwise-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="amqp-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                    <g
+                      data-id="direct-1234"
+                      data-kind="node"
+                      data-type="node"
+                      transform="translate(0, 0)"
+                    />
+                  </g>
                 </g>
                 <g
                   data-layer-id="top"

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -4,7 +4,6 @@ import {
   ConcentricLayout,
   DagreLayout,
   DefaultEdge,
-  DefaultGroup,
   EdgeAnimationSpeed,
   EdgeStyle,
   ForceLayout,
@@ -13,9 +12,11 @@ import {
   Visualization,
 } from '@patternfly/react-topology';
 import { createVisualizationNode } from '../../../models/visualization';
+import { CustomGroupWithSelection } from '../Custom';
 import { CanvasDefaults } from './canvas.defaults';
 import { LayoutType } from './canvas.models';
 import { CanvasService } from './canvas.service';
+import { BaseVisualCamelEntity } from '../../../models/visualization/base-visual-entity';
 
 describe('CanvasService', () => {
   const DEFAULT_NODE_PROPS = {
@@ -60,7 +61,7 @@ describe('CanvasService', () => {
     it('should return the correct component for a group', () => {
       const component = CanvasService.baselineComponentFactory({} as ModelKind, 'group');
 
-      expect(component).toBe(DefaultGroup);
+      expect(component).toBe(CustomGroupWithSelection);
     });
 
     it('should return the correct component for a graph', () => {
@@ -308,6 +309,30 @@ describe('CanvasService', () => {
           ...DEFAULT_EDGE_PROPS,
         },
       ]);
+    });
+
+    it('should return a group node for a multiple nodes VisualizationNode with a group', () => {
+      const routeNode = createVisualizationNode('route', {
+        entity: { getId: () => 'myId' } as BaseVisualCamelEntity,
+        isGroup: true,
+      });
+
+      const fromNode = createVisualizationNode('timer', {
+        path: 'from',
+        icon: undefined,
+        processorName: 'from',
+        componentName: 'timer',
+      });
+      routeNode.addChild(fromNode);
+
+      const { nodes, edges } = CanvasService.getFlowDiagram(routeNode);
+
+      expect(nodes).toHaveLength(2);
+      expect(edges).toHaveLength(0);
+
+      const group = nodes[nodes.length - 1];
+      expect(group.children).toEqual(['timer-1234']);
+      expect(group.group).toBeTruthy();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/CustomGroup.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomGroup.tsx
@@ -1,0 +1,37 @@
+import { DefaultGroup, GraphElement, Layer, isNode, observer, withSelection } from '@patternfly/react-topology';
+import { FunctionComponent } from 'react';
+import { CanvasNode } from '../Canvas/canvas.models';
+
+type IDefaultGroup = Parameters<typeof DefaultGroup>[0];
+interface ICustomGroup extends IDefaultGroup {
+  element: GraphElement<CanvasNode, CanvasNode['data']>;
+}
+
+const CustomGroup: FunctionComponent<ICustomGroup> = observer(({ element, ...rest }) => {
+  const vizNode = element.getData()?.vizNode;
+  const label = vizNode?.getNodeLabel();
+
+  if (!isNode(element)) {
+    throw new Error('DefaultGroup must be used only on Node elements');
+  }
+
+  return (
+    <g>
+      <Layer>
+        <DefaultGroup
+          {...rest}
+          element={element}
+          label={label}
+          truncateLength={15}
+          showLabel={true}
+          collapsible
+          collapsedWidth={50}
+          collapsedHeight={50}
+          hulledOutline={false}
+        />
+      </Layer>
+    </g>
+  );
+});
+
+export const CustomGroupWithSelection = withSelection()(CustomGroup);

--- a/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
@@ -2,6 +2,7 @@ import {
   DefaultNode,
   Node,
   NodeStatus,
+  observer,
   withContextMenu,
   withSelection,
   WithSelectionProps,
@@ -22,7 +23,7 @@ interface CustomNodeProps extends WithSelectionProps {
 }
 const noopFn = () => {};
 
-const CustomNode: FunctionComponent<CustomNodeProps> = ({ element, ...rest }) => {
+const CustomNode: FunctionComponent<CustomNodeProps> = observer(({ element, ...rest }) => {
   const vizNode = element.getData()?.vizNode;
   const label = vizNode?.getNodeLabel();
   const tooltipContent = vizNode?.getTooltipContent();
@@ -60,7 +61,7 @@ const CustomNode: FunctionComponent<CustomNodeProps> = ({ element, ...rest }) =>
       </g>
     </DefaultNode>
   );
-};
+});
 
 export const CustomNodeWithSelection: typeof DefaultNode = withContextMenu(() => [
   <ItemAddNode

--- a/packages/ui/src/components/Visualization/Custom/index.ts
+++ b/packages/ui/src/components/Visualization/Custom/index.ts
@@ -1,0 +1,2 @@
+export * from './CustomGroup';
+export * from './CustomNode';

--- a/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
@@ -4,7 +4,7 @@ import { VisualizationEmptyState } from './VisualizationEmptyState';
 
 describe('VisualizationEmptyState.tsx', () => {
   describe('when there are no routes', () => {
-    it.only('should render the CubesIcon whenever there are no routes', () => {
+    it('should render the CubesIcon whenever there are no routes', () => {
       const wrapper = render(
         <TestProvidersWrapper>
           <VisualizationEmptyState entitiesNumber={0} />

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -114,6 +114,7 @@ export interface IVisualizationNodeData {
   path?: string;
   entity?: BaseVisualCamelEntity;
   isPlaceholder?: boolean;
+  isGroup?: boolean;
   [key: string]: unknown;
 }
 

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -1,0 +1,110 @@
+import { camelFromJson } from '../../../stubs/camel-from';
+import { ROOT_PATH } from '../../../utils';
+import { SourceSchemaType } from '../../camel';
+import { IKameletDefinition, IKameletMetadata, IKameletSpecProperty } from '../../kamelets-catalog';
+import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { KameletVisualEntity } from './kamelet-visual-entity';
+
+describe('KameletVisualEntity', () => {
+  let kameletDef: IKameletDefinition;
+
+  beforeEach(() => {
+    kameletDef = {
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        name: 'My Kamelet',
+        labels: {
+          'camel.apache.org/kamelet.type': '',
+        },
+        annotations: {
+          'camel.apache.org/kamelet.support.level': '',
+          'camel.apache.org/catalog.version': '',
+          'camel.apache.org/kamelet.icon': '',
+          'camel.apache.org/provider': '',
+          'camel.apache.org/kamelet.group': '',
+          'camel.apache.org/kamelet.namespace': '',
+        },
+      },
+      spec: {
+        definition: {
+          title: 'My Kamelet',
+          description: 'My Kamelet Description',
+          required: ['schedule'],
+          properties: {
+            schedule: {
+              title: 'Cron Schedule',
+              description: 'A cron example',
+              type: 'number',
+            },
+            message: {
+              title: 'Message',
+              description: 'The message to generate',
+              default: 'hello',
+              type: 'string',
+              example: 'secretsmanager.amazonaws.com',
+            },
+          } as Record<string, IKameletSpecProperty>,
+          type: 'source',
+        },
+        template: {
+          from: camelFromJson.from,
+        },
+        dependencies: [],
+      },
+    };
+  });
+
+  it('should create an instance', () => {
+    expect(new KameletVisualEntity(kameletDef)).toBeTruthy();
+  });
+
+  it('should set the id to the name if provided', () => {
+    const kamelet = new KameletVisualEntity(kameletDef);
+    expect(kamelet.id).toEqual('My Kamelet');
+    expect(kamelet.metadata.name).toEqual('My Kamelet');
+  });
+
+  it('should set a random id if the kamelet name is not provided', () => {
+    kameletDef.metadata.name = undefined as unknown as IKameletMetadata['name'];
+    const kamelet = new KameletVisualEntity(kameletDef);
+    expect(kamelet.id).toEqual('kamelet-1234');
+    expect(kamelet.metadata.name).toEqual('kamelet-1234');
+  });
+
+  it('should set the id', () => {
+    const kamelet = new KameletVisualEntity(kameletDef);
+    kamelet.setId('new-id');
+    expect(kamelet.id).toEqual('new-id');
+    expect(kamelet.metadata.name).toEqual('new-id');
+  });
+
+  describe('getComponentSchema', () => {
+    it('should return the kamelet root schema when querying the ROOT_PATH', () => {
+      const kamelet = new KameletVisualEntity(kameletDef);
+      expect(kamelet.getComponentSchema(ROOT_PATH)).toEqual({
+        title: 'Kamelet',
+        schema: {},
+        definition: kamelet.route,
+      });
+    });
+
+    it('should return the component schema from the underlying AbstractCamelVisualEntity', () => {
+      const getComponentSchemaSpy = jest.spyOn(AbstractCamelVisualEntity.prototype, 'getComponentSchema');
+
+      const kamelet = new KameletVisualEntity(kameletDef);
+      kamelet.getComponentSchema('test-path');
+
+      expect(getComponentSchemaSpy).toHaveBeenCalledWith('test-path');
+    });
+  });
+
+  it('should return the root uri', () => {
+    class KameletVisualEntityTest extends KameletVisualEntity {
+      getRootUri(): string | undefined {
+        return super.getRootUri();
+      }
+    }
+    const kamelet = new KameletVisualEntityTest(kameletDef);
+    expect(kamelet.getRootUri()).toEqual('timer:tutorial');
+  });
+});

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,8 +1,10 @@
-import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-/* eslint-disable no-case-declarations */
-import { IKameletDefinition, IKameletMetadata, IKameletSpec } from '../..';
+import { JSONSchemaType } from 'ajv';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { ROOT_PATH } from '../../../utils';
 import { EntityType } from '../../camel/entities';
+import { IKameletDefinition, IKameletMetadata, IKameletSpec } from '../../kamelets-catalog';
+import { VisualComponentSchema } from '../base-visual-entity';
+import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 
 export class KameletVisualEntity extends AbstractCamelVisualEntity {
   id: string;
@@ -14,6 +16,7 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity {
     super({ id: kamelet.metadata?.name, from: kamelet?.spec.template.from });
     this.id = (kamelet?.metadata?.name as string) ?? getCamelRandomId('kamelet');
     this.metadata = kamelet?.metadata ?? { name: this.id };
+    this.metadata.name = kamelet?.metadata.name ?? this.id;
     this.spec = kamelet.spec;
   }
 
@@ -21,6 +24,19 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity {
   setId(routeId: string): void {
     this.id = routeId;
     this.metadata.name = this.id;
+  }
+
+  getComponentSchema(path?: string | undefined): VisualComponentSchema | undefined {
+    if (path === ROOT_PATH) {
+      /** A better schema will be provided at a later stage */
+      return {
+        title: 'Kamelet',
+        schema: {} as JSONSchemaType<unknown>,
+        definition: this.route,
+      };
+    }
+
+    return super.getComponentSchema(path);
   }
 
   protected getRootUri(): string | undefined {

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -1,5 +1,216 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CamelComponentSchemaService getVisualComponentSchema should build the appropriate schema for \`route\` entity 1`] = `
+{
+  "definition": {
+    "from": {
+      "uri": "timer:MyTimer?period=1000",
+    },
+    "id": "route-1234",
+  },
+  "schema": {
+    "additionalProperties": false,
+    "definitions": {
+      "org.apache.camel.model.FromDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "parameters": {
+            "type": "object",
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/definitions/org.apache.camel.model.ProcessorDefinition",
+            },
+            "type": "array",
+          },
+          "uri": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "steps",
+          "uri",
+        ],
+        "type": "object",
+      },
+      "org.apache.camel.model.InputTypeDefinition": {
+        "additionalProperties": false,
+        "description": "Set the expected data type of the input message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the transformation from/to XML.",
+        "properties": {
+          "description": {
+            "description": "Sets the description of this node",
+            "title": "Description",
+            "type": "string",
+          },
+          "id": {
+            "description": "Sets the id of this node",
+            "title": "Id",
+            "type": "string",
+          },
+          "urn": {
+            "description": "The input type URN.",
+            "title": "Urn",
+            "type": "string",
+          },
+          "validate": {
+            "description": "Whether if validation is required for this input type.",
+            "title": "Validate",
+            "type": "boolean",
+          },
+        },
+        "required": [
+          "urn",
+        ],
+        "title": "Input Type",
+        "type": "object",
+      },
+      "org.apache.camel.model.OutputTypeDefinition": {
+        "additionalProperties": false,
+        "description": "Set the expected data type of the output message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the XML-Java transformation.",
+        "properties": {
+          "description": {
+            "description": "Sets the description of this node",
+            "title": "Description",
+            "type": "string",
+          },
+          "id": {
+            "description": "Sets the id of this node",
+            "title": "Id",
+            "type": "string",
+          },
+          "urn": {
+            "description": "Set output type URN.",
+            "title": "Urn",
+            "type": "string",
+          },
+          "validate": {
+            "description": "Whether if validation is required for this output type.",
+            "title": "Validate",
+            "type": "boolean",
+          },
+        },
+        "required": [
+          "urn",
+        ],
+        "title": "Output Type",
+        "type": "object",
+      },
+    },
+    "properties": {
+      "autoStartup": {
+        "default": "true",
+        "description": "Whether to auto start this route",
+        "title": "Auto Startup",
+        "type": "boolean",
+      },
+      "description": {
+        "description": "Sets the description of this node",
+        "title": "Description",
+        "type": "string",
+      },
+      "from": {
+        "$ref": "#/definitions/org.apache.camel.model.FromDefinition",
+        "description": "From",
+        "title": "From",
+      },
+      "group": {
+        "description": "The group that this route belongs to; could be the name of the RouteBuilder class or be explicitly configured in the XML. May be null.",
+        "title": "Group",
+        "type": "string",
+      },
+      "id": {
+        "description": "Sets the id of this node",
+        "title": "Id",
+        "type": "string",
+      },
+      "inputType": {
+        "$ref": "#/definitions/org.apache.camel.model.InputTypeDefinition",
+      },
+      "logMask": {
+        "default": "false",
+        "description": "Whether security mask for Logging is enabled on this route.",
+        "title": "Log Mask",
+        "type": "boolean",
+      },
+      "messageHistory": {
+        "description": "Whether message history is enabled on this route.",
+        "title": "Message History",
+        "type": "boolean",
+      },
+      "nodePrefixId": {
+        "description": "Sets a prefix to use for all node ids (not route id).",
+        "title": "Node Prefix Id",
+        "type": "string",
+      },
+      "outputType": {
+        "$ref": "#/definitions/org.apache.camel.model.OutputTypeDefinition",
+      },
+      "precondition": {
+        "description": "The predicate of the precondition in simple language to evaluate in order to determine if this route should be included or not.",
+        "title": "Precondition",
+        "type": "string",
+      },
+      "routeConfigurationId": {
+        "description": "The route configuration id or pattern this route should use for configuration. Multiple id/pattern can be separated by comma.",
+        "title": "Route Configuration Id",
+        "type": "string",
+      },
+      "routePolicy": {
+        "description": "Reference to custom org.apache.camel.spi.RoutePolicy to use by the route. Multiple policies can be configured by separating values using comma.",
+        "title": "Route Policy",
+        "type": "string",
+      },
+      "shutdownRoute": {
+        "default": "Default",
+        "description": "To control how to shutdown the route.",
+        "enum": [
+          "Default",
+          "Defer",
+        ],
+        "title": "Shutdown Route",
+        "type": "string",
+      },
+      "shutdownRunningTask": {
+        "default": "CompleteCurrentTaskOnly",
+        "description": "To control how to shut down the route.",
+        "enum": [
+          "CompleteCurrentTaskOnly",
+          "CompleteAllTasks",
+        ],
+        "title": "Shutdown Running Task",
+        "type": "string",
+      },
+      "startupOrder": {
+        "description": "To configure the ordering of the routes being started",
+        "title": "Startup Order",
+        "type": "number",
+      },
+      "streamCaching": {
+        "description": "Whether stream caching is enabled on this route.",
+        "title": "Stream Cache",
+        "type": "boolean",
+      },
+      "trace": {
+        "description": "Whether tracing is enabled on this route.",
+        "title": "Trace",
+        "type": "boolean",
+      },
+    },
+    "required": [
+      "from",
+    ],
+    "type": "object",
+  },
+  "title": "route",
+}
+`;
+
 exports[`CamelComponentSchemaService getVisualComponentSchema should build the appropriate schema for processors combined that holds a component 1`] = `
 {
   "definition": {

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -176,9 +176,10 @@ describe('VisualizationNode', () => {
       const camelRouteVisualEntityStub = new CamelRouteVisualEntity(camelRouteJson.route);
 
       node = camelRouteVisualEntityStub.toVizNode();
+      const fromNode = node.getChildren()?.[0];
 
       /** Get set-header node */
-      const setHeaderNode = node.getChildren()?.[0];
+      const setHeaderNode = fromNode!.getChildren()?.[0];
 
       /** Remove set-header node */
       setHeaderNode!.removeChild();
@@ -186,7 +187,9 @@ describe('VisualizationNode', () => {
       /** Refresh the Viz Node */
       node = camelRouteVisualEntityStub.toVizNode();
 
-      expect(node.getChildren()?.[0].getNodeLabel()).toEqual('choice');
+      expect(node.getChildren()?.[0].getNodeLabel()).toEqual('timer');
+      expect(fromNode!.getChildren()?.[0].getNodeLabel()).toEqual('choice-1234');
+      expect(fromNode!.getChildren()).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
### Context
Currently, when rendering two routes at the same time, there's no easy way to distinguish one from the other.

This commit adds a root container to each route, with a label to identify them.

### Todo
- [X] Draw a root container for Camel Routes
- [X] Connect the Route description with the container label
- [X] Connect the Camel Route configuration with the Form

### Screenshots
#### Two routes
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/e3259e54-b429-4590-b386-78a83838570b)

#### Configuring a route
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/355bafaf-2a30-49c7-9328-95bd730044d3)

fix: https://github.com/KaotoIO/kaoto-next/issues/767