### PR TITLE
fix: Moved forms field spacing related styling to uniforms-patternfly

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.scss
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.scss
@@ -1,16 +1,3 @@
-/*
-  This is required since there's a div between the form
-  element and its children that breaks the following styles
-    - display: grid
-    - gap: var(--pf-c-form--GridGap)
-  from @patternfly and making the fields very close to
-  each other
-*/
-form[data-testid='autoform'] > div {
-  display: inherit;
-  gap: inherit;
-}
-
 .canvas-form {
   overflow: auto;
 }


### PR DESCRIPTION
This change is related to fix #695. Here we moved the canvas forms field spacing related styling to uniforms-patternfly!
Check this for further details: https://github.com/KaotoIO/uniforms-patternfly/pull/73