### PR TITLE
feat(utils): Add get-value and set-value utils

### DIFF
--- a/packages/ui/src/utils/get-value.test.ts
+++ b/packages/ui/src/utils/get-value.test.ts
@@ -1,0 +1,32 @@
+import { ROOT_PATH, getValue } from './get-value';
+
+describe('getValue', () => {
+  it('should return the value of the given path', () => {
+    const obj = { a: { b: { c: 1 } } };
+    const path = 'a.b.c';
+    const value = getValue(obj, path);
+    expect(value).toBe(1);
+  });
+
+  it('should return the default value if the path does not exist', () => {
+    const obj = { a: { b: { c: 1 } } };
+    const path = 'a.b.d';
+    const defaultValue = 2;
+    const value = getValue(obj, path, defaultValue);
+    expect(value).toBe(defaultValue);
+  });
+
+  it('should return the value for a path that is an array', () => {
+    const obj = { a: { b: [{ c: 1 }, { c: 2 }] } };
+    const path = ['a', 'b', '1', 'c'];
+    const value = getValue(obj, path);
+    expect(value).toBe(2);
+  });
+
+  it('should return the root object if the path is the root path', () => {
+    const obj = { a: { b: { c: 1 } } };
+    const path = ROOT_PATH;
+    const value = getValue(obj, path);
+    expect(value).toBe(obj);
+  });
+});

--- a/packages/ui/src/utils/get-value.ts
+++ b/packages/ui/src/utils/get-value.ts
@@ -1,0 +1,12 @@
+import get from 'lodash.get';
+
+export const ROOT_PATH = '#';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getValue = (obj: unknown, path: string | string[], defaultValue?: any) => {
+  if (path === ROOT_PATH) {
+    return obj;
+  }
+
+  return get(obj, path, defaultValue);
+};

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -3,6 +3,8 @@ export * from './camel-uri-helper';
 export * from './catalog-schema-loader';
 export * from './event-notifier';
 export * from './get-array-property';
+export * from './get-value';
 export * from './is-defined';
 export * from './is-enum-type';
 export * from './node-icon-resolver';
+export * from './set-value';

--- a/packages/ui/src/utils/node-icon-resolver.ts
+++ b/packages/ui/src/utils/node-icon-resolver.ts
@@ -32,6 +32,7 @@ import remove_property from '../assets/eip/removeproperty.png';
 import resequence from '../assets/eip/resequence.png';
 import resumable from '../assets/eip/resumable.png';
 import rollback from '../assets/eip/rollback.png';
+import route from '../assets/eip/route.png';
 import sample from '../assets/eip/sample.png';
 import script from '../assets/eip/script.png';
 import set_body from '../assets/eip/setbody.png';
@@ -126,6 +127,11 @@ export class NodeIconResolver {
     }
 
     icon = this.getEIPIcon(elementName);
+    if (icon !== undefined) {
+      return icon;
+    }
+
+    icon = this.getVisualEntityIcon(elementName);
     if (icon !== undefined) {
       return icon;
     }
@@ -708,6 +714,15 @@ export class NodeIconResolver {
         return when;
       case 'wireTap':
         return wiretap;
+      default:
+        return undefined;
+    }
+  }
+
+  private static getVisualEntityIcon(elementName?: string): string | undefined {
+    switch (elementName) {
+      case 'route':
+        return route;
       default:
         return undefined;
     }

--- a/packages/ui/src/utils/set-value.test.ts
+++ b/packages/ui/src/utils/set-value.test.ts
@@ -1,0 +1,16 @@
+import { ROOT_PATH } from './get-value';
+import { setValue } from './set-value';
+
+describe('setValue', () => {
+  it('should set the value at the given path', () => {
+    const obj = { a: { b: { c: 1 } } };
+    setValue(obj, 'a.b.c', 2);
+    expect(obj).toEqual({ a: { b: { c: 2 } } });
+  });
+
+  it('should combine the properties of the value at the root path', () => {
+    const obj = { a: { b: { c: 1 } } };
+    setValue(obj, ROOT_PATH, { d: 2 });
+    expect(obj).toEqual({ a: { b: { c: 1 } }, d: 2 });
+  });
+});

--- a/packages/ui/src/utils/set-value.ts
+++ b/packages/ui/src/utils/set-value.ts
@@ -1,0 +1,12 @@
+import set from 'lodash.set';
+import { ROOT_PATH } from './get-value';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const setValue = (obj: any, path: string | string[], value: any): void => {
+  if (path === ROOT_PATH) {
+    Object.assign(obj, value);
+    return;
+  }
+
+  set(obj, path, value);
+};


### PR DESCRIPTION
### Context
This commit adds `getValue` and `setValue` utils, leveraging the existing `lodash.get` and `lodash.set` respectively in order to support `#` as a `ROOT_PATH`.

relates to: https://github.com/KaotoIO/kaoto-next/issues/767