### PR TITLE
fix(ajv): Avoid ajv throw exception for unresolved fields

### DIFF
--- a/packages/ui/src/components/Form/schema.service.test.ts
+++ b/packages/ui/src/components/Form/schema.service.test.ts
@@ -24,4 +24,29 @@ describe('SchemaService', () => {
 
     expect(schemaBridge).toBeUndefined();
   });
+
+  it('should catch and notify an exception from the validator', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { $ref: 'invalid' },
+      },
+    };
+
+    expect(() => schemaService.getSchemaBridge(schema)).not.toThrow();
+  });
+
+  it('should return null when there is no valid validator', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { $ref: 'invalid' },
+      },
+    };
+    const schemaBridge = schemaService.getSchemaBridge(schema);
+    const validator = schemaBridge?.validator;
+
+    expect(() => validator!({})).not.toThrow();
+    expect(validator!({})).toBeNull();
+  });
 });

--- a/packages/ui/src/components/Form/schema.service.ts
+++ b/packages/ui/src/components/Form/schema.service.ts
@@ -1,4 +1,4 @@
-import Ajv, { JSONSchemaType } from 'ajv';
+import Ajv, { JSONSchemaType, ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { filterDOMProps, FilterDOMPropsKeys } from 'uniforms';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
@@ -30,11 +30,17 @@ export class SchemaService {
   }
 
   private createValidator<T>(schema: JSONSchemaType<T>) {
-    const validator = this.ajv.compile(schema);
+    let validator: ValidateFunction | undefined;
+
+    try {
+      validator = this.ajv.compile(schema);
+    } catch (error) {
+      console.error('Could not compile schema', error);
+    }
 
     return (model: Record<string, unknown>) => {
-      validator(model);
-      return validator.errors?.length ? { details: validator.errors } : null;
+      validator?.(model);
+      return validator?.errors?.length ? { details: validator.errors } : null;
     };
   }
 }

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -18,6 +18,7 @@ interface CanvasFormProps {
 }
 
 const omitFields = [
+  'from',
   'expression',
   'dataFormatType',
   'outputs',


### PR DESCRIPTION
Currently, if a schema field cannot be resolved by using the `$ref` keyword, `ajv` throws an exception, making the `CanvasForm` unusable.

In addition to that, the `form` field has been removed from the `CanvasForm` as is meant to be rendered by the `Canvas` itself.

relates to: https://github.com/KaotoIO/kaoto-next/issues/767