### PR TITLE
chore(catalog): Add description to `CatalogKind`

### DIFF
--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -1,10 +1,26 @@
+/** Kaoto catalog kinds */
 export const enum CatalogKind {
+  /** Camel components catalog, f.i. amqp, log, timer */
   Component = 'component',
+
+  /** Camel model catalog, f.i. route, from, eips, routeTemplate, languages, dataformats, loadbalancer */
   Processor = 'processor',
+
+  /** Camel processors (EIPs) definitions, f.i. log, to, toD, transform, filter */
   Pattern = 'pattern',
+
+  /** Camel entities catalog, f.i. from, route, routeTemplate */
   Entity = 'entity',
+
+  /** Camel languages catalog, f.i. simple, groovy, kotlin */
   Language = 'language',
+
+  /** Camel dataformats catalog, f.i. json, xml, csv */
   Dataformat = 'dataformat',
+
+  /** Camel loadbalancer catalog, f.i. round robin, failover, random */
   Loadbalancer = 'loadbalancer',
+
+  /** Camel kamelets catalog, f.i. xj-template-action */
   Kamelet = 'kamelet',
 }


### PR DESCRIPTION
### Context
This commit adds a brief description to the `CatalogKind` enum to understand what's available on each Catalog kind.

The advantage of doing so is the description appears when hovering over the usage
![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/86ab4fe7-bac6-44ac-b68b-b4def5154b11)

relates to: https://github.com/KaotoIO/kaoto-next/issues/767