### PR TITLE
chore(tests): Enable SVG mocks

### DIFF
--- a/packages/ui/jest-setup.ts
+++ b/packages/ui/jest-setup.ts
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom';
 import { FilterDOMPropsKeys, filterDOMProps } from 'uniforms';
+import { setupJestCanvasMock } from 'jest-canvas-mock';
 // import '@testing-library/jest-dom/extend-expect'
 
 filterDOMProps.register('inputRef' as FilterDOMPropsKeys, 'placeholder' as FilterDOMPropsKeys);
+enableSVGElementMocks();
 
 Object.defineProperty(window, 'fetch', {
   writable: true,
@@ -28,4 +30,42 @@ const fetchMock = jest.spyOn(window, 'fetch');
 
 beforeEach(() => {
   fetchMock.mockResolvedValue(null as unknown as Response);
+  setupJestCanvasMock();
 });
+
+function enableSVGElementMocks() {
+  /**
+   * Mocking the following SVG methods to avoid errors when running tests
+   *
+   * Taken from the following comment:
+   * https://github.com/apexcharts/react-apexcharts/issues/52#issuecomment-844757362
+   */
+
+  Object.defineProperty(global.SVGElement.prototype, 'getScreenCTM', {
+    writable: true,
+    value: jest.fn(),
+  });
+
+  Object.defineProperty(global.SVGElement.prototype, 'getBBox', {
+    writable: true,
+    value: jest.fn().mockReturnValue({
+      x: 0,
+      y: 0,
+    }),
+  });
+
+  Object.defineProperty(global.SVGElement.prototype, 'getComputedTextLength', {
+    writable: true,
+    value: jest.fn().mockReturnValue(0),
+  });
+
+  Object.defineProperty(global.SVGElement.prototype, 'createSVGMatrix', {
+    writable: true,
+    value: jest.fn().mockReturnValue({
+      x: 10,
+      y: 10,
+      inverse: () => {},
+      multiply: () => {},
+    }),
+  });
+}

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -150,10 +150,10 @@ export default {
   // runner: 'jest-runner',
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['jest-canvas-mock'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts', 'jest-canvas-mock'],
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,


### PR DESCRIPTION
### Context
Currently, there are no mocks for `SVGElement`'s methods, like `getBBox`.

### Changes
This commit adds a few of them and also moves the `jest-canvas-mock` package to the `setupFiles` array so it's loaded during the environment configuration.

relates to: https://github.com/KaotoIO/kaoto-next/issues/767