### PR TITLE
fix(storybook): Have a static ID for Kamelet

### DIFF
--- a/packages/ui-tests/stories/canvas/Canvas.stories.tsx
+++ b/packages/ui-tests/stories/canvas/Canvas.stories.tsx
@@ -5,6 +5,7 @@ import {
   CatalogSchemaLoader,
   CatalogTilesProvider,
   EntitiesProvider,
+  KameletVisualEntity,
   PipeVisualEntity,
   SchemasLoaderProvider,
   SourceCodeProvider,
@@ -41,7 +42,7 @@ const emptyCamelRouteJson = {
 const camelRouteEntity = new CamelRouteVisualEntity(complexRouteMock.route);
 const emptyCamelRouteEntity = new CamelRouteVisualEntity(emptyCamelRouteJson.route);
 const pipeEntity = new PipeVisualEntity(pipeJson.spec!);
-const kameletEntity = new CamelRouteVisualEntity(kameletJson.spec.template);
+const kameletEntity = new KameletVisualEntity(kameletJson);
 const emptyPipeEntity = new PipeVisualEntity(emptyPipeJson.spec!);
 
 const ContextDecorator = (Story: StoryFn) => (


### PR DESCRIPTION
### Context
Currently, the kamelet's storybook example is using a `CamelRouteVisualEntity` class, and since the `JSON` example doesn't have an id, an automatic one is provided.

This generates a visual diff every time a new PR is created

The fix is to use the appropriate `KameletVisualEntity` class so that we could have a static Id for the example

| Kamelet's storybook example | Visual diff | Kamelet using the appropriate class |
| --- | --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/542a60dc-4bce-4c39-9208-80f4a974846b) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/9808cbc7-fa51-405e-baad-3e5ec35d68c7) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/44fccfb8-85aa-4ae6-b43d-c63f57627ba7) |


