### PR TITLE
fix(759): stabilize branchingStepAddition test - reformat ComplexKame…

### DIFF
--- a/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
@@ -56,7 +56,7 @@ describe('Test source code editor', () => {
   it('User Deletes branch in the YAML', () => {
     cy.uploadFixture('flows/ComplexKamelet.yaml');
 
-    cy.editorDeleteLine(40, 7);
+    cy.editorDeleteLine(41, 7);
     cy.openDesignPage();
 
     // CHECK branch with digitalocean and set header step was deleted
@@ -71,7 +71,7 @@ describe('Test source code editor', () => {
                 steps:
                   - to:
                       uri: atlasmap:null`;
-    const insertLine = 39;
+    const insertLine = 40;
     cy.editorAddText(insertLine, stepToInsert);
     cy.openDesignPage();
 

--- a/packages/ui-tests/cypress/fixtures/flows/ComplexKamelet.yaml
+++ b/packages/ui-tests/cypress/fixtures/flows/ComplexKamelet.yaml
@@ -8,18 +8,15 @@ metadata:
   name: eip-action
 spec:
   definition:
-    title: kamelet-2082
     description: Produces periodic events about random users!
-    type: object
     properties:
       period:
-        title: Period
-        description: The time interval between two events
-        type: integer
         default: 5000
-  types:
-    out:
-      mediaType: application/json
+        description: The time interval between two events
+        title: Period
+        type: integer
+    title: kamelet-2082
+    type: object
   dependencies:
     - camel:timer
     - camel:http
@@ -33,37 +30,38 @@ spec:
             copy: true
             steps:
               - delay:
+                  async-delayed: true
                   expression:
                     simple: ${body}
-                  async-delayed: true
+
         - choice:
+            otherwise:
+              steps:
+                - aggregate: {}
             when:
-              - simple: "{{?foo}}"
-                steps:
+              - steps:
                   - to:
                       uri: digitalocean:null
                   - setHeader:
                       name: bar
                       simple: foo
-              - simple: "{{?bar}}"
-                steps:
+                simple: "{{?foo}}"
+              - steps:
                   - delay: {}
                   - marshal:
                       json:
                         library: Gson
-              - simple: "{{?baz}}"
-                steps:
+                simple: "{{?bar}}"
+              - steps:
                   - choice:
                       when: []
                   - log:
-                      message: test
-                      logging-level: INFO
                       log-name: yaml
-            otherwise:
-              steps:
-                - aggregate: {}
+                      logging-level: INFO
+                      message: test
+                simple: "{{?baz}}"
         - filter:
             simple: "{{?foo}}"
         - to:
-            uri: kamelet:sink
             id: to-2621
+            uri: kamelet:sink


### PR DESCRIPTION
…let.yaml

fixes https://github.com/KaotoIO/kaoto-next/issues/759

Issue was caused by Kaoto not being able to read the `ComplexKamelet.yaml` - this was occurring only in the GH test env: 
![Test for Branching actions from the canvas -- User deletes a branch from the canvas (failed)](https://github.com/KaotoIO/kaoto-next/assets/4180208/364243fa-6a2c-4742-899a-e1ba83f860e0)
