### PR TITLE
feat(vscode): Gain space for the editor in VS Code

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-flow: column nowrap;
   position: relative;
-  padding-top: 15px;
 
   // Tab header shouldn't grow or shrink
   > div[role='region'] {
@@ -17,7 +16,6 @@
     flex-grow: 1;
     flex-shrink: 1;
     position: relative;
-    padding: 0 15px 15px;
     overflow: scroll;
   }
 }


### PR DESCRIPTION
part of kaotoio/vscode-kaoto#465

with this PR:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/ea3e477f-d765-42d7-84d2-a0c6ce4f6e2b)

so compared to before, we gain space related to highlighted in the color red, dark blue and a part of purple and light blue with this PR:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/79755d3f-87f4-4813-bd08-7e9e55310250)

