### PR TITLE
465 gain toolbar space overriding patternfly

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -19,3 +19,8 @@
     overflow: scroll;
   }
 }
+
+div[data-envelope-context='vscode'].shell .pf-v5-c-toolbar {
+  row-gap: 0;
+  padding-block: 0 0;
+}

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -39,7 +39,7 @@ export const KaotoEditor = () => {
   }
 
   return (
-    <div className="shell">
+    <div className="shell" data-envelope-context="vscode">
       <Tabs
         inset={{ default: 'insetSm' }}
         isBox


### PR DESCRIPTION
based on https://github.com/KaotoIO/kaoto-next/pull/817

With this PR, we now have:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/e5a97087-00cb-4416-8ace-d618495ec040)


it takes car of the yellow, orange and green:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/6b0e39b6-47f1-4a1d-8075-c9ef004a5f36)
