### PR TITLE
465 Gain unused scrollbar space for design canvas

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -18,6 +18,13 @@
     position: relative;
     overflow: scroll;
   }
+
+  // Tab content for Design canvas is not scrollable
+  section#{&}__tab-content_design-canvas {
+    flex-grow: 1;
+    flex-shrink: 1;
+    position: relative;
+  }
 }
 
 div[data-envelope-context='vscode'].shell .pf-v5-c-toolbar {

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -52,7 +52,7 @@ export const KaotoEditor = () => {
         <Tab
           isHidden={SCHEMA_TABS[resource.getType()].indexOf(TabList.Design) === -1}
           eventKey={TabList.Design}
-          className="shell__tab-content"
+          className="shell__tab-content_design-canvas"
           title={
             <>
               <TabTitleIcon>


### PR DESCRIPTION
based on https://github.com/KaotoIO/kaoto-next/pull/818

no more space for scrollbar on design canvas:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/00638a8c-46e3-4689-9e56-729b42302212)

and still available on other tabs like Beans:
![image](https://github.com/KaotoIO/kaoto-next/assets/1105127/eb465698-6acb-47d9-a6cd-8235250fdc17)
