### PR TITLE
fix - TypeError: props.tab is undefined

### DIFF
--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
@@ -35,7 +35,7 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
     }
   }, [props.tile]);
   const [activeTabKey, setActiveTabKey] = useState<number>(0);
-  const [activeTab, setActiveTab] = useState<IPropertiesTab>();
+  const [activeTab, setActiveTab] = useState<IPropertiesTab>(tabs[0]);
 
   useEffect(() => {
     setActiveTabKey(0);


### PR DESCRIPTION
Fix for console error when opening the catalog modal:

![Screenshot from 2024-02-09 15-46-52](https://github.com/KaotoIO/kaoto-next/assets/4180208/8a3e5416-0ace-43a5-9a28-56d643cc5e2f)
