### PR TITLE
feat(canvas-form): Use CustomAutoForm

### DIFF
--- a/packages/ui/src/components/Form/CustomAutoForm.tsx
+++ b/packages/ui/src/components/Form/CustomAutoForm.tsx
@@ -1,4 +1,4 @@
-import { AutoField, AutoForm, ErrorsField } from '@kaoto-next/uniforms-patternfly';
+import { AutoField, AutoFields, AutoForm, ErrorsField } from '@kaoto-next/uniforms-patternfly';
 import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { IDataTestID } from '../../models';
@@ -8,18 +8,29 @@ interface CustomAutoFormProps extends IDataTestID {
   schemaBridge?: JSONSchemaBridge;
   model: unknown;
   disabled?: boolean;
-  onChangeModel: (model: unknown) => void;
+  sortFields?: boolean;
+  omitFields?: string[];
+  onChangeModel?: (model: unknown) => void;
+  onChange?: (path: string, value: unknown) => void;
 }
 
-export const CustomAutoForm = forwardRef<{ fields: HTMLElement[] }, CustomAutoFormProps>((props, forwardedRef) => {
+export type CustomAutoFormRef = { fields: HTMLElement[]; form: typeof AutoForm };
+
+export const CustomAutoForm = forwardRef<CustomAutoFormRef, CustomAutoFormProps>((props, forwardedRef) => {
+  const formRef = useRef<typeof AutoForm>();
   const fieldsRefs = useRef<HTMLElement[]>([]);
   const sortedFieldsNames = useMemo(() => {
-    if (props.schemaBridge === undefined) {
+    if (props.schemaBridge === undefined || !props.sortFields) {
       return [];
     }
     return props.schemaBridge
       .getSubfields()
       .slice()
+      .filter((field) => {
+        if (!Array.isArray(props.omitFields)) return true;
+
+        return !props.omitFields.includes(field);
+      })
       .sort((a, b) => {
         const propsA = props.schemaBridge?.getProps(a);
         const propsB = props.schemaBridge?.getProps(b);
@@ -32,26 +43,34 @@ export const CustomAutoForm = forwardRef<{ fields: HTMLElement[] }, CustomAutoFo
 
   useImperativeHandle(forwardedRef, () => ({
     fields: fieldsRefs.current,
+    form: formRef.current,
   }));
 
   return (
     <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
       <AutoForm
+        ref={formRef}
         schema={props.schemaBridge}
         model={props.model}
         onChangeModel={props.onChangeModel}
+        onChange={props.onChange}
         data-testid={props['data-testid']}
         disabled={props.disabled}
       >
-        {sortedFieldsNames.map((field, index) => (
-          <AutoField
-            key={field}
-            name={field}
-            inputRef={(node: HTMLElement) => {
-              fieldsRefs.current[index] = node;
-            }}
-          />
-        ))}
+        {props.sortFields ? (
+          // For some forms, sorting its fields might be beneficial
+          sortedFieldsNames.map((field, index) => (
+            <AutoField
+              key={field}
+              name={field}
+              inputRef={(node: HTMLElement) => {
+                fieldsRefs.current[index] = node;
+              }}
+            />
+          ))
+        ) : (
+          <AutoFields omitFields={props.omitFields} />
+        )}
         <ErrorsField />
       </AutoForm>
     </AutoField.componentDetectorContext.Provider>

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.tsx
@@ -1,5 +1,5 @@
 import { FieldHintPopover } from '@kaoto-next/uniforms-patternfly';
-import { Button, Form, FormGroup, InputGroup, InputGroupItem, Modal, TextInput } from '@patternfly/react-core';
+import { Button, FormGroup, InputGroup, InputGroupItem, Modal, TextInput } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { useState } from 'react';
 import { ICamelLanguageDefinition } from '../../../models';
@@ -43,30 +43,28 @@ export const ExpressionModalLauncher = ({
   const expressionLabel = language && model?.expression ? language.model.name + ': ' + model.expression : '';
 
   return (
-    <div className="expression-field">
-      <Form>
-        <FormGroup label="Expression" labelIcon={<FieldHintPopover description={description} />}>
-          <InputGroup>
-            <InputGroupItem isFill>
-              <TextInput
-                id={'expression-preview-' + name}
-                placeholder="Not configured"
-                readOnlyVariant="default"
-                value={expressionLabel}
-              />
-            </InputGroupItem>
-            <InputGroupItem>
-              <Button
-                data-testid="launch-expression-modal-btn"
-                variant="control"
-                aria-label="Configure Expression"
-                icon={<PencilAltIcon />}
-                onClick={() => setIsModalOpen(true)}
-              />
-            </InputGroupItem>
-          </InputGroup>
-        </FormGroup>
-      </Form>
+    <div className="expression-field pf-v5-c-form">
+      <FormGroup label="Expression" labelIcon={<FieldHintPopover description={description} />}>
+        <InputGroup>
+          <InputGroupItem isFill>
+            <TextInput
+              id={'expression-preview-' + name}
+              placeholder="Not configured"
+              readOnlyVariant="default"
+              value={expressionLabel}
+            />
+          </InputGroupItem>
+          <InputGroupItem>
+            <Button
+              data-testid="launch-expression-modal-btn"
+              variant="control"
+              aria-label="Configure Expression"
+              icon={<PencilAltIcon />}
+              onClick={() => setIsModalOpen(true)}
+            />
+          </InputGroupItem>
+        </InputGroup>
+      </FormGroup>
       <Modal
         isOpen={isModalOpen}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
+++ b/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
@@ -3,9 +3,9 @@ import cloneDeep from 'lodash/cloneDeep';
 import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { SchemaService } from '../Form';
-import { CustomAutoForm } from '../Form/CustomAutoForm';
-import { TopmostArrayTable } from './TopmostArrayTable';
+import { CustomAutoForm, CustomAutoFormRef } from '../Form/CustomAutoForm';
 import './MetadataEditor.scss';
+import { TopmostArrayTable } from './TopmostArrayTable';
 
 interface MetadataEditorProps {
   name: string;
@@ -22,7 +22,7 @@ export const MetadataEditor: FunctionComponent<PropsWithChildren<MetadataEditorP
   const [schemaBridge, setSchemaBridge] = useState<JSONSchemaBridge | undefined>(
     schemaServiceRef.current.getSchemaBridge(getFormSchema()),
   );
-  const fieldsRefs = useRef<{ fields: HTMLElement[] }>(null);
+  const fieldsRefs = useRef<CustomAutoFormRef>(null);
   const [selected, setSelected] = useState(-1);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [preparedModel, setPreparedModel] = useState<any>(null);
@@ -119,6 +119,7 @@ export const MetadataEditor: FunctionComponent<PropsWithChildren<MetadataEditorP
                   onChangeModel={onChangeFormModel}
                   data-testid={`metadata-editor-form-${props.name}`}
                   disabled={isFormDisabled()}
+                  sortFields={true}
                   ref={fieldsRefs}
                 />
               </StackItem>
@@ -132,6 +133,7 @@ export const MetadataEditor: FunctionComponent<PropsWithChildren<MetadataEditorP
           onChangeModel={onChangeFormModel}
           data-testid={`metadata-editor-form-${props.name}`}
           disabled={isFormDisabled()}
+          sortFields={true}
           ref={fieldsRefs}
         />
       )}


### PR DESCRIPTION
### Context
Currently, there are 2 different `AutoForm` instances, one from `CanvasForm` and another one from the `MetadataEditor`.

This leads to code duplication and different form behavior depending on which screen is displayed.

### Changes
This commit updates the `CanvasForm` and `MetadataEditor` components to use the `CustomAutoForm`.