### PR TITLE
chore(typings): Remove `ajv.JSONSchemaType` usage

### DIFF
--- a/packages/ui-tests/stories/metadataEditor/DataformatEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/DataformatEditor.stories.tsx
@@ -3,11 +3,11 @@ import {
   CatalogLoaderProvider,
   CatalogSchemaLoader,
   IVisualizationNode,
+  KaotoSchemaDefinition,
   SchemasLoaderProvider,
   VisualComponentSchema,
 } from '@kaoto-next/ui/testing';
 import { Meta, StoryFn } from '@storybook/react';
-import { JSONSchemaType } from 'ajv';
 import { CanvasNode } from './../canvas.models';
 
 const visualComponentSchema: VisualComponentSchema = {
@@ -19,7 +19,7 @@ const visualComponentSchema: VisualComponentSchema = {
         type: 'string',
       },
     },
-  } as unknown as JSONSchemaType<unknown>,
+  } as unknown as KaotoSchemaDefinition['schema'],
   definition: {
     name: 'my node',
   },

--- a/packages/ui-tests/stories/metadataEditor/ExpressionEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/ExpressionEditor.stories.tsx
@@ -1,13 +1,13 @@
-import { StepExpressionEditor, MetadataEditor } from '@kaoto-next/ui';
+import { MetadataEditor, StepExpressionEditor } from '@kaoto-next/ui';
 import {
   CatalogLoaderProvider,
   CatalogSchemaLoader,
   IVisualizationNode,
+  KaotoSchemaDefinition,
   SchemasLoaderProvider,
   VisualComponentSchema,
 } from '@kaoto-next/ui/testing';
 import { Meta, StoryFn } from '@storybook/react';
-import { JSONSchemaType } from 'ajv';
 import { CanvasNode } from './../canvas.models';
 
 const visualComponentSchema: VisualComponentSchema = {
@@ -19,7 +19,7 @@ const visualComponentSchema: VisualComponentSchema = {
         type: 'string',
       },
     },
-  } as unknown as JSONSchemaType<unknown>,
+  } as unknown as KaotoSchemaDefinition['schema'],
   definition: {
     name: 'my node',
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -83,6 +83,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.4.0",
+    "@types/json-schema": "^7.0.15",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.get": "^4.4.2",
     "@types/lodash.isempty": "^4.4.9",

--- a/packages/ui/src/components/Form/bean/NewBeanModal.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.tsx
@@ -1,11 +1,11 @@
-import { MetadataEditor } from '../../MetadataEditor';
+import { RegistryBeanDefinition } from '@kaoto-next/camel-catalog/types';
 import { Button, Modal } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import { RegistryBeanDefinition } from '@kaoto-next/camel-catalog/types';
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from '../../../models';
+import { MetadataEditor } from '../../MetadataEditor';
 
 export type NewBeanModalProps = {
-  beanSchema: JSONSchemaType<unknown>;
+  beanSchema: KaotoSchemaDefinition['schema'];
   beanName?: string;
   propertyTitle: string;
   javaType?: string;

--- a/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
+++ b/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
@@ -1,13 +1,12 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { CamelCatalogService } from '../../../models/visualization/flows';
-import { CatalogKind, ICamelDataformatDefinition } from '../../../models';
-import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
-import { JSONSchemaType } from 'ajv';
-import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { DataFormatEditor } from './DataFormatEditor';
-import { MetadataEditor } from '../../MetadataEditor';
 import { act } from 'react-dom/test-utils';
+import { CatalogKind, ICamelDataformatDefinition, KaotoSchemaDefinition } from '../../../models';
+import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
+import { CamelCatalogService } from '../../../models/visualization/flows';
+import { MetadataEditor } from '../../MetadataEditor';
+import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
+import { DataFormatEditor } from './DataFormatEditor';
 
 describe('DataFormatEditor', () => {
   let mockNode: CanvasNode;
@@ -30,7 +29,7 @@ describe('DataFormatEditor', () => {
             type: 'string',
           },
         },
-      } as unknown as JSONSchemaType<unknown>,
+      } as unknown as KaotoSchemaDefinition['schema'],
       definition: {
         name: 'my node',
       },

--- a/packages/ui/src/components/Form/dataFormat/dataformat.service.test.ts
+++ b/packages/ui/src/components/Form/dataFormat/dataformat.service.test.ts
@@ -28,9 +28,9 @@ describe('DataFormatService', () => {
     it('should return DataFormat schema', () => {
       const dataFormatMap = DataFormatService.getDataFormatMap();
       const jsonSchema = DataFormatService.getDataFormatSchema(dataFormatMap.json);
-      expect(jsonSchema!.properties.unmarshalType.type).toBe('string');
+      expect(jsonSchema!.properties!.unmarshalType.type).toBe('string');
       const customSchema = DataFormatService.getDataFormatSchema(dataFormatMap.custom);
-      expect(customSchema!.properties.ref.type).toBe('string');
+      expect(customSchema!.properties!.ref.type).toBe('string');
     });
   });
 

--- a/packages/ui/src/components/Form/expression/expression.service.test.ts
+++ b/packages/ui/src/components/Form/expression/expression.service.test.ts
@@ -29,9 +29,9 @@ describe('ExpressionService', () => {
     it('should return language schema', () => {
       const languageMap = ExpressionService.getLanguageMap();
       const jsonpathSchema = ExpressionService.getLanguageSchema(languageMap.jsonpath);
-      expect(jsonpathSchema.properties.suppressExceptions.type).toBe('boolean');
+      expect(jsonpathSchema.properties!.suppressExceptions.type).toBe('boolean');
       const customSchema = ExpressionService.getLanguageSchema(languageMap.language);
-      expect(customSchema.properties.language.type).toBe('string');
+      expect(customSchema.properties!.language.type).toBe('string');
     });
   });
 

--- a/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.test.tsx
+++ b/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.test.tsx
@@ -1,8 +1,7 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { JSONSchemaType } from 'ajv';
 import { act } from 'react-dom/test-utils';
-import { CatalogKind, ICamelLoadBalancerDefinition } from '../../../models';
+import { CatalogKind, ICamelLoadBalancerDefinition, KaotoSchemaDefinition } from '../../../models';
 import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
 import { CamelCatalogService } from '../../../models/visualization/flows';
 import { MetadataEditor } from '../../MetadataEditor';
@@ -30,7 +29,7 @@ describe('LoadBalancerEditor', () => {
             type: 'string',
           },
         },
-      } as unknown as JSONSchemaType<unknown>,
+      } as unknown as KaotoSchemaDefinition['schema'],
       definition: {
         name: 'my node',
       },

--- a/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.test.ts
+++ b/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.test.ts
@@ -18,11 +18,11 @@ describe('LoadBalancerService', () => {
     it('should return LoadBalancer map', () => {
       const loadBalancerMap = LoadBalancerService.getLoadBalancerMap();
       expect(loadBalancerMap.failover.model.title).toEqual('Failover');
-      expect(loadBalancerMap.sticky.propertiesSchema.properties.correlationExpression[`$comment`]).toEqual(
+      expect(loadBalancerMap.sticky.propertiesSchema.properties!.correlationExpression[`$comment`]).toEqual(
         'expression',
       );
       expect(loadBalancerMap.customLoadBalancer.model.description).toContain('custom load balancer');
-      expect(loadBalancerMap.customLoadBalancer.propertiesSchema.properties.ref.title).toEqual('Ref');
+      expect(loadBalancerMap.customLoadBalancer.propertiesSchema.properties!.ref.title).toEqual('Ref');
     });
   });
 
@@ -30,9 +30,9 @@ describe('LoadBalancerService', () => {
     it('should return LoadBalancer schema', () => {
       const loadBalancerMap = LoadBalancerService.getLoadBalancerMap();
       const jsonSchema = LoadBalancerService.getLoadBalancerSchema(loadBalancerMap.roundRobin);
-      expect(jsonSchema!.properties.id.type).toBe('string');
+      expect(jsonSchema!.properties!.id.type).toBe('string');
       const customSchema = LoadBalancerService.getLoadBalancerSchema(loadBalancerMap.customLoadBalancer);
-      expect(customSchema!.properties.ref.type).toBe('string');
+      expect(customSchema!.properties!.ref.type).toBe('string');
     });
   });
 

--- a/packages/ui/src/components/Form/schema.service.ts
+++ b/packages/ui/src/components/Form/schema.service.ts
@@ -1,7 +1,8 @@
-import Ajv, { JSONSchemaType, ValidateFunction } from 'ajv';
+import Ajv, { ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { filterDOMProps, FilterDOMPropsKeys } from 'uniforms';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
 
 export class SchemaService {
   static readonly DROPDOWN_PLACEHOLDER = 'Select an option...';
@@ -31,18 +32,18 @@ export class SchemaService {
     addFormats(this.ajv);
   }
 
-  getSchemaBridge(schema?: Record<string, unknown>): JSONSchemaBridge | undefined {
+  getSchemaBridge(schema?: unknown): JSONSchemaBridge | undefined {
     if (!schema) return undefined;
 
     // uniforms passes it down to the React elements as an attribute, causes a warning
     this.FILTER_DOM_PROPS.forEach((prop) => filterDOMProps.register(prop as FilterDOMPropsKeys));
 
-    const schemaValidator = this.createValidator(schema as JSONSchemaType<unknown>);
+    const schemaValidator = this.createValidator(schema);
 
     return new JSONSchemaBridge({ schema, validator: schemaValidator });
   }
 
-  private createValidator<T>(schema: JSONSchemaType<T>) {
+  private createValidator(schema: KaotoSchemaDefinition['schema']) {
     let validator: ValidateFunction | undefined;
 
     try {

--- a/packages/ui/src/components/Form/stepExpression/StepExpressionEditor.test.tsx
+++ b/packages/ui/src/components/Form/stepExpression/StepExpressionEditor.test.tsx
@@ -1,14 +1,13 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { StepExpressionEditor } from './StepExpressionEditor';
-import { CamelCatalogService } from '../../../models/visualization/flows';
-import { CatalogKind, ICamelLanguageDefinition } from '../../../models';
-import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
-import { JSONSchemaType } from 'ajv';
-import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { MetadataEditor } from '../../MetadataEditor';
-import { SchemaService } from '../schema.service';
 import { act } from 'react-dom/test-utils';
+import { CatalogKind, ICamelLanguageDefinition, KaotoSchemaDefinition } from '../../../models';
+import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
+import { CamelCatalogService } from '../../../models/visualization/flows';
+import { MetadataEditor } from '../../MetadataEditor';
+import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
+import { SchemaService } from '../schema.service';
+import { StepExpressionEditor } from './StepExpressionEditor';
 
 describe('StepExpressionEditor', () => {
   let mockNode: CanvasNode;
@@ -31,7 +30,7 @@ describe('StepExpressionEditor', () => {
             type: 'string',
           },
         },
-      } as unknown as JSONSchemaType<unknown>,
+      } as unknown as KaotoSchemaDefinition['schema'],
       definition: {
         name: 'my node',
       },

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -1,14 +1,9 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
 import { AutoField, AutoFields } from '@kaoto-next/uniforms-patternfly';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { JSONSchemaType } from 'ajv';
+import { act } from 'react-dom/test-utils';
 import { AutoForm } from 'uniforms';
-import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { EntitiesContext } from '../../../providers/entities.provider';
-import { SchemaService } from '../../Form';
-import { CustomAutoFieldDetector } from '../../Form/CustomAutoField';
-import { CanvasForm } from './CanvasForm';
-import { CanvasNode } from './canvas.models';
 import {
   CamelCatalogService,
   CamelRouteVisualEntity,
@@ -17,9 +12,14 @@ import {
   ICamelLanguageDefinition,
   ICamelLoadBalancerDefinition,
   ICamelProcessorDefinition,
+  KaotoSchemaDefinition,
 } from '../../../models';
-import { act } from 'react-dom/test-utils';
-import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
+import { EntitiesContext } from '../../../providers/entities.provider';
+import { SchemaService } from '../../Form';
+import { CustomAutoFieldDetector } from '../../Form/CustomAutoField';
+import { CanvasForm } from './CanvasForm';
+import { CanvasNode } from './canvas.models';
 
 describe('CanvasForm', () => {
   const schemaService = new SchemaService();
@@ -31,7 +31,7 @@ describe('CanvasForm', () => {
         type: 'string',
       },
     },
-  } as unknown as JSONSchemaType<unknown>;
+  } as unknown as KaotoSchemaDefinition['schema'];
 
   beforeAll(async () => {
     const patternCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
@@ -111,7 +111,7 @@ describe('CanvasForm', () => {
   it('should render nothing if no schema and no definition is available', () => {
     const visualComponentSchema: VisualComponentSchema = {
       title: 'My Node',
-      schema: null as unknown as JSONSchemaType<unknown>,
+      schema: null as unknown as KaotoSchemaDefinition['schema'],
       definition: null,
     };
 
@@ -137,7 +137,7 @@ describe('CanvasForm', () => {
   it('should update the parameters object if null', () => {
     const visualComponentSchema: VisualComponentSchema = {
       title: 'My Node',
-      schema: null as unknown as JSONSchemaType<unknown>,
+      schema: null as unknown as KaotoSchemaDefinition['schema'],
       definition: {
         parameters: null,
       },

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/FlowTypeSelector.test.tsx
@@ -1,21 +1,24 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { EntitiesContextResult } from '../../../../hooks';
-import { Schema } from '../../../../models';
+import { KaotoSchemaDefinition } from '../../../../models';
 import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { FlowTypeSelector } from './FlowTypeSelector';
 
 const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Pipe].schema = { name: 'Pipe', schema: { name: 'Pipe', description: 'desc' } } as Schema;
+config.config[SourceSchemaType.Pipe].schema = {
+  name: 'Pipe',
+  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
 config.config[SourceSchemaType.Kamelet].schema = {
   name: 'Kamelet',
-  schema: { name: 'Kamelet', description: 'desc' },
-} as Schema;
+  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
 config.config[SourceSchemaType.Route].schema = {
   name: 'route',
-  schema: { name: 'route', description: 'desc' },
-} as Schema;
+  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
 
 const onSelect = jest.fn();
 const FlowTypeSelectorWithContext: React.FunctionComponent<{ currentSchemaType?: SourceSchemaType }> = ({

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowType/NewFlow.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import { EntitiesContextResult } from '../../../../hooks';
-import { Schema } from '../../../../models';
+import { KaotoSchemaDefinition } from '../../../../models';
 import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { VisibleFlowsProvider } from '../../../../providers';
@@ -11,15 +11,21 @@ import { NewFlow } from './NewFlow';
 describe('NewFlow.tsx', () => {
   const config = sourceSchemaConfig;
   config.config[SourceSchemaType.Integration].schema = {
-    schema: { name: 'Integration', description: 'desc' },
-  } as Schema;
-  config.config[SourceSchemaType.Pipe].schema = { schema: { name: 'Pipe', description: 'desc' } } as Schema;
-  config.config[SourceSchemaType.Kamelet].schema = { schema: { name: 'Kamelet', description: 'desc' } } as Schema;
+    schema: { name: 'Integration', description: 'desc' } as KaotoSchemaDefinition['schema'],
+  } as KaotoSchemaDefinition;
+  config.config[SourceSchemaType.Pipe].schema = {
+    schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
+  } as KaotoSchemaDefinition;
+  config.config[SourceSchemaType.Kamelet].schema = {
+    schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
+  } as KaotoSchemaDefinition;
   config.config[SourceSchemaType.KameletBinding].schema = {
     name: 'kameletBinding',
     schema: { description: 'desc' },
-  } as Schema;
-  config.config[SourceSchemaType.Route].schema = { schema: { name: 'route', description: 'desc' } } as Schema;
+  } as KaotoSchemaDefinition;
+  config.config[SourceSchemaType.Route].schema = {
+    schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
+  } as KaotoSchemaDefinition;
 
   const renderWithContext = () => {
     return render(

--- a/packages/ui/src/models/camel-components-catalog.ts
+++ b/packages/ui/src/models/camel-components-catalog.ts
@@ -1,12 +1,12 @@
 import { CamelPropertyCommon } from './camel-properties-common';
 import { CatalogKind } from './catalog-kind';
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface ICamelComponentDefinition {
   component: ICamelComponent;
   componentProperties: Record<string, ICamelComponentProperty>;
   properties: Record<string, ICamelComponentProperty>;
-  propertiesSchema: JSONSchemaType<unknown>;
+  propertiesSchema: KaotoSchemaDefinition['schema'];
   headers?: Record<string, ICamelComponentHeader>;
   apis?: Record<string, ICamelComponentApi>;
   apiProperties?: Record<string, ICamelComponentApiProperty>;

--- a/packages/ui/src/models/camel-dataformats-catalog.ts
+++ b/packages/ui/src/models/camel-dataformats-catalog.ts
@@ -1,10 +1,10 @@
-import { JSONSchemaType } from 'ajv';
 import { ICamelProcessorModel, ICamelProcessorProperty } from './camel-processors-catalog';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface ICamelDataformatDefinition {
   model: ICamelDataformatModel;
   properties: Record<string, ICamelDataformatProperty>;
-  propertiesSchema: JSONSchemaType<unknown>;
+  propertiesSchema: KaotoSchemaDefinition['schema'];
 }
 
 export interface ICamelDataformatModel extends ICamelProcessorModel {}

--- a/packages/ui/src/models/camel-languages-catalog.ts
+++ b/packages/ui/src/models/camel-languages-catalog.ts
@@ -1,10 +1,10 @@
-import { JSONSchemaType } from 'ajv';
 import { ICamelProcessorModel, ICamelProcessorProperty } from './camel-processors-catalog';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface ICamelLanguageDefinition {
   model: ICamelLanguageModel;
   properties: Record<string, ICamelLanguageProperty>;
-  propertiesSchema: JSONSchemaType<unknown>;
+  propertiesSchema: KaotoSchemaDefinition['schema'];
 }
 
 export interface ICamelLanguageModel extends ICamelProcessorModel {}

--- a/packages/ui/src/models/camel-loadbalancers-catalog.ts
+++ b/packages/ui/src/models/camel-loadbalancers-catalog.ts
@@ -1,10 +1,10 @@
-import { JSONSchemaType } from 'ajv';
 import { ICamelProcessorModel, ICamelProcessorProperty } from './camel-processors-catalog';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface ICamelLoadBalancerDefinition {
   model: ICamelLoadBalancerModel;
   properties: Record<string, ICamelLoadBalancerProperty>;
-  propertiesSchema: JSONSchemaType<unknown>;
+  propertiesSchema: KaotoSchemaDefinition['schema'];
 }
 
 export interface ICamelLoadBalancerModel extends ICamelProcessorModel {}

--- a/packages/ui/src/models/camel-processors-catalog.ts
+++ b/packages/ui/src/models/camel-processors-catalog.ts
@@ -1,11 +1,11 @@
 import { CamelPropertyCommon } from './camel-properties-common';
 import { CatalogKind } from './catalog-kind';
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface ICamelProcessorDefinition {
   model: ICamelProcessorModel;
   properties: Record<string, ICamelProcessorProperty>;
-  propertiesSchema?: JSONSchemaType<unknown>;
+  propertiesSchema?: KaotoSchemaDefinition['schema'];
 }
 
 export interface ICamelProcessorModel {

--- a/packages/ui/src/models/camel/source-schema-config.ts
+++ b/packages/ui/src/models/camel/source-schema-config.ts
@@ -1,9 +1,9 @@
-import { Schema } from '../schema';
+import { KaotoSchemaDefinition } from '../kaoto-schema';
 import { SourceSchemaType } from './source-schema-type';
 import { isEnumType } from '../../utils';
 
 export interface ISourceSchema {
-  schema: Schema | undefined;
+  schema: KaotoSchemaDefinition | undefined;
   name: string;
   multipleRoute: boolean;
 }
@@ -45,7 +45,7 @@ class SourceSchemaConfig {
     },
   };
 
-  setSchema(name: string, schema: Schema) {
+  setSchema(name: string, schema: KaotoSchemaDefinition) {
     if (name === 'camelYamlDsl') {
       this.config[SourceSchemaType.Route].schema = schema;
     }

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -9,6 +9,6 @@ export * from './catalog-kind';
 export * from './kamelets-catalog';
 export * from './local-storage-keys';
 export * from './react-component';
-export * from './schema';
+export * from './kaoto-schema';
 export * from './validation';
 export * from './visualization';

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -1,12 +1,12 @@
 import { FromDefinition, Kamelet, ObjectMeta, RouteTemplateBeanDefinition } from '@kaoto-next/camel-catalog/types';
 import { SourceSchemaType } from './camel/source-schema-type';
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from './kaoto-schema';
 
 export interface IKameletDefinition extends Omit<Kamelet, 'kind' | 'metadata' | 'spec'> {
   kind: SourceSchemaType.Kamelet;
   metadata: IKameletMetadata;
   spec: IKameletSpec;
-  propertiesSchema?: JSONSchemaType<unknown>;
+  propertiesSchema?: KaotoSchemaDefinition['schema'];
 }
 
 export interface IKameletMetadata extends ObjectMeta {

--- a/packages/ui/src/models/kaoto-schema.ts
+++ b/packages/ui/src/models/kaoto-schema.ts
@@ -1,0 +1,9 @@
+import { JSONSchema4 } from 'json-schema';
+
+export interface KaotoSchemaDefinition {
+  name: string;
+  version: string;
+  tags: string[];
+  uri: string;
+  schema: JSONSchema4;
+}

--- a/packages/ui/src/models/schema.ts
+++ b/packages/ui/src/models/schema.ts
@@ -1,7 +1,0 @@
-export interface Schema {
-  name: string;
-  version: string;
-  tags: string[];
-  uri: string;
-  schema: unknown;
-}

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -1,6 +1,6 @@
-import type { JSONSchemaType } from 'ajv';
 import { DefinedComponent } from '../camel-catalog-index';
 import { BaseCamelEntity, EntityType } from '../camel/entities';
+import { KaotoSchemaDefinition } from '../kaoto-schema';
 
 /**
  * BaseVisualCamelEntity
@@ -120,7 +120,7 @@ export interface IVisualizationNodeData {
  */
 export interface VisualComponentSchema {
   title: string;
-  schema: JSONSchemaType<unknown>;
+  schema: KaotoSchemaDefinition['schema'];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   definition: any;
 }

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -1,10 +1,10 @@
 import { ProcessorDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
-import { JSONSchemaType } from 'ajv';
 import cloneDeep from 'lodash.clonedeep';
 import { camelFromJson } from '../../../stubs/camel-from';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { ROOT_PATH } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
 import { IVisualizationNode } from '../base-visual-entity';
 import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from './camel-route-visual-entity';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
@@ -115,7 +115,7 @@ describe('Camel Route', () => {
       const spy = jest.spyOn(CamelComponentSchemaService, 'getVisualComponentSchema');
       spy.mockReturnValueOnce({
         title: 'test',
-        schema: {} as JSONSchemaType<unknown>,
+        schema: {} as KaotoSchemaDefinition['schema'],
         definition: {},
       });
 

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,8 +1,8 @@
-import { JSONSchemaType } from 'ajv';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { ROOT_PATH } from '../../../utils';
 import { EntityType } from '../../camel/entities';
 import { IKameletDefinition, IKameletMetadata, IKameletSpec } from '../../kamelets-catalog';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
 import { VisualComponentSchema } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 
@@ -31,7 +31,7 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity {
       /** A better schema will be provided at a later stage */
       return {
         title: 'Kamelet',
-        schema: {} as JSONSchemaType<unknown>,
+        schema: {} as KaotoSchemaDefinition['schema'],
         definition: this.route,
       };
     }

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -1,13 +1,13 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
 import { Pipe } from '@kaoto-next/camel-catalog/types';
-import { JSONSchemaType } from 'ajv';
 import cloneDeep from 'lodash/cloneDeep';
 import { pipeJson } from '../../../stubs/pipe';
 import { EntityType } from '../../camel/entities';
 import { CatalogKind } from '../../catalog-kind';
 import { IKameletDefinition } from '../../kamelets-catalog';
-import { PipeVisualEntity } from './pipe-visual-entity';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
 import { CamelCatalogService } from './camel-catalog.service';
+import { PipeVisualEntity } from './pipe-visual-entity';
 import { KameletSchemaService } from './support/kamelet-schema.service';
 
 describe('Pipe', () => {
@@ -57,7 +57,7 @@ describe('Pipe', () => {
       const spy = jest.spyOn(KameletSchemaService, 'getVisualComponentSchema');
       spy.mockReturnValueOnce({
         title: 'test',
-        schema: {} as JSONSchemaType<unknown>,
+        schema: {} as KaotoSchemaDefinition['schema'],
         definition: {},
       });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,13 +1,13 @@
 import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
-import type { JSONSchemaType } from 'ajv';
 import cloneDeep from 'lodash/cloneDeep';
 import { CamelUriHelper, ROOT_PATH, isDefined } from '../../../../utils';
+import { ICamelComponentDefinition } from '../../../camel-components-catalog';
 import { CatalogKind } from '../../../catalog-kind';
+import { IKameletDefinition } from '../../../kamelets-catalog';
+import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { VisualComponentSchema } from '../../base-visual-entity';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelProcessorStepsProperties, ICamelElementLookupResult } from './camel-component-types';
-import { IKameletDefinition } from '../../../kamelets-catalog';
-import { ICamelComponentDefinition } from '../../../camel-components-catalog';
 
 export class CamelComponentSchemaService {
   static DISABLED_SIBLING_STEPS = ['from', 'onWhen', 'when', 'otherwise', 'doCatch', 'doFinally'];
@@ -230,7 +230,7 @@ export class CamelComponentSchemaService {
     return uriParts[0];
   }
 
-  private static getSchema(camelElementLookup: ICamelElementLookupResult): JSONSchemaType<unknown> {
+  private static getSchema(camelElementLookup: ICamelElementLookupResult): KaotoSchemaDefinition['schema'] {
     let catalogKind: CatalogKind;
     switch (camelElementLookup.processorName) {
       case 'route' as keyof ProcessorDefinition:
@@ -251,20 +251,20 @@ export class CamelComponentSchemaService {
 
     const processorDefinition = CamelCatalogService.getComponent(catalogKind, camelElementLookup.processorName);
 
-    if (processorDefinition === undefined) return {} as unknown as JSONSchemaType<unknown>;
+    if (processorDefinition === undefined) return {} as unknown as KaotoSchemaDefinition['schema'];
 
-    let schema = {} as unknown as JSONSchemaType<unknown>;
+    let schema = {} as unknown as KaotoSchemaDefinition['schema'];
     if (processorDefinition.propertiesSchema !== undefined) {
       schema = cloneDeep(processorDefinition.propertiesSchema);
     }
 
     if (camelElementLookup.componentName !== undefined) {
       const catalogLookup = CamelCatalogService.getCatalogLookup(camelElementLookup.componentName);
-      const componentSchema: JSONSchemaType<unknown> =
-        catalogLookup.definition?.propertiesSchema ?? ({} as unknown as JSONSchemaType<unknown>);
+      const componentSchema: KaotoSchemaDefinition['schema'] =
+        catalogLookup.definition?.propertiesSchema ?? ({} as unknown as KaotoSchemaDefinition['schema']);
 
       if (catalogLookup.definition !== undefined && componentSchema !== undefined) {
-        schema.properties.parameters = {
+        schema.properties!.parameters = {
           type: 'object',
           title: 'Endpoint Properties',
           description: 'Endpoint properties description',

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
@@ -1,9 +1,9 @@
 import { KameletBindingStep, PipeStep } from '../../../camel/entities';
 import { CatalogKind } from '../../../catalog-kind';
 import { IKameletDefinition } from '../../../kamelets-catalog';
+import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { VisualComponentSchema } from '../../base-visual-entity';
 import { CamelCatalogService } from '../camel-catalog.service';
-import { JSONSchemaType } from 'ajv';
 
 export class KameletSchemaService {
   static getVisualComponentSchema(stepModel?: PipeStep): VisualComponentSchema | undefined {
@@ -15,7 +15,7 @@ export class KameletSchemaService {
 
     return {
       title: definition?.metadata.name || '',
-      schema: definition?.propertiesSchema || ({} as JSONSchemaType<unknown>),
+      schema: definition?.propertiesSchema || ({} as KaotoSchemaDefinition['schema']),
       definition: stepModel?.properties || {},
     };
   }

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
@@ -1,4 +1,4 @@
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from '../../../../kaoto-schema';
 import { VisualComponentSchema } from '../../../base-visual-entity';
 
 interface IValidationResult {
@@ -45,7 +45,7 @@ export class ModelValidationService {
   }
 
   private static validateRequiredProperties(
-    schema: JSONSchemaType<unknown>,
+    schema: KaotoSchemaDefinition['schema'],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     model: any,
     parentPath: string,
@@ -54,7 +54,7 @@ export class ModelValidationService {
 
     if (schema.properties) {
       Object.entries(schema.properties).forEach(([propertyName, propertyValue]) => {
-        const propertySchema = propertyValue as JSONSchemaType<unknown>;
+        const propertySchema = propertyValue as KaotoSchemaDefinition['schema'];
         // TODO
         if (propertySchema.type === 'array') return;
         if (propertySchema.type === 'object') {
@@ -66,7 +66,8 @@ export class ModelValidationService {
         }
         // check missing required parameter
         if (
-          schema.required?.includes(propertyName) &&
+          Array.isArray(schema.required) &&
+          schema.required.includes(propertyName) &&
           propertySchema.default === undefined &&
           (!model || !model[propertyName])
         ) {

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -1,12 +1,13 @@
-import { BeansEntityHandler } from './beans-entity-handler';
-import { CamelRouteResource, KameletResource, PipeResource } from '../../camel';
-import * as kameletStub from '../../../stubs/kamelet-route';
-import * as routeStub from '../../../stubs/camel-route';
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
-import { CamelCatalogService } from '../flows';
-import { CatalogKind } from '../../catalog-kind';
-import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 import cloneDeep from 'lodash/cloneDeep';
+import * as routeStub from '../../../stubs/camel-route';
+import * as kameletStub from '../../../stubs/kamelet-route';
+import { CamelRouteResource, KameletResource, PipeResource } from '../../camel';
+import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
+import { CatalogKind } from '../../catalog-kind';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import { CamelCatalogService } from '../flows';
+import { BeansEntityHandler } from './beans-entity-handler';
 
 describe('BeansEntityHandler', () => {
   beforeAll(async () => {
@@ -32,10 +33,10 @@ describe('BeansEntityHandler', () => {
       expect(model.beans).toBeUndefined();
       expect(beansHandler.isSupported()).toBeTruthy();
       const beanSchema = beansHandler.getBeanSchema();
-      expect(beanSchema?.properties.builderClass.title).toEqual('Builder Class');
-      expect(beanSchema?.properties.script.title).toEqual('Script');
+      expect(beanSchema!.properties!.builderClass.title).toEqual('Builder Class');
+      expect(beanSchema!.properties!.script.title).toEqual('Script');
       const beansSchema = beansHandler.getBeansSchema();
-      expect(beansSchema?.items['$ref']).toContain('RegistryBeanDefinition');
+      expect((beansSchema!.items as KaotoSchemaDefinition['schema'])['$ref']).toContain('RegistryBeanDefinition');
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
     });
@@ -84,11 +85,13 @@ describe('BeansEntityHandler', () => {
       expect(model.spec.template.beans).toBeUndefined();
       expect(beansHandler.isSupported()).toBeTruthy();
       const beanSchema = beansHandler.getBeanSchema();
-      expect(beanSchema?.properties.builderClass).toBeUndefined();
-      expect(beanSchema?.properties.script.title).toEqual('Script');
+      expect(beanSchema?.properties!.builderClass).toBeUndefined();
+      expect(beanSchema?.properties!.script.title).toEqual('Script');
       const beansSchema = beansHandler.getBeansSchema();
-      expect(beansSchema?.items.properties.scriptLanguage.title).toEqual('Script Language');
-      expect(beansSchema?.items.properties.builderClass).toBeUndefined();
+      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.scriptLanguage.title).toEqual(
+        'Script Language',
+      );
+      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.builderClass).toBeUndefined();
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
     });

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -1,14 +1,15 @@
-import { BeansAwareResource, CamelResource, RouteTemplateBeansAwareResource } from '../../camel';
-import { CamelCatalogService, CatalogKind } from '../../index';
-import { EntityType } from '../../camel/entities';
-import { BeansEntity } from './index';
-import { RouteTemplateBeansEntity } from './routeTemplateBeansEntity';
 import {
   BeansDeserializer,
   RegistryBeanDefinition,
   RouteTemplateBeanDefinition,
 } from '@kaoto-next/camel-catalog/types';
-import { JSONSchemaType } from 'ajv';
+import { BeansAwareResource, CamelResource, RouteTemplateBeansAwareResource } from '../../camel';
+import { EntityType } from '../../camel/entities';
+import { CatalogKind } from '../../catalog-kind';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import { CamelCatalogService } from '../flows/camel-catalog.service';
+import { BeansEntity } from './beansEntity';
+import { RouteTemplateBeansEntity } from './routeTemplateBeansEntity';
 
 /**
  * This class is to absorb a little bit of difference between beans such as {@link RegistryBeanDefinition} and {@link RouteTemplateBeanDefinition}.
@@ -34,7 +35,7 @@ export class BeansEntityHandler {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getBeanSchema(): JSONSchemaType<any> | undefined {
+  getBeanSchema(): KaotoSchemaDefinition['schema'] | undefined {
     switch (this.type) {
       case 'beans':
         return CamelCatalogService.getComponent(CatalogKind.Entity, 'bean')?.propertiesSchema;
@@ -46,7 +47,7 @@ export class BeansEntityHandler {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getBeansSchema(): JSONSchemaType<any> | undefined {
+  getBeansSchema(): KaotoSchemaDefinition['schema'] | undefined {
     switch (this.type) {
       case 'beans': {
         const beanCatalog = CamelCatalogService.getComponent(CatalogKind.Entity, 'beans');

--- a/packages/ui/src/providers/schemas.provider.tsx
+++ b/packages/ui/src/providers/schemas.provider.tsx
@@ -1,12 +1,12 @@
 import { Text, TextVariants } from '@patternfly/react-core';
 import { FunctionComponent, PropsWithChildren, createContext, useEffect, useState } from 'react';
 import { Loading } from '../components/Loading';
-import { CamelCatalogIndex, Schema } from '../models';
+import { CamelCatalogIndex, KaotoSchemaDefinition } from '../models';
 import { sourceSchemaConfig } from '../models/camel';
 import { useSchemasStore } from '../store';
 import { CatalogSchemaLoader } from '../utils';
 
-export const SchemasContext = createContext<Record<string, Schema>>({});
+export const SchemasContext = createContext<Record<string, KaotoSchemaDefinition>>({});
 
 /**
  * Loader for the components schemas.
@@ -14,7 +14,7 @@ export const SchemasContext = createContext<Record<string, Schema>>({});
 export const SchemasLoaderProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: string }>> = (props) => {
   const setSchema = useSchemasStore((state) => state.setSchema);
   const [isLoading, setIsLoading] = useState(true);
-  const [schemas, setSchemas] = useState<Record<string, Schema>>({});
+  const [schemas, setSchemas] = useState<Record<string, KaotoSchemaDefinition>>({});
 
   useEffect(() => {
     fetch(`${props.catalogUrl}/index.json`)
@@ -31,7 +31,7 @@ export const SchemasLoaderProvider: FunctionComponent<PropsWithChildren<{ catalo
 
             return acc;
           },
-          {} as Record<string, Schema>,
+          {} as Record<string, KaotoSchemaDefinition>,
         );
 
         setSchemas(combinedSchemas);

--- a/packages/ui/src/store/schemas.store.ts
+++ b/packages/ui/src/store/schemas.store.ts
@@ -1,16 +1,16 @@
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
-import { Schema } from '../models';
+import { KaotoSchemaDefinition } from '../models';
 
 interface SchemasState {
-  schemas: { [key: string]: Schema };
-  setSchema: (schemaKey: string, schema: Schema) => void;
+  schemas: { [key: string]: KaotoSchemaDefinition };
+  setSchema: (schemaKey: string, schema: KaotoSchemaDefinition) => void;
 }
 
 export const useSchemasStore = createWithEqualityFn<SchemasState>(
   (set) => ({
     schemas: {},
-    setSchema: (schemaKey: string, schema: Schema) => {
+    setSchema: (schemaKey: string, schema: KaotoSchemaDefinition) => {
       set((state) => ({
         schemas: {
           ...state.schemas,

--- a/packages/ui/src/utils/catalog-schema-loader.ts
+++ b/packages/ui/src/utils/catalog-schema-loader.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaEntry } from '../models';
+import { KaotoSchemaDefinition, SchemaEntry } from '../models';
 
 export class CatalogSchemaLoader {
   /** The `.` is required to support relative routes in GitHub pages */
@@ -12,7 +12,7 @@ export class CatalogSchemaLoader {
     return { body, uri: response.url };
   }
 
-  static getSchemasFiles(basePath: string, schemaFiles: Record<string, SchemaEntry>): Promise<Schema>[] {
+  static getSchemasFiles(basePath: string, schemaFiles: Record<string, SchemaEntry>): Promise<KaotoSchemaDefinition>[] {
     return Object.entries(schemaFiles).map(async ([name, schemaDef]) => {
       const fetchedSchema = await this.fetchFile(`${basePath}/${schemaDef.file}`);
       const tags = [];
@@ -26,7 +26,7 @@ export class CatalogSchemaLoader {
         tags,
         version: schemaDef.version,
         uri: fetchedSchema.uri,
-        schema: fetchedSchema.body,
+        schema: fetchedSchema.body as KaotoSchemaDefinition['schema'],
       };
     });
   }

--- a/packages/ui/src/utils/get-non-default-properties.test.ts
+++ b/packages/ui/src/utils/get-non-default-properties.test.ts
@@ -1,4 +1,4 @@
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
 import { getNonDefaultProperties } from './get-non-default-properties';
 
 describe('getNonDefaultProperties()', () => {
@@ -25,7 +25,7 @@ describe('getNonDefaultProperties()', () => {
         },
       },
     },
-  } as unknown as JSONSchemaType<unknown>;
+  } as unknown as KaotoSchemaDefinition['schema'];
 
   const newModel: Record<string, unknown> = {
     id: 'from-7126',
@@ -50,7 +50,7 @@ describe('getNonDefaultProperties()', () => {
   };
 
   it('should return only the properties which are different from default', () => {
-    const newModelClean = getNonDefaultProperties(schema?.properties.parameters.properties, newModel);
+    const newModelClean = getNonDefaultProperties(schema.properties!.parameters.properties!, newModel);
     expect(newModelClean).toMatchObject(newModelExpected);
   });
 });

--- a/packages/ui/src/utils/get-non-default-properties.ts
+++ b/packages/ui/src/utils/get-non-default-properties.ts
@@ -1,9 +1,5 @@
-import type { JSONSchemaType } from 'ajv';
-
-export function getNonDefaultProperties(
-  obj1: JSONSchemaType<unknown>,
-  obj2: Record<string, unknown>,
-): Record<string, unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getNonDefaultProperties(obj1: Record<string, any>, obj2: Record<string, any>): Record<string, unknown> {
   const newModelUpdated = Object.entries(obj2.parameters as object).reduce(
     (acc: [string, unknown][], currentValue: [string, unknown]) => {
       if (!(obj1[currentValue[0]]['default'] == currentValue[1])) {

--- a/packages/ui/src/utils/get-non-empty-properties.test.ts
+++ b/packages/ui/src/utils/get-non-empty-properties.test.ts
@@ -1,9 +1,9 @@
-import { JSONSchemaType } from 'ajv';
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
 import { getNonDefaultProperties } from './get-non-default-properties';
 import { getNonEmptyProperties } from './get-non-empty-properties';
 
 describe('CanvasForm getNonEmptyProperties()', () => {
-  const schema = {
+  const schema: KaotoSchemaDefinition['schema'] = {
     type: 'object',
     properties: {
       parameters: {
@@ -30,7 +30,7 @@ describe('CanvasForm getNonEmptyProperties()', () => {
         },
       },
     },
-  } as unknown as JSONSchemaType<unknown>;
+  };
 
   const newModel: Record<string, unknown> = {
     id: 'from-7126',
@@ -68,7 +68,7 @@ describe('CanvasForm getNonEmptyProperties()', () => {
   };
 
   it('should return only the properties which are different from default', () => {
-    const newModelClean = getNonDefaultProperties(schema?.properties.parameters.properties, newModel);
+    const newModelClean = getNonDefaultProperties(schema.properties!.parameters.properties!, newModel);
     expect(newModelClean).toMatchObject(newModelIntermediate);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,7 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.4.3
     "@types/jest": ^29.4.0
+    "@types/json-schema": ^7.0.15
     "@types/lodash.clonedeep": ^4.5.7
     "@types/lodash.get": ^4.4.2
     "@types/lodash.isempty": ^4.4.9
@@ -5997,6 +5998,13 @@ __metadata:
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
   checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Curently, we're relying on the `JSONSchemaType` from the `ajv` library, and while this is working, we're not leveraging it in a meaningful way.

This commit removes its usage in favor of the lightweight `@types/json-schema` package and consolidate its definition in the `KaotoSchema.ts` file, this way, when a new type is desired, the change will happen in a single file instead.