### PR TITLE
chore(build): Enable maven cache

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       # Install dependencies
       - run: yarn

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
       - name: Install dependencies

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "21"
+          cache: 'maven'
 
       - name: "🔧 Install dependencies"
         run: yarn

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,11 +33,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-          
+
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       # Install dependencies
       - run: yarn install --immutable
@@ -79,6 +80,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v4
@@ -137,6 +139,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v4
@@ -195,6 +198,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       - name: 🗄️ Download the UI build folder
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       - name: 🔧 Install dependencies
         run: yarn
@@ -97,6 +98,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'maven'
 
       - name: 🔧 Install dependencies
         run: yarn
@@ -121,7 +123,7 @@ jobs:
         shell: bash
         run: |
           docker push quay.io/kaotoio/kaoto-app:${{ github.event.inputs.tag_version }}
-          
+
       - name: "🔧 Build Container Image"
         shell: bash
         run: |


### PR DESCRIPTION
Currently, there's no cache enabled for the `actions/setup-java` GitHub action.

This commit enables it.