### PR TITLE
chore(form): Add SchemaBridge provider

### DIFF
--- a/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
@@ -85,7 +85,6 @@ export default {
 } as Meta<typeof CanvasSideBar>;
 
 const Template: StoryFn<typeof CanvasSideBar> = (args) => {
-  console.log(args);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleClose = () => setIsModalOpen(!isModalOpen);
   return <CanvasSideBar {...args} onClose={handleClose} />;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,7 @@
     "@patternfly/react-topology": "5.2.1",
     "@types/uuid": "^9.0.2",
     "ajv": "^8.12.0",
+    "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^2.1.1",
     "clsx": "^2.1.0",
     "html-to-image": "^1.11.11",

--- a/packages/ui/src/components/Form/schema.service.test.ts
+++ b/packages/ui/src/components/Form/schema.service.test.ts
@@ -48,5 +48,6 @@ describe('SchemaService', () => {
     jest.spyOn(console, 'error').mockImplementation(() => null);
     expect(() => validator!({})).not.toThrow();
     expect(validator!({})).toBeNull();
+    (console.error as jest.Mock).mockRestore();
   });
 });

--- a/packages/ui/src/components/Form/schema.service.ts
+++ b/packages/ui/src/components/Form/schema.service.ts
@@ -1,7 +1,7 @@
-import Ajv, { ValidateFunction } from 'ajv';
+import Ajv, { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { filterDOMProps, FilterDOMPropsKeys } from 'uniforms';
-import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
+import { JSONSchemaBridge as SchemaBridge } from 'uniforms-bridge-json-schema';
 import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
 
 export class SchemaService {
@@ -24,15 +24,16 @@ export class SchemaService {
 
   constructor() {
     this.ajv = new Ajv({
+      strict: false,
       allErrors: true,
       useDefaults: true,
-      keywords: ['uniforms'],
+      keywords: ['uniforms', 'isRequired'],
     });
 
     addFormats(this.ajv);
   }
 
-  getSchemaBridge(schema?: unknown): JSONSchemaBridge | undefined {
+  getSchemaBridge(schema?: unknown): SchemaBridge | undefined {
     if (!schema) return undefined;
 
     // uniforms passes it down to the React elements as an attribute, causes a warning
@@ -40,7 +41,7 @@ export class SchemaService {
 
     const schemaValidator = this.createValidator(schema);
 
-    return new JSONSchemaBridge({ schema, validator: schemaValidator });
+    return new SchemaBridge({ schema, validator: schemaValidator });
   }
 
   private createValidator(schema: KaotoSchemaDefinition['schema']) {

--- a/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
+++ b/packages/ui/src/components/MetadataEditor/MetadataEditor.tsx
@@ -1,8 +1,7 @@
 import { Split, SplitItem, Stack, StackItem, Title } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
-import { SchemaService } from '../Form';
+import { SchemaBridgeProvider } from '../../providers/schema-bridge.provider';
 import { CustomAutoForm, CustomAutoFormRef } from '../Form/CustomAutoForm';
 import './MetadataEditor.scss';
 import { TopmostArrayTable } from './TopmostArrayTable';
@@ -19,10 +18,6 @@ interface MetadataEditorProps {
 }
 
 export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>((props, forwardedRef) => {
-  const schemaServiceRef = useRef(new SchemaService());
-  const [schemaBridge, setSchemaBridge] = useState<JSONSchemaBridge | undefined>(
-    schemaServiceRef.current.getSchemaBridge(getFormSchema()),
-  );
   const fieldsRefs = useRef<CustomAutoFormRef>(null);
   const [selected, setSelected] = useState(-1);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,10 +27,6 @@ export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>
     fields: fieldsRefs.current?.fields ?? [],
     form: fieldsRefs.current?.form,
   }));
-
-  useEffect(() => {
-    setSchemaBridge(schemaServiceRef.current.getSchemaBridge(getFormSchema()));
-  }, [props.schema]);
 
   useEffect(() => {
     // The input like checkbox doesn't have focus() method
@@ -99,7 +90,7 @@ export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>
   }
 
   return (
-    <>
+    <SchemaBridgeProvider schema={getFormSchema()}>
       {isTopmostArray() ? (
         <Split hasGutter>
           <SplitItem className="metadata-editor-modal-list-view">
@@ -120,7 +111,6 @@ export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>
               </StackItem>
               <StackItem isFilled>
                 <CustomAutoForm
-                  schemaBridge={schemaBridge}
                   model={getFormModel()}
                   onChangeModel={onChangeFormModel}
                   data-testid={`metadata-editor-form-${props.name}`}
@@ -135,7 +125,6 @@ export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>
         </Split>
       ) : (
         <CustomAutoForm
-          schemaBridge={schemaBridge}
           model={getFormModel()}
           onChangeModel={onChangeFormModel}
           data-testid={`metadata-editor-form-${props.name}`}
@@ -145,6 +134,6 @@ export const MetadataEditor = forwardRef<CustomAutoFormRef, MetadataEditorProps>
           handleConfirm={props.handleConfirm}
         />
       )}
-    </>
+    </SchemaBridgeProvider>
   );
 });

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './entities';
 export * from './local-storage.hook';
+export * from './schema-bridge.hook';

--- a/packages/ui/src/hooks/schema-bridge.hook.test.tsx
+++ b/packages/ui/src/hooks/schema-bridge.hook.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { SchemaBridgeProvider } from '../providers/schema-bridge.provider';
+import { useSchemaBridgeContext } from './schema-bridge.hook';
+
+describe('useSchemaBridgeContext', () => {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <SchemaBridgeProvider schema={{}}>{children}</SchemaBridgeProvider>
+  );
+
+  it('should throw an error if used outside of SchemaBridgeProvider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useSchemaBridgeContext());
+    }).toThrowError('useSchemaBridgeContext needs to be called inside `SchemaBridgeProvider`');
+
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it('should be return EntityContext', () => {
+    const { result } = renderHook(() => useSchemaBridgeContext(), { wrapper });
+
+    expect(result.current).not.toBe(null);
+  });
+});

--- a/packages/ui/src/hooks/schema-bridge.hook.tsx
+++ b/packages/ui/src/hooks/schema-bridge.hook.tsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { SchemaBridgeContext } from '../providers/schema-bridge.provider';
+
+export const useSchemaBridgeContext = () => {
+  const ctx = useContext(SchemaBridgeContext);
+
+  if (!ctx) throw new Error('useSchemaBridgeContext needs to be called inside `SchemaBridgeProvider`');
+
+  return ctx;
+};

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -9,6 +9,7 @@ describe('useEntityContext', () => {
   it('should be throw when use hook without provider', () => {
     jest.spyOn(console, 'error').mockImplementation(() => null);
     expect(() => renderHook(() => useEntityContext())).toThrow(errorMessage);
+    (console.error as jest.Mock).mockRestore();
   });
 
   it('should be return EntityContext', () => {

--- a/packages/ui/src/models/camel/entities/base-entity.ts
+++ b/packages/ui/src/models/camel/entities/base-entity.ts
@@ -2,6 +2,7 @@
 export const enum EntityType {
   Route = 'route',
   OnException = 'onException',
+  ErrorHandler = 'errorHandler',
   Integration = 'integration',
   Kamelet = 'kamelet',
   KameletBinding = 'kameletBinding',
@@ -10,7 +11,7 @@ export const enum EntityType {
   RestConfiguration = 'restConfiguration',
   Beans = 'beans',
   Metadata = 'metadata',
-  ErrorHandler = 'errorHandler',
+  PipeErrorHandler = 'pipeErrorHandler',
   NonVisualEntity = 'nonVisualEntity',
 }
 

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -20,7 +20,7 @@ import { CamelComponentDefaultService } from './support/camel-component-default.
 
 export class CamelOnExceptionVisualEntity implements BaseVisualCamelEntity {
   id: string;
-  readonly type = EntityType.ErrorHandler;
+  readonly type = EntityType.OnException;
   private static readonly ROOT_PATH = 'onException';
 
   constructor(public onExceptionDef: { onException: OnException }) {

--- a/packages/ui/src/models/visualization/metadata/pipeErrorHandlerEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/pipeErrorHandlerEntity.ts
@@ -4,7 +4,7 @@ import { PipeSpecErrorHandler } from '../../camel/entities/pipe-overrides';
 
 export class PipeErrorHandlerEntity implements BaseCamelEntity {
   readonly id = uuidv4();
-  readonly type = EntityType.ErrorHandler;
+  readonly type = EntityType.PipeErrorHandler;
 
   constructor(public parent: PipeSpecErrorHandler) {}
 

--- a/packages/ui/src/providers/schema-bridge.provider.test.tsx
+++ b/packages/ui/src/providers/schema-bridge.provider.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { SchemaBridgeProvider } from './schema-bridge.provider';
+import { KaotoSchemaDefinition } from '../models';
+import { SchemaService } from '../public-api';
+
+describe('SchemaBridgeProvider', () => {
+  const schema: KaotoSchemaDefinition['schema'] = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+    },
+  };
+
+  it('should use SchemaService to create a bridge', () => {
+    const schemaServiceSpy = jest.spyOn(SchemaService.prototype, 'getSchemaBridge');
+    const result = render(<SchemaBridgeProvider schema={schema} />);
+
+    expect(result).not.toBe(null);
+    expect(schemaServiceSpy).toHaveBeenCalledWith(schema);
+  });
+});

--- a/packages/ui/src/providers/schema-bridge.provider.tsx
+++ b/packages/ui/src/providers/schema-bridge.provider.tsx
@@ -1,0 +1,21 @@
+import { FunctionComponent, PropsWithChildren, createContext, useMemo } from 'react';
+import { JSONSchemaBridge as SchemaBridge } from 'uniforms-bridge-json-schema';
+import { SchemaService } from '../components/Form/schema.service';
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
+
+interface SchemaBridgeProviderProps {
+  schema: KaotoSchemaDefinition['schema'] | undefined;
+}
+
+export const SchemaBridgeContext = createContext<SchemaBridge | undefined>(undefined);
+
+export const SchemaBridgeProvider: FunctionComponent<PropsWithChildren<SchemaBridgeProviderProps>> = (props) => {
+  const schemaBridge = useMemo(() => {
+    const schemaService = new SchemaService();
+    const schemaBridge = schemaService.getSchemaBridge(props.schema);
+
+    return schemaBridge;
+  }, [props.schema]);
+
+  return <SchemaBridgeContext.Provider value={schemaBridge}>{props.children}</SchemaBridgeContext.Provider>;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,6 +2480,7 @@ __metadata:
     "@typescript-eslint/parser": ^7.0.0
     "@vitejs/plugin-react": ^4.0.3
     ajv: ^8.12.0
+    ajv-draft-04: ^1.0.0
     ajv-formats: ^2.1.1
     babel-jest: ^29.4.2
     clsx: ^2.1.0
@@ -6834,6 +6835,18 @@ __metadata:
     clean-stack: ^2.0.0
     indent-string: ^4.0.0
   checksum: 1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
+  languageName: node
+  linkType: hard
+
+"ajv-draft-04@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "ajv-draft-04@npm:1.0.0"
+  peerDependencies:
+    ajv: ^8.5.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 3f11fa0e7f7359bef6608657f02ab78e9cc62b1fb7bdd860db0d00351b3863a1189c1a23b72466d2d82726cab4eb20725c76f5e7c134a89865e2bfd0e6828137
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
Currently, we need to create a `JSONSchemaBridge` to use a schema with uniforms.

This commit creates a new `SchemaBridgeProvider` so the handling and creation of the bridge are consolidated in a single place, leaving the consumer to provide only a desired schema to the form.

relates: https://github.com/KaotoIO/kaoto-next/issues/560