### PR TITLE
build: Trigger vscode-kaoto tests on push to main branch

### DIFF
--- a/.github/workflows/vscode-tests.yml
+++ b/.github/workflows/vscode-tests.yml
@@ -1,0 +1,21 @@
+name: 🏗️ VS Code Kaoto Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-vscode-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger vscode-kaoto tests
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: KaotoIO
+          repo: vscode-kaoto
+          ref: main
+          github_token: ${{ secrets.KAOTO_CI_TOKEN }}
+          workflow_file_name: main-kaoto.yaml
+          propagate_failure: false # do not fail this pipeline when vscode-kaoto tests fails
+          wait_workflow: false # do not wait for vscode-kaoto tests finish


### PR DESCRIPTION
Requirement

- we need to add some (eg TRIGGER_VSCODE_TOKEN) token with `repo` permissions enabled and add it into project secrets. May I ask for help @lordrip ?

unfortunately we cannot use `secrets.GITHUB_TOKEN` because there are limitations for triggering jobs (https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)