### PR TITLE
fix(801) - remove bit more noise from jest tests

### DIFF
--- a/packages/ui/src/components/Form/schema.service.test.ts
+++ b/packages/ui/src/components/Form/schema.service.test.ts
@@ -32,7 +32,7 @@ describe('SchemaService', () => {
         name: { $ref: 'invalid' },
       },
     };
-
+    jest.spyOn(console, 'error').mockImplementation(() => null);
     expect(() => schemaService.getSchemaBridge(schema)).not.toThrow();
   });
 
@@ -45,7 +45,7 @@ describe('SchemaService', () => {
     };
     const schemaBridge = schemaService.getSchemaBridge(schema);
     const validator = schemaBridge?.validator;
-
+    jest.spyOn(console, 'error').mockImplementation(() => null);
     expect(() => validator!({})).not.toThrow();
     expect(validator!({})).toBeNull();
   });

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -7,7 +7,7 @@ const wrapper = ({ children }: PropsWithChildren) => <EntitiesProvider>{children
 
 describe('useEntityContext', () => {
   it('should be throw when use hook without provider', () => {
-    jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+    jest.spyOn(console, 'error').mockImplementation(() => null);
     expect(() => renderHook(() => useEntityContext())).toThrow(errorMessage);
   });
 


### PR DESCRIPTION
continue with fixes for https://github.com/KaotoIO/kaoto-next/issues/801

The rest of the noise from the jest tests is caused by the jest generated canvas DOM not setting some attributes - resulting in "Warning: Received NaN for the `y2` attribute. If this is expected, cast the value to a string."
This is harmless, even though annoying, polluting the test output, can't figure a way to suppress this warning ATM, other than suppressing the warnings altogether.