### PR TITLE
fix(catalog): Provide fixed size for Properties Catalog

### DIFF
--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.scss
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.scss
@@ -25,4 +25,20 @@
   span[data-label='group'] {
     font-weight: normal;
   }
+
+  &__body {
+    height: 75vh;
+
+    @media screen and (height <= 720px) {
+      height: 100vh;
+    }
+
+    @media screen and (height <= 1080px) {
+      height: 75vh;
+    }
+
+    @media screen and (height <= 1440px) {
+      height: 60vh;
+    }
+  }
 }

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
@@ -67,8 +67,9 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
       onClose={props.onClose}
       ouiaId="BasicModal"
       description={description}
+      variant="large"
     >
-      <ModalBoxBody>
+      <ModalBoxBody className="properties-modal__body">
         {tabs.length === 0 ? (
           <EmptyTableState name={props.tile.name} />
         ) : (


### PR DESCRIPTION
Currently, the Properties Modal size is determined according to its content, meaning that a long list will occupy the entire screen while other tabs might be smaller, effectively changing the size and position of the modal.

The fix for this is to provide a fixed size for the modal, according to the User's viewport.

Ideally, in the future, we should transform the properties modal into a page, which will allow the user to share the link to a specific component and properties. Ideally, it should also contain a breadcrumb to show the user's current location.

### Screenshot
#### 720p size
| Long list | Short list |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/12747ba4-a64e-4072-a8e2-7a5f9737c93f) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/e5bbde4c-19b2-47b8-a128-27cef14f4936) |

#### 1080p size
| Long list | Short list |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/d2ba8bd8-38e9-4f91-8b49-39c876b95784) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/552aec3f-0203-4811-bcc6-585c36d09172) |

#### 1440p size
| Long list | Short list |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/e22b2f0f-7079-4704-ae98-69191bacff0a) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/64b69a89-dcbb-4dcc-bc92-dfc2c5573ee1) |

#### UHD size (4K)
| Long list | Short list |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/15077904-66ae-4732-b9fa-f20bb7d45044) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/b684fe89-d698-4bfb-af63-bc0783724dd7) |

fix: https://github.com/KaotoIO/kaoto-next/issues/742