### PR TITLE
feat(catalog): Sort Processor's properties

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparator.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparator.java
@@ -1,0 +1,27 @@
+package io.kaoto.camelcatalog;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.camel.tooling.model.EipModel.EipOptionModel;
+
+public class CamelYamlDSLKeysComparator implements Comparator<String> {
+
+    private final List<EipOptionModel> eipOptions;
+
+    CamelYamlDSLKeysComparator(List<EipOptionModel> eipOptions) {
+        this.eipOptions = eipOptions;
+    }
+
+    @Override
+    public int compare(String firstKey, String secondKey) {
+        Optional<EipOptionModel> firstOption = eipOptions.stream().filter(e -> e.getName().equals(firstKey)).findFirst();
+        Optional<EipOptionModel> secondOption = eipOptions.stream().filter(e -> e.getName().equals(secondKey)).findFirst();
+
+        var firstIndex = firstOption.isPresent() ? firstOption.get().getIndex() : Integer.MAX_VALUE;
+        var secondIndex = secondOption.isPresent() ? secondOption.get().getIndex() : Integer.MAX_VALUE;
+
+        return Integer.compare(firstIndex, secondIndex);
+    }
+}

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
@@ -103,6 +103,20 @@ public class CamelCatalogProcessorTest {
                 .withObject("/propertiesSchema");
         var etcdEProperty = etcdSchema.withObject("/properties").withObject("/endpoints");
         assertEquals("Etcd3Constants.ETCD_DEFAULT_ENDPOINTS", etcdEProperty.withArray("/default").get(0).asText());
+
+        var smbSchema = componentCatalog
+                .withObject("/smb")
+                .withObject("/propertiesSchema");
+        var smbUsernameProperty = smbSchema.withObject("/properties").withObject("/username");
+        assertEquals("password", smbUsernameProperty.get("format").asText());
+        var smbPasswordProperty = smbSchema.withObject("/properties").withObject("/password");
+        assertEquals("password", smbPasswordProperty.get("format").asText());
+
+        var cxfSchema = componentCatalog
+                .withObject("/cxf")
+                .withObject("/propertiesSchema");
+        var cxfContinuationTimeout = cxfSchema.withObject("/properties").withObject("/continuationTimeout");
+        assertEquals("duration", cxfContinuationTimeout.get("format").asText());
     }
 
     @Test

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparatorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparatorTest.java
@@ -1,0 +1,53 @@
+package io.kaoto.camelcatalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.catalog.Kind;
+import org.apache.camel.tooling.model.EipModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CamelYamlDSLKeysComparatorTest {
+    private DefaultCamelCatalog api;
+
+    @BeforeEach
+    public void setUp() {
+        this.api = new DefaultCamelCatalog();
+    }
+
+    @Test
+    public void sort_keys_using_the_catalog_index() throws Exception {
+        var aggregateCatalogModel = (EipModel) api.model(Kind.eip, "aggregate");
+
+        List<String> aggregateKeysFromCamelYAMLDsl = List.of("aggregateController", "aggregationRepository",
+                "aggregationStrategy", "aggregationStrategyMethodAllowNull", "aggregationStrategyMethodName",
+                "closeCorrelationKeyOnCompletion", "completeAllOnStop", "completionFromBatchConsumer",
+                "completionInterval", "completionOnNewCorrelationGroup", "completionPredicate", "completionSize",
+                "completionSizeExpression", "completionTimeout", "completionTimeoutCheckerInterval",
+                "completionTimeoutExpression", "correlationExpression", "description", "disabled",
+                "discardOnAggregationFailure", "discardOnCompletionTimeout", "eagerCheckCompletion", "executorService",
+                "forceCompletionOnStop", "id", "ignoreInvalidCorrelationKeys", "optimisticLockRetryPolicy",
+                "optimisticLocking", "parallelProcessing", "steps", "timeoutCheckerExecutorService");
+
+        List<String> expected = List.of("id", "description", "disabled", "correlationExpression", "completionPredicate",
+                "completionTimeoutExpression", "completionSizeExpression", "optimisticLockRetryPolicy",
+                "parallelProcessing", "optimisticLocking", "executorService", "timeoutCheckerExecutorService",
+                "aggregateController", "aggregationRepository", "aggregationStrategy", "aggregationStrategyMethodName",
+                "aggregationStrategyMethodAllowNull", "completionSize", "completionInterval", "completionTimeout",
+                "completionTimeoutCheckerInterval", "completionFromBatchConsumer", "completionOnNewCorrelationGroup",
+                "eagerCheckCompletion", "ignoreInvalidCorrelationKeys", "closeCorrelationKeyOnCompletion",
+                "discardOnCompletionTimeout", "discardOnAggregationFailure", "forceCompletionOnStop",
+                "completeAllOnStop", "steps");
+
+        Comparator<String> comparator = new CamelYamlDSLKeysComparator(aggregateCatalogModel.getOptions());
+
+        List<String> result = aggregateKeysFromCamelYAMLDsl.stream().sorted(comparator).toList();
+
+        assertEquals(result, expected);
+    }
+
+}


### PR DESCRIPTION
### Context
Currently, since the component's schema is generated from the Camel's components catalog, iterating over the properties dictionary, the output is written using the same sorting as well.

Ths is not the case for processors, which are extracted from the Camel YAML DSL schema first, and then decorated with elements from the Camel's catalog.

This commit changes the iteration to be performed from the Camel's processor catalog instead.

Changes:
* Move the `class:xxx` information from `$comment` to `format`
* Move the `duration` information from `$comment` to `format`
* Add `format: password` for `secret: true` fields

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/c9d5e6f7-253e-46b6-8f87-ddabfa3ff7d8) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/ec892e06-3fc8-488a-aee7-3f09743844a0) |

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/6fe47289-0a8a-4941-974c-59da317d8a55) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/fb1d17c7-748e-4e4c-b6d9-794475c51717) |

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/79c47a82-7a81-4949-9e5e-445988d7a54c) | ![image](https://github.com/KaotoIO/kaoto-next/assets/16512618/a709f089-258a-408d-ba5e-46657a392940) |


fix: https://github.com/KaotoIO/kaoto-next/issues/51