### PR TITLE
e2e - fix flaky stepRemoval.cy.ts

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -45,6 +45,8 @@ Cypress.Commands.add('checkConfigInputObject', (inputName: string, value: string
 Cypress.Commands.add('removeNodeByName', (nodeName: string, nodeIndex?: number) => {
   cy.performNodeAction(nodeName, 'remove', nodeIndex);
   cy.get(nodeName).should('not.exist');
+  // wait for the canvas rerender
+  cy.wait(1000);
 });
 
 Cypress.Commands.add('selectReplaceNode', (nodeName: string, nodeIndex?: number) => {


### PR DESCRIPTION
[Step removal tests](https://github.com/KaotoIO/kaoto-next/blob/be65d340592f1dbed7cb2fd5e735014d441b8405/packages/ui-tests/cypress/e2e/designer/stepRemoval.cy.ts#L4) are flaky due to the disappearing `context-menu-item`, which can be hidden after the rerender happens, after previous node removal.