### PR TITLE
feat(sourcecode): Serialize URI string

### DIFF
--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -6,6 +6,7 @@ import { CamelCatalogService } from './camel-catalog.service';
 import { CatalogKind } from '../../catalog-kind';
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('AbstractCamelVisualEntity', () => {
   let abstractVisualEntity: CamelRouteVisualEntity;
@@ -50,6 +51,23 @@ describe('AbstractCamelVisualEntity', () => {
       const result = abstractVisualEntity.getNodeValidationText('from');
 
       expect(result).toEqual('1 required parameter is not yet configured: [ uri ]');
+    });
+  });
+
+  describe('updateModel', () => {
+    it('should update the model with the new value', () => {
+      const newUri = 'timer:MyTimer';
+      abstractVisualEntity.updateModel('from', { uri: newUri });
+
+      expect(abstractVisualEntity.route.from.uri).toEqual(newUri);
+    });
+
+    it('should delegate the serialization to the `CamelComponentSchemaService`', () => {
+      const newUri = 'timer:MyTimer';
+      const spy = jest.spyOn(CamelComponentSchemaService, 'getUriSerializedDefinition');
+      abstractVisualEntity.updateModel('from', { uri: newUri });
+
+      expect(spy).toHaveBeenCalledWith('from', { uri: newUri });
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -69,8 +69,9 @@ export abstract class AbstractCamelVisualEntity implements BaseVisualCamelEntity
 
   updateModel(path: string | undefined, value: unknown): void {
     if (!path) return;
+    const updatedValue = CamelComponentSchemaService.getUriSerializedDefinition(path, value);
 
-    setValue(this.route, path, value);
+    setValue(this.route, path, updatedValue);
   }
 
   /**

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -45,8 +45,6 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity {
   }
 
   updateModel(path: string | undefined, value: Record<string, unknown>): void {
-    if (!path) return;
-
     if (path === ROOT_PATH) {
       updateKameletFromCustomSchema(this.kamelet, value);
       return;

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -1,4 +1,4 @@
-import { CamelUriHelper } from './camel-uri-helper';
+import { CamelUriHelper, ParsedParameters } from './camel-uri-helper';
 
 describe('CamelUriHelper', () => {
   describe('getUriString', () => {
@@ -62,6 +62,7 @@ describe('CamelUriHelper', () => {
         syntax: 'aws2-eventbridge://eventbusNameOrArn',
         uri: 'aws2-eventbridge://arn:aws:iam::123456789012:user/johndoe',
         result: { eventbusNameOrArn: 'arn:aws:iam::123456789012:user/johndoe' },
+        requiredParameters: ['eventbusNameOrArn'],
       },
       {
         syntax: 'jms:destinationType:destinationName',
@@ -80,6 +81,42 @@ describe('CamelUriHelper', () => {
         uri: 'jms:myQueue',
         result: { destinationName: 'myQueue' },
         requiredParameters: ['destinationName'],
+      },
+      {
+        syntax: 'http://httpUri',
+        uri: 'http://helloworld.io/api/greetings/{header.name}',
+        requiredParameters: ['httpUri'],
+        result: { httpUri: 'helloworld.io/api/greetings/{header.name}' },
+      },
+      {
+        syntax: 'https://httpUri',
+        uri: 'https://helloworld.io/api/greetings/{header.name}',
+        requiredParameters: ['httpUri'],
+        result: { httpUri: 'helloworld.io/api/greetings/{header.name}' },
+      },
+      {
+        syntax: 'ftp:host:port/directoryName',
+        uri: 'ftp:localhost:21/a/nested/directory',
+        requiredParameters: ['host'],
+        result: { host: 'localhost', port: 21, directoryName: 'a/nested/directory' },
+      },
+      {
+        syntax: 'rest-openapi:specificationUri#operationId',
+        uri: 'rest-openapi:afile-openapi.json#myOperationId',
+        requiredParameters: ['operationId'],
+        result: { specificationUri: 'afile-openapi.json', operationId: 'myOperationId' },
+      },
+      {
+        syntax: 'rest:method:path:uriTemplate',
+        uri: 'rest:::{header.name}',
+        requiredParameters: ['method', 'path'],
+        result: { uriTemplate: '{header.name}' },
+      },
+      {
+        syntax: 'rest:method:path:uriTemplate',
+        uri: 'rest:options:myPath:',
+        requiredParameters: ['method', 'path'],
+        result: { method: 'options', path: 'myPath' },
       },
     ])(
       'for an URI: `$uri`, using the syntax: `$syntax`, should return `$result`',
@@ -101,5 +138,193 @@ describe('CamelUriHelper', () => {
     ])('should return `$result` for `$queryString`', ({ queryString, result }) => {
       expect(CamelUriHelper.getParametersFromQueryString(queryString)).toEqual(result);
     });
+  });
+
+  describe('getUriStringFromParameters', () => {
+    it.each([
+      { uri: 'log', syntax: 'log', parameters: {}, result: { uri: 'log', parameters: {} } },
+      {
+        uri: 'timer',
+        syntax: 'timer:timerName',
+        parameters: undefined,
+        result: { uri: 'timer', parameters: undefined },
+      },
+      {
+        uri: 'timer',
+        syntax: 'timer:timerName',
+        parameters: null,
+        result: { uri: 'timer', parameters: null },
+      },
+      {
+        uri: 'timer',
+        syntax: 'timer:timerName',
+        parameters: {},
+        result: { uri: 'timer', parameters: {} },
+      },
+      {
+        uri: 'timer:myTimer',
+        syntax: 'timer:timerName',
+        parameters: { timerName: 'myTimer' },
+        result: { uri: 'timer:myTimer', parameters: {} },
+      },
+      {
+        uri: 'timer:myTimer',
+        syntax: 'timer:timerName',
+        parameters: { timerName: 'myTimer', groupDelay: 1000, groupSize: 5 },
+        result: { uri: 'timer:myTimer', parameters: { groupDelay: 1000, groupSize: 5 } },
+      },
+      { uri: 'as2', syntax: 'as2:apiName/methodName', parameters: {}, result: { uri: 'as2', parameters: {} } },
+      {
+        uri: 'activemq',
+        syntax: 'activemq:destinationType:destinationName',
+        parameters: { destinationType: 'queue', destinationName: 'myQueue' },
+        result: { uri: 'activemq:queue:myQueue', parameters: {} },
+      },
+      {
+        uri: 'as2:CLIENT/GET',
+        syntax: 'as2:apiName/methodName',
+        parameters: {
+          apiName: 'CLIENT',
+          methodName: 'GET',
+        },
+        result: { uri: 'as2:CLIENT/GET', parameters: {} },
+      },
+      {
+        uri: 'atmosphere-websocket',
+        syntax: 'atmosphere-websocket:servicePath',
+        parameters: { servicePath: '//localhost:8080/echo' },
+        result: { uri: 'atmosphere-websocket://localhost:8080/echo', parameters: {} },
+      },
+      {
+        uri: 'avro',
+        syntax: 'avro:transport:host:port/messageName',
+        parameters: { transport: 'netty', host: 'localhost', port: 41414, messageName: 'foo' },
+        requiredParameters: ['transport', 'host', 'port'],
+        result: { uri: 'avro:netty:localhost:41414/foo', parameters: {} },
+      },
+      {
+        uri: 'avro',
+        syntax: 'avro:transport:host:port/messageName',
+        parameters: {},
+        requiredParameters: ['transport', 'host', 'port'],
+        result: { uri: 'avro:::', parameters: {} },
+      },
+      {
+        uri: 'aws2-eventbridge',
+        syntax: 'aws2-eventbridge://eventbusNameOrArn',
+        parameters: { eventbusNameOrArn: 'arn:aws:iam::123456789012:user/johndoe' },
+        requiredParameters: ['eventbusNameOrArn'],
+        result: { uri: 'aws2-eventbridge://arn:aws:iam::123456789012:user/johndoe', parameters: {} },
+      },
+      {
+        uri: 'aws2-eventbridge://arn:aws:iam::123456789012:user/johndoe',
+        syntax: 'aws2-eventbridge://eventbusNameOrArn',
+        parameters: { eventbusNameOrArn: 'arn:aws:iam::123456789012:user/johndoe' },
+        requiredParameters: ['eventbusNameOrArn'],
+        result: { uri: 'aws2-eventbridge://arn:aws:iam::123456789012:user/johndoe', parameters: {} },
+      },
+      {
+        uri: 'jms',
+        syntax: 'jms:destinationType:destinationName',
+        parameters: { destinationType: 'queue', destinationName: 'myQueue' },
+        requiredParameters: ['destinationName'],
+        defaultValues: { destinationType: 'queue' },
+        result: { uri: 'jms:queue:myQueue', parameters: {} },
+      },
+      {
+        uri: 'jms',
+        syntax: 'jms:destinationType:destinationName',
+        parameters: { destinationName: 'myQueue' },
+        requiredParameters: ['destinationName'],
+        defaultValues: { destinationType: 'queue' },
+        result: { uri: 'jms:queue:myQueue', parameters: {} },
+      },
+      {
+        uri: 'jms:myQueue',
+        syntax: 'jms:destinationType:destinationName',
+        parameters: { destinationName: 'myQueue' },
+        requiredParameters: ['destinationName'],
+        defaultValues: { destinationType: 'queue' },
+        result: { uri: 'jms:queue:myQueue', parameters: {} },
+      },
+      {
+        uri: 'http',
+        syntax: 'http://httpUri',
+        parameters: { httpUri: 'helloworld.io/api/greetings/{header.name}' },
+        requiredParameters: ['httpUri'],
+        result: { uri: 'http://helloworld.io/api/greetings/{header.name}', parameters: {} },
+      },
+      {
+        uri: 'https',
+        syntax: 'https://httpUri',
+        parameters: { httpUri: 'helloworld.io/api/greetings/{header.name}' },
+        requiredParameters: ['httpUri'],
+        result: { uri: 'https://helloworld.io/api/greetings/{header.name}', parameters: {} },
+      },
+      {
+        uri: 'https',
+        syntax: 'https://httpUri',
+        parameters: { httpUri: 'https://helloworld.io/api/greetings/{header.name}' },
+        requiredParameters: ['httpUri'],
+        result: { uri: 'https://helloworld.io/api/greetings/{header.name}', parameters: {} },
+      },
+      {
+        uri: 'ftp',
+        syntax: 'ftp:host:port/directoryName',
+        parameters: { host: 'localhost', port: 21, directoryName: 'a/nested/directory' },
+        requiredParameters: ['host'],
+        result: { uri: 'ftp:localhost:21/a/nested/directory', parameters: {} },
+      },
+      {
+        uri: 'rest-openapi',
+        syntax: 'rest-openapi:specificationUri#operationId',
+        parameters: { specificationUri: 'afile-openapi.json', operationId: 'myOperationId' },
+        defaultValues: { specificationUri: 'openapi.json' },
+        requiredParameters: ['operationId'],
+        result: { uri: 'rest-openapi:afile-openapi.json#myOperationId', parameters: {} },
+      },
+      {
+        uri: 'rest-openapi',
+        syntax: 'rest-openapi:specificationUri#operationId',
+        parameters: { specificationUri: '', operationId: 'myOperationId' },
+        defaultValues: { specificationUri: 'openapi.json' },
+        requiredParameters: ['operationId'],
+        result: { uri: 'rest-openapi:openapi.json#myOperationId', parameters: {} },
+      },
+      {
+        uri: 'rest-openapi',
+        syntax: 'rest-openapi:specificationUri#operationId',
+        parameters: { operationId: 'myOperationId' },
+        defaultValues: { specificationUri: 'openapi.json' },
+        requiredParameters: ['operationId'],
+        result: { uri: 'rest-openapi:openapi.json#myOperationId', parameters: {} },
+      },
+      {
+        uri: 'rest',
+        syntax: 'rest:method:path:uriTemplate',
+        parameters: { uriTemplate: '{header.name}' },
+        requiredParameters: ['method', 'path'],
+        result: { uri: 'rest:::{header.name}', parameters: {} },
+      },
+      {
+        uri: 'rest',
+        syntax: 'rest:method:path:uriTemplate',
+        parameters: { method: 'options', path: 'myPath' },
+        requiredParameters: ['method', 'path'],
+        result: { uri: 'rest:options:myPath', parameters: {} },
+      },
+    ])(
+      'should return `$result` for `$parameters`',
+      ({ uri, syntax, parameters, requiredParameters, defaultValues: testDefaultValues, result }) => {
+        const defaultValues = testDefaultValues ?? {};
+
+        expect(
+          CamelUriHelper.getUriStringFromParameters(uri, syntax, parameters as unknown as ParsedParameters, {
+            requiredParameters,
+            defaultValues,
+          }),
+        ).toEqual(result);
+      },
+    );
   });
 });

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -1,13 +1,18 @@
 import get from 'lodash/get';
 import { getParsedValue } from './get-parsed-value';
+import { isDefined } from './is-defined';
 
-type ParsedParameters = Record<string, string | boolean | number>;
+export type ParsedParameters = Record<string, string | boolean | number>;
 
 /**
  * Helper class for working with Camel URIs
  */
 export class CamelUriHelper {
-  private static readonly URI_SEPARATORS_REGEX = /:|(\/\/)|\//g;
+  private static readonly URI_SEPARATORS_REGEX = /:|(\/\/)|#|\//g;
+  private static readonly KNOWN_URI_MAP: Record<string, string> = {
+    'http://httpUri': 'http://',
+    'https://httpUri': 'https://',
+  };
 
   static getUriString<T>(value: T | undefined | null): string | undefined {
     /** For string-based processor definitions, we can return the definition itself */
@@ -34,19 +39,16 @@ export class CamelUriHelper {
     /** If `:` is not present in the syntax, we can return an empty object since there's nothing to parse */
     if (!uriSyntax || !uriString || !uriSyntax.includes(':')) return {};
 
-    /** Remove the scheme from the URI syntax: 'avro:transport:host:port/messageName' => 'transport:host:port/messageName' */
-    const syntaxWithoutScheme = uriSyntax.substring(uriSyntax.indexOf(':') + 1);
-
     /** Validate that the actual URI contains the correct schema, otherwise return empty object since we could be validating the wrong URI */
     if (!uriString.startsWith(uriSyntax.substring(0, uriSyntax.indexOf(':')))) return {};
-
-    /** Remove the scheme from the URI string: 'avro:netty:localhost:41414/foo' => 'netty:localhost:41414/foo' */
-    const uriWithoutScheme = uriString.substring(uriSyntax.indexOf(':') + 1);
 
     /** Prepare options */
     const requiredParameters = options?.requiredParameters ?? [];
     /** Holder for parsed parameters */
     const parameters: ParsedParameters = {};
+
+    const syntaxWithoutScheme = this.getSyntaxWithoutSchema(uriSyntax).syntax;
+    const uriWithoutScheme = this.getUriWithoutScheme(uriString, uriSyntax);
 
     /**
      * Retrieve the delimiters from the syntax by matching the delimiters
@@ -85,7 +87,13 @@ export class CamelUriHelper {
       }
 
       keys.forEach((key, index) => {
-        const parsedValue = getParsedValue(values[index]);
+        let parsedValue = getParsedValue(values[index]);
+        const isLastItem = index === keys.length - 1;
+        /** If the values length is greater than the keys length, we need to join the remaining values, f.i. ftp component */
+        if (isLastItem && values.length > keys.length) {
+          parsedValue = getParsedValue(values.slice(index).join(delimiters[index - 1]));
+        }
+
         if (key !== '' && parsedValue !== '') {
           parameters[key] = parsedValue;
         }
@@ -107,5 +115,103 @@ export class CamelUriHelper {
         return parameters;
       }, {} as ParsedParameters) ?? {}
     );
+  }
+
+  /**
+   * Write the appropriate parameters in the URI string, and
+   * and keep the parameters that are not present in the URI syntax
+   */
+  static getUriStringFromParameters(
+    originalUri: string,
+    uriSyntax: string,
+    parameters?: ParsedParameters,
+    options?: { requiredParameters?: string[]; defaultValues?: ParsedParameters },
+  ): { uri: string; parameters: ParsedParameters | undefined } {
+    const { schema, syntax: syntaxWithoutScheme } = this.getSyntaxWithoutSchema(uriSyntax);
+    /** Prepare options */
+    const requiredParameters = options?.requiredParameters ?? [];
+    const defaultValues = options?.defaultValues ?? {};
+
+    /**
+     * Retrieve the delimiters from the syntax by matching the delimiters
+     * Example: 'transport:host:port/messageName' => [':', ':', '/']
+     */
+    const delimiters = syntaxWithoutScheme.match(this.URI_SEPARATORS_REGEX);
+    this.URI_SEPARATORS_REGEX.lastIndex = 0;
+
+    /** If the syntax does not contain any delimiters, we can return the URI string as is */
+    if (
+      syntaxWithoutScheme === '' ||
+      (delimiters === null && parameters?.[syntaxWithoutScheme] === undefined) ||
+      !isDefined(parameters)
+    ) {
+      return { uri: originalUri, parameters };
+    } else if (delimiters === null) {
+      const value = parameters?.[syntaxWithoutScheme] ?? defaultValues[syntaxWithoutScheme] ?? '';
+      const uri = `${schema}:${this.cleanUriParts(value.toString(), uriSyntax)}`;
+      const filteredParameters = this.filterParameters(parameters, [syntaxWithoutScheme]);
+      return { uri, parameters: filteredParameters };
+    }
+
+    /** Otherwise, we create a RegExp using the delimiters found [':', ':', '/'] */
+    const delimitersRegex = new RegExp(delimiters.join('|'), 'g');
+
+    /**
+     * Splitting the syntax string using the delimiters
+     * keys: [ 'transport', 'host', 'port', 'messageName' ]
+     */
+    const keys = syntaxWithoutScheme.split(delimitersRegex);
+    const values = keys.map((key) => {
+      const valueOrUndefined = parameters[key] === '' ? undefined : parameters[key];
+      const value = valueOrUndefined ?? defaultValues[key] ?? '';
+      const isRequired = requiredParameters.includes(key);
+      const previousDelimiter = keys.indexOf(key) > 0 ? delimiters[keys.indexOf(key) - 1] : ':';
+
+      return { key, value, isRequired, previousDelimiter };
+    });
+    values.unshift({ key: 'schema', value: schema, isRequired: true, previousDelimiter: '' });
+
+    const uri = values.reduceRight((acc, current, index) => {
+      const isNextSegmentRequired = values[index + 1]?.isRequired;
+      if (!current.isRequired && current.value === '' && !isNextSegmentRequired) {
+        return acc;
+      }
+
+      const cleanValue = this.cleanUriParts(current.value.toString(), uriSyntax);
+      return `${current.previousDelimiter}${cleanValue}${acc}`;
+    }, '');
+
+    const filteredParameters = this.filterParameters(parameters, keys);
+    return { uri, parameters: filteredParameters };
+  }
+
+  /**
+   * Remove the scheme from the URI syntax:
+   * 'avro:transport:host:port/messageName' => { schema: 'avro', syntax: 'transport:host:port/messageName' } */
+  private static getSyntaxWithoutSchema(uriSyntax: string): { schema: string; syntax: string } {
+    const splitIndex = uriSyntax.indexOf(':');
+    const schema = uriSyntax.substring(0, splitIndex === -1 ? uriSyntax.length : splitIndex);
+    const syntax = splitIndex === -1 ? '' : uriSyntax.substring(splitIndex + 1);
+    return { schema, syntax };
+  }
+
+  /** Remove the scheme from the URI string: 'avro:netty:localhost:41414/foo' => 'netty:localhost:41414/foo' */
+  private static getUriWithoutScheme(uriString: string, uriSyntax: string): string {
+    return uriString.substring(uriSyntax.indexOf(':') + 1);
+  }
+
+  /** Remove parts from URI for known components, particularly for URL-relate components */
+  private static cleanUriParts(uri: string, syntax: string): string {
+    return uri.replace(this.KNOWN_URI_MAP[syntax], '');
+  }
+
+  /** Return a new object ignoring the parameters from the `keys` array*/
+  private static filterParameters(parameters: ParsedParameters, keys: string[]): ParsedParameters {
+    return Object.keys(parameters).reduce((acc, parameterKey) => {
+      if (!keys.includes(parameterKey)) {
+        acc[parameterKey] = parameters[parameterKey];
+      }
+      return acc;
+    }, {} as ParsedParameters);
   }
 }


### PR DESCRIPTION
### Context
Currently, only the component name gets serialized into the URI string, the remaining parameters ar serialized in the parameters dictionary as follows:

```yaml
  - from:
      uri: timer
      parameters:
        period: "1000"
        timerName: template
```

While this works for the Camel CLI, CamelK doesn't support this schema at the moment, causing the deployment to fail.

This commit writes the path parameters into the URI string, in order to support CamelK deployments, f.i.:
```yaml
  - from:
      uri: timer:template
      parameters:
        period: "1000"
```

fixes: https://github.com/KaotoIO/kaoto-next/issues/884