### PR TITLE
Chore - add rules to limit the chromatic action triggering

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,11 +13,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'packages/ui-tests/cypress/**'
 
 # List of jobs
 jobs:
   chromatic-deployment:
-    if: github.repository == 'KaotoIO/kaoto-next' && github.actor != 'renovate[bot]'
+    if: github.repository == 'KaotoIO/kaoto-next' && github.actor != 'renovate[bot]' && !github.event.pull_request.draft
     # Operating System
     runs-on: ubuntu-latest
     # Job steps


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/883

added `paths-ignore` for the cypress directory - based [on docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), this should cause ignoring additions solely to ui-tests

also should ignore while the PR is in `draft` state