### PR TITLE
 fix(718): Data Format and LoadBalance config field spacing

### DIFF
--- a/packages/ui/src/components/Form/dataFormat/DataFormatEditor.scss
+++ b/packages/ui/src/components/Form/dataFormat/DataFormatEditor.scss
@@ -1,0 +1,9 @@
+.dataformat-metadata-editor {
+  .pf-v5-c-card {
+    margin-bottom: 24px;
+  }
+
+  .pf-v5-c-form {
+    margin-top: 24px;
+  }
+}

--- a/packages/ui/src/components/Form/dataFormat/DataFormatEditor.tsx
+++ b/packages/ui/src/components/Form/dataFormat/DataFormatEditor.tsx
@@ -17,8 +17,9 @@ import { FunctionComponent, Ref, useCallback, useContext, useEffect, useMemo, us
 import { EntitiesContext } from '../../../providers';
 import { MetadataEditor } from '../../MetadataEditor';
 import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
-import { DataFormatService } from './dataformat.service';
 import { SchemaService } from '../schema.service';
+import './DataFormatEditor.scss';
+import { DataFormatService } from './dataformat.service';
 
 interface DataFormatEditorProps {
   selectedNode: CanvasNode;
@@ -93,49 +94,51 @@ export const DataFormatEditor: FunctionComponent<DataFormatEditorProps> = (props
 
   return (
     dataFormatCatalogMap && (
-      <Card isCompact={true} isExpanded={isExpanded}>
-        <CardHeader onExpand={() => setIsExpanded(!isExpanded)}>
-          <CardTitle>Data Format</CardTitle>
-        </CardHeader>
-        <CardExpandableContent>
-          <CardBody data-testid={'dataformat-config-card'}>
-            <Dropdown
-              id="dataformat-select"
-              data-testid="expression-dropdown"
-              isOpen={isOpen}
-              selected={selected !== '' ? selected : undefined}
-              onSelect={onSelect}
-              onOpenChange={setIsOpen}
-              toggle={toggle}
-              isScrollable={true}
-            >
-              <DropdownList data-testid="dataformat-dropdownlist">
-                {Object.values(dataFormatCatalogMap).map((df) => {
-                  return (
-                    <DropdownItem
-                      data-testid={`dataformat-dropdownitem-${df.model.name}`}
-                      key={df.model.title}
-                      value={df.model.name}
-                      description={df.model.description}
-                    >
-                      {df.model.title}
-                    </DropdownItem>
-                  );
-                })}
-              </DropdownList>
-            </Dropdown>
-            {dataFormat && (
-              <MetadataEditor
-                data-testid="dataformat-editor"
-                name={'dataformat'}
-                schema={dataFormatSchema}
-                metadata={dataFormatModel}
-                onChangeModel={(model) => handleOnChange(dataFormat.model.name, model)}
-              />
-            )}
-          </CardBody>
-        </CardExpandableContent>
-      </Card>
+      <div className="dataformat-metadata-editor">
+        <Card isCompact={true} isExpanded={isExpanded}>
+          <CardHeader onExpand={() => setIsExpanded(!isExpanded)}>
+            <CardTitle>Data Format</CardTitle>
+          </CardHeader>
+          <CardExpandableContent>
+            <CardBody data-testid={'dataformat-config-card'}>
+              <Dropdown
+                id="dataformat-select"
+                data-testid="expression-dropdown"
+                isOpen={isOpen}
+                selected={selected !== '' ? selected : undefined}
+                onSelect={onSelect}
+                onOpenChange={setIsOpen}
+                toggle={toggle}
+                isScrollable={true}
+              >
+                <DropdownList data-testid="dataformat-dropdownlist">
+                  {Object.values(dataFormatCatalogMap).map((df) => {
+                    return (
+                      <DropdownItem
+                        data-testid={`dataformat-dropdownitem-${df.model.name}`}
+                        key={df.model.title}
+                        value={df.model.name}
+                        description={df.model.description}
+                      >
+                        {df.model.title}
+                      </DropdownItem>
+                    );
+                  })}
+                </DropdownList>
+              </Dropdown>
+              {dataFormat && (
+                <MetadataEditor
+                  data-testid="dataformat-editor"
+                  name={'dataformat'}
+                  schema={dataFormatSchema}
+                  metadata={dataFormatModel}
+                  onChangeModel={(model) => handleOnChange(dataFormat.model.name, model)}
+                />
+              )}
+            </CardBody>
+          </CardExpandableContent>
+        </Card>
+      </div>
     )
   );
 };

--- a/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.scss
+++ b/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.scss
@@ -1,0 +1,3 @@
+.load-balancer-editor {
+  margin-top: 24px;
+}

--- a/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.tsx
+++ b/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.tsx
@@ -19,7 +19,7 @@ import { MetadataEditor } from '../../MetadataEditor';
 import { CanvasNode } from '../../Visualization/Canvas/canvas.models';
 import { LoadBalancerService } from './loadbalancer.service';
 import { SchemaService } from '../schema.service';
-
+import './LoadBalancerEditor.scss';
 interface LoadBalancerEditorProps {
   selectedNode: CanvasNode;
 }
@@ -128,13 +128,15 @@ export const LoadBalancerEditor: FunctionComponent<LoadBalancerEditorProps> = (p
               </DropdownList>
             </Dropdown>
             {loadBalancer && (
-              <MetadataEditor
-                data-testid="loadbalancer-editor"
-                name={'loadbalancer'}
-                schema={loadBalancerSchema}
-                metadata={loadBalancerModel}
-                onChangeModel={(model) => handleOnChange(loadBalancer.model.name, model)}
-              />
+              <div className="load-balancer-editor">
+                <MetadataEditor
+                  data-testid="loadbalancer-editor"
+                  name={'loadbalancer'}
+                  schema={loadBalancerSchema}
+                  metadata={loadBalancerModel}
+                  onChangeModel={(model) => handleOnChange(loadBalancer.model.name, model)}
+                />
+              </div>
             )}
           </CardBody>
         </CardExpandableContent>

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -43,14 +43,12 @@ export const MetadataPage: FunctionComponent = () => {
   );
 
   return isSupported ? (
-    <>
-      <MetadataEditor
-        name="Metadata"
-        schema={metadataSchema}
-        metadata={getMetadataModel()}
-        onChangeModel={onChangeModel}
-      />
-    </>
+    <MetadataEditor
+      name="Metadata"
+      schema={metadataSchema}
+      metadata={getMetadataModel()}
+      onChangeModel={onChangeModel}
+    />
   ) : (
     <TextContent>Not applicable</TextContent>
   );


### PR DESCRIPTION
partial fix for https://github.com/KaotoIO/kaoto-next/issues/718

specifically fixing the part:
`there is a different vertical spacing between the drop down and the follow up fields then between all the other fields`

here is the situation before and after:

![imgonline-com-ua-twotoone-46cxr6qiYu](https://github.com/KaotoIO/kaoto-next/assets/4180208/90bce368-ec0c-44eb-95f3-bd61e6eedbf7)
![imgonline-com-ua-twotoone-RXW1CmDD7nl5](https://github.com/KaotoIO/kaoto-next/assets/4180208/2d22bff0-8c98-4493-bfeb-655d5b992fa9)
