### PR TITLE
fix(SourceCode): Avoid loading Schema multiple times

### DIFF
--- a/packages/ui/src/components/SourceCode/SourceCode.tsx
+++ b/packages/ui/src/components/SourceCode/SourceCode.tsx
@@ -22,8 +22,10 @@ export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
   useEffect(() => {
     const schemaType: SourceSchemaType = entityContext?.currentSchemaType ?? SourceSchemaType.Route;
     const currentSchema = sourceSchemaConfig.config[schemaType].schema;
+    let monacoYamlHandler: ReturnType<typeof configureMonacoYaml> | undefined;
+
     if (currentSchema) {
-      configureMonacoYaml(monaco, {
+      monacoYamlHandler = configureMonacoYaml(monaco, {
         enableSchemaRequest: true,
         hover: true,
         completion: true,
@@ -39,6 +41,10 @@ export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
         ],
       });
     }
+
+    return () => {
+      monacoYamlHandler?.dispose();
+    };
   }, [entityContext?.currentSchemaType]);
 
   const handleEditorDidMount: EditorDidMount = useCallback((editor) => {


### PR DESCRIPTION
### Context
After loading the SourceCode editor, a specific schema is applied to the Monaco editor.

The problem with this is that going back and forth between the SourceCode page and any other page, causes the schema to be loaded multiple times, as the workers are not disposed of.

The fix is to dispose of the workers when leaving the SourceCode page.

fix: https://github.com/KaotoIO/kaoto-next/issues/833