### PR TITLE
Fix chromatic not triggering on change to "ready for review"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,6 +15,7 @@ on:
       - main
     paths-ignore:
       - 'packages/ui-tests/cypress/**'
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # List of jobs
 jobs:


### PR DESCRIPTION
fixes issue with the triggering chromatic action on converting `Draft`  to `Ready for review` discovered here -https://github.com/KaotoIO/kaoto-next/pull/914

Based on discussion and recommendation from here - https://github.com/orgs/community/discussions/25722#discussioncomment-3248917