### PR TITLE
fix(schema): Added Properties section to Kamelet Configuration Schema

### DIFF
--- a/packages/camel-catalog/assembly/src/main/resources/schemas/KameletConfiguration.json
+++ b/packages/camel-catalog/assembly/src/main/resources/schemas/KameletConfiguration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
   "description": "Schema for Kamelet configuration",
@@ -20,14 +20,14 @@
       "type": "string"
     },
     "type": {
-      "type": "string",
+      "title": "Kamelet Type",
       "description": "Select the Kamelet type from the available options",
+      "type": "string",
       "enum": [
         "source",
         "action",
         "sink"
-      ],
-      "title": "Kamelet Type"
+      ]
     },
     "icon": {
       "title": "Kamelet Icon",
@@ -64,18 +64,75 @@
         "default": "",
         "type": "string"
       },
+      "title": "Additional Labels",
       "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
-      "type": "object",
-      "title": "Additional Labels"
+      "type": "object"
     },
     "annotations": {
       "additionalProperties": {
         "default": "",
         "type": "string"
       },
+      "title": "Additional Annotations",
       "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
-      "type": "object",
-      "title": "Additional Annotations"
+      "type": "object"
+    },
+    "kameletProperties": {
+      "title": "Properties",
+      "type": "array",
+      "description": "Configure properties on the Kamelet",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Property name",
+            "description": "Name of the property",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "description": "Display name of the property",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "description": "Simple text description of the property",
+            "type": "string"
+          },
+          "type": {
+            "title": "Property type",
+            "description": "Set the expected type for this property",
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "default": "string"
+          },
+          "default": {
+            "title": "Default",
+            "description": "Default value for the property",
+            "type": "string"
+          },
+          "x-descriptors": {
+          "title": "X-descriptors",
+            "description": "Specific aids for the visual tools",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      }
     }
-  }
+  },
+  "required": [
+    "name",
+    "type"
+  ]
 }

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -68,7 +68,6 @@ export interface IKameletSpecDefinition {
   properties?: Record<string, IKameletSpecProperty>;
   example?: string;
   default?: unknown;
-  'x-descriptors'?: string[];
 }
 
 export interface IKameletSpecProperty {
@@ -77,6 +76,11 @@ export interface IKameletSpecProperty {
   type: string;
   default?: string | boolean | number;
   example?: string;
+  'x-descriptors'?: string[];
+}
+
+export interface IKameletCustomProperty extends IKameletSpecProperty {
+  name: string;
 }
 
 export interface IKameletCustomDefinition {
@@ -92,4 +96,5 @@ export interface IKameletCustomDefinition {
   namespace: string;
   labels: Record<string, string>;
   annotations: Record<string, string>;
+  kameletProperties: IKameletCustomProperty[];
 }

--- a/packages/ui/src/utils/get-custom-schema-from-kamelet.test.ts
+++ b/packages/ui/src/utils/get-custom-schema-from-kamelet.test.ts
@@ -1,5 +1,6 @@
+import cloneDeep from 'lodash/cloneDeep';
 import { SourceSchemaType } from '../models/camel/source-schema-type';
-import { IKameletDefinition } from '../models/kamelets-catalog';
+import { IKameletDefinition, IKameletSpecProperty } from '../models/kamelets-catalog';
 import { getCustomSchemaFromKamelet } from './get-custom-schema-from-kamelet';
 
 describe('getCustomSchemaFromKamelet', () => {
@@ -82,6 +83,7 @@ describe('getCustomSchemaFromKamelet', () => {
       namespace: undefined,
       labels: {},
       annotations: {},
+      kameletProperties: [],
     };
 
     const customSchema = getCustomSchemaFromKamelet({} as IKameletDefinition);
@@ -106,9 +108,127 @@ describe('getCustomSchemaFromKamelet', () => {
       annotations: {
         foo: 'bar',
       },
+      kameletProperties: [
+        {
+          name: 'period',
+          default: 5000,
+          description: 'The time interval between two events',
+          title: 'Period',
+          type: 'integer',
+        },
+      ],
     };
 
     const customSchema = getCustomSchemaFromKamelet(inputKameletStruct as unknown as IKameletDefinition);
+    expect(customSchema).toEqual(expectedCustomSchema);
+  });
+
+  it('should get a custom kamelet definition from a kamelet with string properies', () => {
+    const kameletWithStringProperties = cloneDeep(inputKameletStruct);
+    kameletWithStringProperties.spec.definition.properties = test as unknown as Record<string, IKameletSpecProperty>;
+
+    const expectedCustomSchema = {
+      name: 'test',
+      title: 'kamelet-35256',
+      description: 'test description!',
+      type: 'Action',
+      icon: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: 'test',
+      labels: {
+        type: 'Action',
+      },
+      annotations: {
+        foo: 'bar',
+      },
+      kameletProperties: [],
+    };
+
+    const customSchema = getCustomSchemaFromKamelet(kameletWithStringProperties as unknown as IKameletDefinition);
+    expect(customSchema).toEqual(expectedCustomSchema);
+  });
+
+  it('should get a custom kamelet definition from a kamelet with malformed properies', () => {
+    const kameletWithMalformedProperties = {
+      apiVersion: 'camel.apache.org/v1',
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        annotations: {
+          'camel.apache.org/catalog.version': 'main-SNAPSHOT',
+          'camel.apache.org/kamelet.group': 'Users',
+          'camel.apache.org/kamelet.icon':
+            'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+          'camel.apache.org/kamelet.namespace': 'test',
+          'camel.apache.org/kamelet.support.level': 'Stable',
+          'camel.apache.org/provider': 'Apache Software Foundation',
+          foo: 'bar',
+        },
+        labels: {
+          'camel.apache.org/kamelet.type': 'Action',
+          type: 'Action',
+        },
+        name: 'test',
+      },
+      spec: {
+        definition: {
+          description: 'test description!',
+          properties: {
+            period: test,
+          },
+          title: 'kamelet-35256',
+          type: 'object',
+        },
+        dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
+        template: {
+          from: {
+            steps: [
+              {
+                to: 'https://random-data-api.com/api/v2/users',
+              },
+              {
+                to: 'kamelet:sink',
+              },
+            ],
+            id: 'from-3836',
+            parameters: {
+              period: '{{period}}',
+              timerName: 'user',
+            },
+            uri: 'timer',
+          },
+        },
+        types: {
+          out: {
+            mediaType: 'application/json',
+          },
+        },
+      },
+    };
+
+    const expectedCustomSchema = {
+      name: 'test',
+      title: 'kamelet-35256',
+      description: 'test description!',
+      type: 'Action',
+      icon: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: 'test',
+      labels: {
+        type: 'Action',
+      },
+      annotations: {
+        foo: 'bar',
+      },
+      kameletProperties: [],
+    };
+
+    const customSchema = getCustomSchemaFromKamelet(kameletWithMalformedProperties as unknown as IKameletDefinition);
     expect(customSchema).toEqual(expectedCustomSchema);
   });
 });

--- a/packages/ui/src/utils/set-value.test.ts
+++ b/packages/ui/src/utils/set-value.test.ts
@@ -8,6 +8,12 @@ describe('setValue', () => {
     expect(obj).toEqual({ a: undefined });
   });
 
+  it('should not replace empty arrays `[]` with `undefined`', () => {
+    const obj = { a: [] };
+    setValue(obj, 'a', []);
+    expect(obj).toEqual({ a: [] });
+  });
+
   it('should ignore empty objects `{}` when setting it at root path', () => {
     const obj = {};
     setValue(obj, ROOT_PATH, {});

--- a/packages/ui/src/utils/set-value.ts
+++ b/packages/ui/src/utils/set-value.ts
@@ -4,7 +4,7 @@ import isEmpty from 'lodash.isempty';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const setValue = (obj: any, path: string | string[], value: any): void => {
-  if (typeof value === 'object' && isEmpty(value)) {
+  if (!Array.isArray(value) && typeof value === 'object' && isEmpty(value)) {
     value = undefined;
   }
 

--- a/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
+++ b/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { SourceSchemaType } from '../models/camel/source-schema-type';
-import { IKameletDefinition } from '../models/kamelets-catalog';
+import { IKameletDefinition, IKameletSpecProperty } from '../models/kamelets-catalog';
 import { updateKameletFromCustomSchema } from './update-kamelet-from-custom-schema';
 
 describe('updateKameletFromCustomSchema', () => {
@@ -75,6 +75,178 @@ describe('updateKameletFromCustomSchema', () => {
     expect(inputKameletStruct).toEqual(originalValue);
   });
 
+  it(`should preserve kamelet's original values when there are no properties`, () => {
+    const kameletWithoutProperties = cloneDeep(inputKameletStruct);
+    kameletWithoutProperties.spec.definition.properties = {};
+
+    const originalValue = cloneDeep(kameletWithoutProperties);
+    const value = undefined;
+
+    updateKameletFromCustomSchema(kameletWithoutProperties, value as unknown as Record<string, unknown>);
+    expect(kameletWithoutProperties).toEqual(originalValue);
+  });
+
+  it(`should preserve kamelet properties original values while custom schema changed(not kameletProperties)`, () => {
+    const kameletWithstringProperties = cloneDeep(inputKameletStruct);
+    kameletWithstringProperties.spec.definition.properties = test as unknown as Record<string, IKameletSpecProperty>;
+
+    const value = {
+      name: 'test',
+      title: 'kamelet-35256',
+      description: 'test description!',
+      type: 'Action',
+      icon: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: 'test',
+      labels: {
+        type: 'Action',
+      },
+      annotations: {
+        foo: 'bar',
+      },
+    };
+
+    const outputKameletStruct = {
+      apiVersion: 'camel.apache.org/v1',
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        annotations: {
+          'camel.apache.org/catalog.version': 'main-SNAPSHOT',
+          'camel.apache.org/kamelet.group': 'Users',
+          'camel.apache.org/kamelet.icon':
+            'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+          'camel.apache.org/kamelet.namespace': 'test',
+          'camel.apache.org/kamelet.support.level': 'Stable',
+          'camel.apache.org/provider': 'Apache Software Foundation',
+          foo: 'bar',
+        },
+        labels: {
+          'camel.apache.org/kamelet.type': 'Action',
+          type: 'Action',
+        },
+        name: 'test',
+      },
+      spec: {
+        definition: {
+          description: 'test description!',
+          properties: test,
+          title: 'kamelet-35256',
+          type: 'object',
+        },
+        dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
+        template: {
+          from: {
+            steps: [
+              {
+                to: 'https://random-data-api.com/api/v2/users',
+              },
+              {
+                to: 'kamelet:sink',
+              },
+            ],
+            id: 'from-3836',
+            parameters: {
+              period: '{{period}}',
+              timerName: 'user',
+            },
+            uri: 'timer',
+          },
+        },
+        types: {
+          out: {
+            mediaType: 'application/json',
+          },
+        },
+      },
+    };
+    updateKameletFromCustomSchema(kameletWithstringProperties, value as unknown as Record<string, unknown>);
+    expect(kameletWithstringProperties).toEqual(outputKameletStruct);
+  });
+
+  it(`should not preserve kamelet properties original values while custom schema changed with kameletproperties`, () => {
+    const kameletWithstringProperties = cloneDeep(inputKameletStruct);
+    kameletWithstringProperties.spec.definition.properties = test as unknown as Record<string, IKameletSpecProperty>;
+
+    const value = {
+      name: 'test',
+      title: 'kamelet-35256',
+      description: 'test description!',
+      type: 'Action',
+      icon: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: 'test',
+      labels: {
+        type: 'Action',
+      },
+      annotations: {
+        foo: 'bar',
+      },
+      kameletProperties: [undefined],
+    };
+
+    const outputKameletStruct: IKameletDefinition = {
+      apiVersion: 'camel.apache.org/v1',
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        annotations: {
+          'camel.apache.org/catalog.version': 'main-SNAPSHOT',
+          'camel.apache.org/kamelet.group': 'Users',
+          'camel.apache.org/kamelet.icon':
+            'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+          'camel.apache.org/kamelet.namespace': 'test',
+          'camel.apache.org/kamelet.support.level': 'Stable',
+          'camel.apache.org/provider': 'Apache Software Foundation',
+          foo: 'bar',
+        },
+        labels: {
+          'camel.apache.org/kamelet.type': 'Action',
+          type: 'Action',
+        },
+        name: 'test',
+      },
+      spec: {
+        definition: {
+          description: 'test description!',
+          title: 'kamelet-35256',
+          type: 'object',
+        },
+        dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
+        template: {
+          from: {
+            steps: [
+              {
+                to: 'https://random-data-api.com/api/v2/users',
+              },
+              {
+                to: 'kamelet:sink',
+              },
+            ],
+            id: 'from-3836',
+            parameters: {
+              period: '{{period}}',
+              timerName: 'user',
+            },
+            uri: 'timer',
+          },
+        },
+        types: {
+          out: {
+            mediaType: 'application/json',
+          },
+        },
+      },
+    };
+
+    updateKameletFromCustomSchema(kameletWithstringProperties, value as unknown as Record<string, unknown>);
+    expect(kameletWithstringProperties).toEqual(outputKameletStruct);
+  });
+
   it('should not mutate the original kamelet when loading a custom schema', () => {
     const value = {
       name: 'test',
@@ -119,6 +291,15 @@ describe('updateKameletFromCustomSchema', () => {
       annotations: {
         foo: 'bar',
       },
+      kameletProperties: [
+        {
+          name: 'period',
+          default: 5000,
+          description: 'The time interval between two events',
+          title: 'Period',
+          type: 'integer',
+        },
+      ],
     };
 
     const outputKameletStruct: IKameletDefinition = {
@@ -152,6 +333,84 @@ describe('updateKameletFromCustomSchema', () => {
               type: 'integer',
             },
           },
+          title: 'kamelet-35256',
+          type: 'object',
+        },
+        dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
+        template: {
+          from: {
+            steps: [
+              {
+                to: 'https://random-data-api.com/api/v2/users',
+              },
+              {
+                to: 'kamelet:sink',
+              },
+            ],
+            id: 'from-3836',
+            parameters: {
+              period: '{{period}}',
+              timerName: 'user',
+            },
+            uri: 'timer',
+          },
+        },
+        types: {
+          out: {
+            mediaType: 'application/json',
+          },
+        },
+      },
+    };
+
+    updateKameletFromCustomSchema(inputKameletStruct as unknown as IKameletDefinition, value);
+    expect(inputKameletStruct).toEqual(outputKameletStruct);
+  });
+
+  it('should get the kamelet schema from the custom schema, special case on the UI when there are no properties set from before and user click on the add property button', () => {
+    const value = {
+      name: 'test',
+      title: 'kamelet-35256',
+      description: 'test description!',
+      type: 'Action',
+      icon: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: 'test',
+      labels: {
+        type: 'Action',
+      },
+      annotations: {
+        foo: 'bar',
+      },
+      kameletProperties: [undefined],
+    };
+
+    const outputKameletStruct: IKameletDefinition = {
+      apiVersion: 'camel.apache.org/v1',
+      kind: SourceSchemaType.Kamelet,
+      metadata: {
+        annotations: {
+          'camel.apache.org/catalog.version': 'main-SNAPSHOT',
+          'camel.apache.org/kamelet.group': 'Users',
+          'camel.apache.org/kamelet.icon':
+            'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
+          'camel.apache.org/kamelet.namespace': 'test',
+          'camel.apache.org/kamelet.support.level': 'Stable',
+          'camel.apache.org/provider': 'Apache Software Foundation',
+          foo: 'bar',
+        },
+        labels: {
+          'camel.apache.org/kamelet.type': 'Action',
+          type: 'Action',
+        },
+        name: 'test',
+      },
+      spec: {
+        definition: {
+          description: 'test description!',
           title: 'kamelet-35256',
           type: 'object',
         },

--- a/packages/ui/src/utils/update-kamelet-from-custom-schema.ts
+++ b/packages/ui/src/utils/update-kamelet-from-custom-schema.ts
@@ -4,6 +4,8 @@ import {
   IKameletMetadataLabels,
   KameletKnownAnnotations,
   KameletKnownLabels,
+  IKameletSpecProperty,
+  IKameletCustomProperty,
 } from '../models/kamelets-catalog';
 import { getValue } from './get-value';
 import { setValue } from './set-value';
@@ -54,4 +56,27 @@ export const updateKameletFromCustomSchema = (kamelet: IKameletDefinition, value
 
   setValue(kamelet, 'metadata.labels', newLabels);
   setValue(kamelet, 'metadata.annotations', newAnnotations);
+
+  const propertiesArray: IKameletCustomProperty[] = getValue(value, 'kameletProperties');
+  const newProperties = propertiesArray?.reduce(
+    (acc, property) => {
+      if (property !== undefined) {
+        const { name, ...rest } = property;
+        acc[name] = rest;
+      }
+      return acc;
+    },
+    {} as Record<string, IKameletSpecProperty>,
+  );
+
+  let previousProperties: Record<string, IKameletSpecProperty> = getValue(kamelet, 'spec.definition.properties', {});
+  if (typeof previousProperties !== 'object') {
+    previousProperties = {};
+  }
+
+  const arePreviousPropertiesEmpty = Object.keys(previousProperties).length === 0;
+  const isPropertiesArrayEmpty = propertiesArray?.length === 0;
+  if (!(arePreviousPropertiesEmpty && isPropertiesArrayEmpty) && newProperties !== undefined) {
+    setValue(kamelet, 'spec.definition.properties', newProperties);
+  }
 };


### PR DESCRIPTION
Added schema for common Properties parameters i.e. 'title', 'description', 'type, 'x-descriptors'. Ref- https://camel.apache.org/camel-k/2.2.x/kamelets/kamelets-user.html#kamelets-specification-definition.
The Form looks like this:
![image](https://github.com/KaotoIO/kaoto-next/assets/73224329/8ee2a140-93fb-4361-b6af-61077d0a1749)

requires: https://github.com/shivamG640/kaoto-next/pull/4
fix: https://github.com/KaotoIO/kaoto-next/issues/880