### PR TITLE
changed the action labels on nodes to more generic ones

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ItemAddNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemAddNode.tsx
@@ -44,8 +44,15 @@ export const ItemAddNode: FunctionComponent<ItemAddNodeProps> = (props) => {
 
   return shouldRender ? (
     <ContextMenuItem onClick={onAddNode} data-testid={props['data-testid']}>
-      {props.mode === AddStepMode.PrependStep ? <AngleUpIcon /> : <AngleDownIcon />} Add node
-      {props.mode === AddStepMode.PrependStep ? ' before' : ' after'} {vizNode?.id}
+      {props.mode === AddStepMode.PrependStep ? (
+        <>
+          <AngleUpIcon /> Prepend
+        </>
+      ) : (
+        <>
+          <AngleDownIcon /> Append
+        </>
+      )}
     </ContextMenuItem>
   ) : null;
 };

--- a/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
@@ -48,8 +48,7 @@ export const ItemInsertChildNode: FunctionComponent<ItemInsertChildNodeProps> = 
 
   return shouldRender ? (
     <ContextMenuItem onClick={onInsertNode} data-testid={props['data-testid']}>
-      <AngleDoubleDownIcon /> Add {props.mode === AddStepMode.InsertSpecialChildStep ? 'special' : ''} step node into{' '}
-      {vizNode?.id}
+      <AngleDoubleDownIcon /> Insert
     </ContextMenuItem>
   ) : null;
 };

--- a/packages/ui/src/components/Visualization/Custom/ItemRemoveNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemRemoveNode.tsx
@@ -18,7 +18,7 @@ export const ItemRemoveNode: FunctionComponent<IDataTestID> = (props) => {
 
   return shouldRender ? (
     <ContextMenuItem onClick={onRemoveNode} data-testid={props['data-testid']}>
-      <MinusIcon /> Remove {vizNode?.id} node
+      <MinusIcon /> Remove
     </ContextMenuItem>
   ) : null;
 };

--- a/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemReplaceNode.tsx
@@ -33,7 +33,7 @@ export const ItemReplaceNode: FunctionComponent<IDataTestID> = (props) => {
 
   return shouldRender ? (
     <ContextMenuItem onClick={onReplaceNode} data-testid={props['data-testid']}>
-      <AngleRightIcon /> Replace {vizNode?.id} node
+      <AngleRightIcon /> Replace
     </ContextMenuItem>
   ) : null;
 };


### PR DESCRIPTION
fixes #872 

Work in progress. Points that are not yet solved in a good way:

- `Insert into` is displayed on the first node of an integration but it should only be shown if the node is branchable (can have child nodes, for instance choice, filter, route)
- we should still consider moving some of the actions directly on the nodes (for instance a plus button or minus button for adding and removing) or the connections similar to what Kaoto v1 did but less noisy.