### PR TITLE
fix(SourceCode): Downgrade @patternfly/react-code-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "resolutions": {
     "@patternfly/patternfly": "5.2.1",
-    "@patternfly/react-code-editor": "5.2.2",
+    "@patternfly/react-code-editor": "5.1.0",
     "@patternfly/react-core": "5.2.2",
     "@patternfly/react-icons": "5.2.1",
     "@patternfly/react-table": "5.2.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/notifications": "0.32.0",
     "@patternfly/patternfly": "5.2.1",
-    "@patternfly/react-code-editor": "5.2.2",
+    "@patternfly/react-code-editor": "5.1.0",
     "@patternfly/react-core": "5.2.2",
     "@patternfly/react-icons": "5.2.1",
     "@patternfly/react-table": "5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2457,7 +2457,7 @@ __metadata:
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0
     "@patternfly/patternfly": 5.2.1
-    "@patternfly/react-code-editor": 5.2.2
+    "@patternfly/react-code-editor": 5.1.0
     "@patternfly/react-core": 5.2.2
     "@patternfly/react-icons": 5.2.1
     "@patternfly/react-table": 5.2.2
@@ -2897,30 +2897,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monaco-editor/loader@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@monaco-editor/loader@npm:1.4.0"
-  dependencies:
-    state-local: ^1.0.6
-  peerDependencies:
-    monaco-editor: ">= 0.21.0 < 1"
-  checksum: 374ec0ea872ee15b33310e105a43217148161480d3955c5cece87d0f801754cd2c45a3f6c539a75da18a066c1615756fb87eaf1003f1df6a64a0cbce5d2c3749
-  languageName: node
-  linkType: hard
-
-"@monaco-editor/react@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@monaco-editor/react@npm:4.6.0"
-  dependencies:
-    "@monaco-editor/loader": ^1.4.0
-  peerDependencies:
-    monaco-editor: ">= 0.25.0 < 1"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 9d44e76c5baad6db5f84c90a5540fbd3c9af691b97d76cf2a99b3c8273004d0efe44c2572d80e9d975c9af10022c21e4a66923924950a5201e82017c8b20428c
-  languageName: node
-  linkType: hard
-
 "@mswjs/cookies@npm:^1.0.0":
   version: 1.0.0
   resolution: "@mswjs/cookies@npm:1.0.0"
@@ -3319,20 +3295,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-code-editor@npm:5.2.2":
-  version: 5.2.2
-  resolution: "@patternfly/react-code-editor@npm:5.2.2"
+"@patternfly/react-code-editor@npm:5.1.0":
+  version: 5.1.0
+  resolution: "@patternfly/react-code-editor@npm:5.1.0"
   dependencies:
-    "@monaco-editor/react": ^4.6.0
-    "@patternfly/react-core": ^5.2.2
-    "@patternfly/react-icons": ^5.2.1
-    "@patternfly/react-styles": ^5.2.1
+    "@patternfly/react-core": ^5.1.0
+    "@patternfly/react-icons": ^5.1.0
+    "@patternfly/react-styles": ^5.1.0
     react-dropzone: 14.2.3
     tslib: ^2.5.0
   peerDependencies:
     react: ^17 || ^18
     react-dom: ^17 || ^18
-  checksum: cbcc7606cadd19d209ab649425020eb1275499f96a8a20d1a8e9947a8fecd414b19e4049fd2af39cf34c52dd288f071388421af514cffc1e25e0f6d7087d1391
+    react-monaco-editor: ^0.51.0
+  checksum: 5d6e9d32491effa040c75f748a042d25d4405dfd2ce462df1abdd1bd2ea3fb6173b4caab58f399c4a42e40db1a820fd6cc4f0412fc59e47797eda2c277a8f72c
   languageName: node
   linkType: hard
 
@@ -3363,17 +3339,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-styles@npm:^5.1.0, @patternfly/react-styles@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "@patternfly/react-styles@npm:5.2.1"
+  checksum: fbc36df191fd1d75a1a9c390bfbe4884adc7b6556a2b30de9e848169df5541c946cde71f4a54db01873a21bce4a09e64f54ee722eb5d9bd6d8b1a77fc62ba141
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-styles@npm:^5.1.1":
   version: 5.2.0
   resolution: "@patternfly/react-styles@npm:5.2.0"
   checksum: ab38211d265c5fdcebf1c6d10503cca3fa87e7f5021021a61e0b1cf320f6f906eb7ae4279b5d7767cd657ddea4659d74b072b100416f8c6dfb485d4d31a3dc76
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-styles@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "@patternfly/react-styles@npm:5.2.1"
-  checksum: fbc36df191fd1d75a1a9c390bfbe4884adc7b6556a2b30de9e848169df5541c946cde71f4a54db01873a21bce4a09e64f54ee722eb5d9bd6d8b1a77fc62ba141
   languageName: node
   linkType: hard
 
@@ -17603,13 +17579,6 @@ __metadata:
     start-server-and-test: src/bin/start.js
     start-test: src/bin/start.js
   checksum: 8788e59ad78275332c78325a804504ac558f06a112d47cb5bc3d012d2bda46add72c863cae2357836fe245ee4e22e2fec0b6d47dbdf5e0f0f5cfd1a57544d100
-  languageName: node
-  linkType: hard
-
-"state-local@npm:^1.0.6":
-  version: 1.0.7
-  resolution: "state-local@npm:1.0.7"
-  checksum: d1afcf1429e7e6eb08685b3a94be8797db847369316d4776fd51f3962b15b984dacc7f8e401ad20968e5798c9565b4b377afedf4e4c4d60fe7495e1cbe14a251
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, `YAML` schemas are not working when upgrading to `@patternfly/react-code-editor` 5.2.

Downgrading the library until we can provide a fix for this situation.

relates: https://github.com/KaotoIO/kaoto-next/issues/943