### PR TITLE
feat(catalog): Remove single OneOf from AnyOf

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
@@ -52,7 +52,7 @@ public class CamelYamlDslSchemaProcessorTest {
     }
 
     @Test
-    public void test_extract_single_oneOf_from_anyOf() throws Exception {
+    public void testExtractSingleOneOfFromAnyOf() throws Exception {
         var subSchemaMap = processor.processSubSchema();
         var errorHandlerSchema = jsonMapper.readTree(subSchemaMap.get("errorHandler"));
 

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
@@ -52,6 +52,18 @@ public class CamelYamlDslSchemaProcessorTest {
     }
 
     @Test
+    public void test_extract_single_oneOf_from_anyOf() throws Exception {
+        var subSchemaMap = processor.processSubSchema();
+        var errorHandlerSchema = jsonMapper.readTree(subSchemaMap.get("errorHandler"));
+
+        assertFalse(errorHandlerSchema.has("anyOf"));
+
+        assertTrue(errorHandlerSchema.has("oneOf"));
+        assertTrue(errorHandlerSchema.get("oneOf").isArray());
+        assertEquals(7, errorHandlerSchema.get("oneOf").size());
+    }
+
+    @Test
     public void testGetDataFormats() throws Exception {
         var dataFormatMap = processor.getDataFormats();
         assertTrue(dataFormatMap.size() > 30 && dataFormatMap.size() < 50);


### PR DESCRIPTION
Extract single OneOf definition from AnyOf definition and put it into the root definitions.

relates: https://github.com/KaotoIO/kaoto-next/issues/948
relates: https://github.com/KaotoIO/kaoto-next/issues/560