### PR TITLE
feat(CanvasForm): Add nested schema utils

### DIFF
--- a/packages/ui/src/utils/get-applied-schema-index.test.ts
+++ b/packages/ui/src/utils/get-applied-schema-index.test.ts
@@ -1,0 +1,32 @@
+import { ErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { getAppliedSchemaIndex } from './get-applied-schema-index';
+import { errorHandlerSchema } from '../stubs/error-handler';
+
+describe('getAppliedSchemaIndex', () => {
+  it('should return the index of the applied oneOf schema for a given model', () => {
+    const model: ErrorHandler = {
+      springTransactionErrorHandler: {
+        id: 'springTransactionErrorHandler',
+        logName: 'springTransactionErrorHandler',
+        useOriginalBody: true,
+      },
+    };
+
+    const result = getAppliedSchemaIndex(model, errorHandlerSchema.oneOf!, errorHandlerSchema);
+
+    expect(result).toBe(6);
+  });
+
+  it('should return the index of the applied oneOf schema for a given model when a missing required property', () => {
+    const model: ErrorHandler = {
+      deadLetterChannel: {
+        deadLetterHandleNewException: true,
+      },
+      springTransactionErrorHandler: undefined,
+    };
+
+    const result = getAppliedSchemaIndex(model, errorHandlerSchema.oneOf!, errorHandlerSchema);
+
+    expect(result).toBe(0);
+  });
+});

--- a/packages/ui/src/utils/get-applied-schema-index.ts
+++ b/packages/ui/src/utils/get-applied-schema-index.ts
@@ -1,0 +1,18 @@
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
+import { weightSchemaProperties } from './weight-schema-properties';
+
+export const getAppliedSchemaIndex = (
+  model: Record<string, unknown>,
+  oneOfList: KaotoSchemaDefinition['schema'][],
+  rootSchema: KaotoSchemaDefinition['schema'],
+): number => {
+  const schemaPoints = oneOfList
+    .map((oneOf, index) => {
+      const points = weightSchemaProperties(model, oneOf, rootSchema);
+      return { index, points };
+    })
+    .filter((oneOf) => oneOf.points > 0)
+    .sort((a, b) => b.points - a.points);
+
+  return schemaPoints.length > 0 ? schemaPoints[0].index : -1;
+};

--- a/packages/ui/src/utils/get-oneof-schema-list.test.ts
+++ b/packages/ui/src/utils/get-oneof-schema-list.test.ts
@@ -1,0 +1,182 @@
+import { KaotoSchemaDefinition } from '../models';
+import { errorHandlerSchema } from '../stubs/error-handler';
+import { getOneOfSchemaList } from './get-oneof-schema-list';
+
+describe('getOneOfSchemaList', () => {
+  it('should return a list of `OneOfSchemas`', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      { type: 'object', properties: { deadLetterChannel: { type: 'number' } } },
+      { type: 'object', properties: { errorHandler: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      { name: 'deadLetterChannel', schema: { type: 'object', properties: { deadLetterChannel: { type: 'number' } } } },
+      { name: 'errorHandler', schema: { type: 'object', properties: { errorHandler: { type: 'string' } } } },
+    ]);
+  });
+
+  it('should use the title from the schema if provided', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      { type: 'object', title: 'Dead Letter Channel', properties: { deadLetterChannel: { type: 'number' } } },
+      { type: 'object', title: 'Error Handler', properties: { errorHandler: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      {
+        name: 'Dead Letter Channel',
+        schema: { type: 'object', title: 'Dead Letter Channel', properties: { deadLetterChannel: { type: 'number' } } },
+      },
+      {
+        name: 'Error Handler',
+        schema: { type: 'object', title: 'Error Handler', properties: { errorHandler: { type: 'string' } } },
+      },
+    ]);
+  });
+
+  it('should use the description from the schema if provided', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      {
+        type: 'object',
+        description: 'Dead Letter Channel handler',
+        properties: { deadLetterChannel: { type: 'number' } },
+      },
+      { type: 'object', description: 'Error Handler', properties: { errorHandler: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      {
+        name: 'deadLetterChannel',
+        title: undefined,
+        description: 'Dead Letter Channel handler',
+        schema: {
+          type: 'object',
+          description: 'Dead Letter Channel handler',
+          properties: { deadLetterChannel: { type: 'number' } },
+        },
+      },
+      {
+        name: 'errorHandler',
+        title: undefined,
+        description: 'Error Handler',
+        schema: { type: 'object', description: 'Error Handler', properties: { errorHandler: { type: 'string' } } },
+      },
+    ]);
+  });
+
+  it('should use the schema title and description when there is a single property schema', () => {
+    const result = getOneOfSchemaList(errorHandlerSchema.oneOf!, errorHandlerSchema);
+
+    expect(result).toEqual([
+      {
+        name: 'Dead Letter Channel',
+        description: 'Error handler with dead letter queue.',
+        schema: expect.any(Object),
+      },
+      {
+        name: 'Default Error Handler',
+        description: 'The default error handler.',
+        schema: expect.any(Object),
+      },
+      {
+        name: 'Jta Transaction Error Handler',
+        description: 'JTA based transactional error handler (requires camel-jta).',
+        schema: expect.any(Object),
+      },
+      {
+        name: 'No Error Handler',
+        description: 'To not use an error handler.',
+        schema: expect.any(Object),
+      },
+      {
+        name: 'Ref Error Handler',
+        description: 'References to an existing or custom error handler.',
+        schema: expect.any(Object),
+      },
+      {
+        name: 'Spring Transaction Error Handler',
+        description: 'Spring based transactional error handler (requires camel-spring).',
+        schema: expect.any(Object),
+      },
+    ]);
+  });
+
+  it('should remove the `not` schemas and non-object schemas', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      { type: 'object', properties: { deadLetterChannel: { type: 'number' } } },
+      { not: { type: 'object' } },
+      { type: 'string' },
+      { type: 'number' },
+      { type: 'boolean' },
+      { type: 'object', properties: { errorHandler: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      { name: 'deadLetterChannel', schema: { type: 'object', properties: { deadLetterChannel: { type: 'number' } } } },
+      { name: 'errorHandler', schema: { type: 'object', properties: { errorHandler: { type: 'string' } } } },
+    ]);
+  });
+
+  it('should use the property name if there is no title or description and there is single property', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      { type: 'object', properties: { deadLetterChannel: { type: 'number' } } },
+      { type: 'object', properties: { errorHandler: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      {
+        name: 'deadLetterChannel',
+        description: undefined,
+        schema: {
+          type: 'object',
+          properties: { deadLetterChannel: { type: 'number' } },
+        },
+      },
+      {
+        name: 'errorHandler',
+        description: undefined,
+        schema: {
+          type: 'object',
+          properties: { errorHandler: { type: 'string' } },
+        },
+      },
+    ]);
+  });
+
+  it('should use generic names if there is no title or description and there are more than one property', () => {
+    const oneOfList: KaotoSchemaDefinition['schema'][] = [
+      { type: 'object', properties: { deadLetterChannel: { type: 'number' }, anotherProperty: { type: 'string' } } },
+      { type: 'object', properties: { errorHandler: { type: 'string' }, anotherProperty: { type: 'string' } } },
+    ];
+
+    const result = getOneOfSchemaList(oneOfList);
+
+    expect(result).toEqual([
+      {
+        name: 'Schema 0',
+        description: undefined,
+        schema: {
+          type: 'object',
+          properties: { deadLetterChannel: { type: 'number' }, anotherProperty: { type: 'string' } },
+        },
+      },
+      {
+        name: 'Schema 1',
+        description: undefined,
+        schema: {
+          type: 'object',
+          properties: { errorHandler: { type: 'string' }, anotherProperty: { type: 'string' } },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/ui/src/utils/get-oneof-schema-list.ts
+++ b/packages/ui/src/utils/get-oneof-schema-list.ts
@@ -1,0 +1,39 @@
+import { KaotoSchemaDefinition } from '../models';
+import { getResolvedSchema } from './get-resolved-schema';
+
+export interface OneOfSchemas {
+  name: string;
+  description?: string;
+  schema: KaotoSchemaDefinition['schema'];
+}
+
+export const getOneOfSchemaList = (
+  oneOfList: KaotoSchemaDefinition['schema'][],
+  rootSchema?: KaotoSchemaDefinition['schema'],
+): OneOfSchemas[] => {
+  return (
+    oneOfList
+      /** Ignore the `not` schemas and schemas that are not object */
+      .filter((oneOfSchema) => oneOfSchema?.type === 'object')
+      .map((oneOfSchema, index) => {
+        const resolvedSchema = getResolvedSchema(oneOfSchema, rootSchema);
+
+        let name = resolvedSchema.title;
+        let description = resolvedSchema.description;
+
+        const oneOfPropsKeys = Object.keys(resolvedSchema.properties ?? {});
+        const isSinglePropertySchema = oneOfPropsKeys.length === 1;
+        if (isSinglePropertySchema && !name) {
+          name = resolvedSchema.properties![oneOfPropsKeys[0]].title ?? oneOfPropsKeys[0];
+        }
+        if (isSinglePropertySchema && !description) {
+          description = resolvedSchema.properties![oneOfPropsKeys[0]].description;
+        }
+
+        name = name ?? `Schema ${index}`;
+        description = description ?? resolvedSchema.description;
+
+        return { name, description, schema: resolvedSchema ?? oneOfSchema };
+      })
+  );
+};

--- a/packages/ui/src/utils/get-resolved-schema.test.ts
+++ b/packages/ui/src/utils/get-resolved-schema.test.ts
@@ -1,0 +1,132 @@
+import { KaotoSchemaDefinition } from '../models';
+import { errorHandlerSchema } from '../stubs/error-handler';
+import { getResolvedSchema } from './get-resolved-schema';
+
+describe('getResolvedSchema', () => {
+  it('should return the same schema if it does not have properties', () => {
+    const schema = { type: 'object' } as KaotoSchemaDefinition['schema'];
+    const result = getResolvedSchema(schema, errorHandlerSchema);
+
+    expect(result).toEqual(schema);
+  });
+
+  it('should return the same schema if there is no root schema', () => {
+    const schema = { type: 'object' } as KaotoSchemaDefinition['schema'];
+    const result = getResolvedSchema(schema);
+
+    expect(result).toEqual(schema);
+  });
+
+  it('should ignore already resolved properties', () => {
+    const schema: KaotoSchemaDefinition['schema'] = {
+      type: 'object',
+      properties: {
+        deadLetterChannel: { type: 'number' },
+      },
+    };
+
+    const result = getResolvedSchema(schema, errorHandlerSchema);
+
+    expect(result).toEqual(schema);
+  });
+
+  it('should resolve a single-property schema', () => {
+    const schema: KaotoSchemaDefinition['schema'] = {
+      type: 'object',
+      required: ['noErrorHandler'],
+      properties: {
+        noErrorHandler: {
+          $ref: '#/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition',
+        },
+      },
+    };
+
+    const result = getResolvedSchema(schema, errorHandlerSchema);
+
+    expect(result).toEqual({
+      type: 'object',
+      required: ['noErrorHandler'],
+      properties: {
+        noErrorHandler: {
+          additionalProperties: false,
+          description: 'To not use an error handler.',
+          properties: {
+            id: {
+              description: 'The id of this node',
+              title: 'Id',
+              type: 'string',
+            },
+          },
+          title: 'No Error Handler',
+          type: 'object',
+        },
+      },
+    });
+  });
+
+  it('should resolve the properties of the schema', () => {
+    const schema: KaotoSchemaDefinition['schema'] = {
+      type: 'object',
+      required: ['noErrorHandler'],
+      properties: {
+        noErrorHandler: {
+          $ref: '#/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition',
+        },
+        anotherErrorHandler: {
+          $ref: '#/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition',
+        },
+      },
+    };
+
+    const result = getResolvedSchema(schema, errorHandlerSchema);
+
+    expect(result).toEqual({
+      type: 'object',
+      required: ['noErrorHandler'],
+      properties: {
+        noErrorHandler: {
+          additionalProperties: false,
+          description: 'To not use an error handler.',
+          properties: {
+            id: {
+              description: 'The id of this node',
+              title: 'Id',
+              type: 'string',
+            },
+          },
+          title: 'No Error Handler',
+          type: 'object',
+        },
+        anotherErrorHandler: {
+          additionalProperties: false,
+          description: 'To not use an error handler.',
+          properties: {
+            id: {
+              description: 'The id of this node',
+              title: 'Id',
+              type: 'string',
+            },
+          },
+          title: 'No Error Handler',
+          type: 'object',
+        },
+      },
+    });
+  });
+
+  it('should no modify the original schema', () => {
+    const schema: KaotoSchemaDefinition['schema'] = {
+      type: 'object',
+      required: ['noErrorHandler'],
+      properties: {
+        noErrorHandler: {
+          $ref: '#/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition',
+        },
+      },
+    };
+
+    const result = getResolvedSchema(schema, errorHandlerSchema);
+
+    expect(result).not.toBe(schema);
+  });
+});

--- a/packages/ui/src/utils/get-resolved-schema.ts
+++ b/packages/ui/src/utils/get-resolved-schema.ts
@@ -1,0 +1,23 @@
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
+import { isDefined } from './is-defined';
+import { resolveRefIfNeeded } from './resolve-ref-if-needed';
+
+export const getResolvedSchema = (
+  oneOf: KaotoSchemaDefinition['schema'],
+  rootSchema?: KaotoSchemaDefinition['schema'],
+) => {
+  if (!(isDefined(oneOf?.properties) && isDefined(rootSchema))) return oneOf;
+
+  const resolvedProperties = Object.keys(oneOf.properties).reduce(
+    (acc, key) => {
+      if (!(isDefined(oneOf.properties) && key in oneOf.properties)) return acc;
+
+      const resolvedOneOfProperty = resolveRefIfNeeded(oneOf.properties[key], rootSchema);
+      acc[key] = resolvedOneOfProperty;
+      return acc;
+    },
+    {} as KaotoSchemaDefinition['schema'],
+  );
+
+  return Object.assign({}, oneOf, { properties: resolvedProperties });
+};

--- a/packages/ui/src/utils/set-value.test.ts
+++ b/packages/ui/src/utils/set-value.test.ts
@@ -31,4 +31,10 @@ describe('setValue', () => {
     setValue(obj, ROOT_PATH, { d: 2 });
     expect(obj).toEqual({ a: { b: { c: 1 } }, d: 2 });
   });
+
+  it('should remove all properties when assigning `undefined` to the root path', () => {
+    const obj = { a: { b: { c: 1 } } };
+    setValue(obj, ROOT_PATH, undefined);
+    expect(obj).toEqual({});
+  });
 });

--- a/packages/ui/src/utils/set-value.ts
+++ b/packages/ui/src/utils/set-value.ts
@@ -1,6 +1,7 @@
+import isEmpty from 'lodash.isempty';
 import set from 'lodash/set';
 import { ROOT_PATH } from './get-value';
-import isEmpty from 'lodash.isempty';
+import { isDefined } from './is-defined';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const setValue = (obj: any, path: string | string[], value: any): void => {
@@ -9,7 +10,11 @@ export const setValue = (obj: any, path: string | string[], value: any): void =>
   }
 
   if (path === ROOT_PATH) {
-    Object.assign(obj, value);
+    if (isDefined(value)) {
+      Object.assign(obj, value);
+    } else {
+      Object.keys(obj).forEach((key) => delete obj[key]);
+    }
     return;
   }
 

--- a/packages/ui/src/utils/weight-schema-properties.test.ts
+++ b/packages/ui/src/utils/weight-schema-properties.test.ts
@@ -70,4 +70,19 @@ describe('weightSchemaProperties', () => {
 
     expect(result).toBe(22);
   });
+
+  it('should resolve nested oneOf properties', () => {
+    const model: ErrorHandler = {
+      '': undefined,
+      noErrorHandler: undefined,
+      refErrorHandler: {
+        id: 'id',
+        ref: 'myReference',
+      },
+    };
+
+    const result = weightSchemaProperties(model, errorHandlerSchema.oneOf![5], errorHandlerSchema);
+
+    expect(result).toBe(23);
+  });
 });

--- a/packages/ui/src/utils/weight-schema-properties.ts
+++ b/packages/ui/src/utils/weight-schema-properties.ts
@@ -24,6 +24,15 @@ export const weightSchemaProperties = (
       points += weightSchemaProperties(model[key] as Record<string, unknown>, oneOfProperty, rootSchema);
     }
 
+    if (!isDefined(oneOfProperty.type) && Array.isArray(oneOfProperty.oneOf)) {
+      const nestedOneOfPoints = oneOfProperty.oneOf.reduce((nestedPoints, nestedOneOf) => {
+        nestedPoints += weightSchemaProperties(model[key] as Record<string, unknown>, nestedOneOf, rootSchema);
+        return nestedPoints;
+      }, 0);
+
+      points += nestedOneOfPoints;
+    }
+
     return points;
   }, 0);
 };


### PR DESCRIPTION
In order to support errorHandler configuration form, a set of utils are required to handle nested schemas, like the oneOf and anyOf schemas.

relates: https://github.com/KaotoIO/kaoto-next/issues/560