### PR TITLE
fix(canvas): Add missing `sideBarOpen` prop to Canvas

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -188,8 +188,11 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props)
     setSelectedNode(undefined);
   }, []);
 
+  const isSidebarOpen = useMemo(() => selectedNode !== undefined, [selectedNode]);
+
   return (
     <TopologyView
+      sideBarOpen={isSidebarOpen}
       sideBar={<CanvasSideBar selectedNode={selectedNode} onClose={handleCloseSideBar} />}
       contextToolbar={props.contextToolbar}
       controlBar={<TopologyControlBar controlButtons={controlButtons} />}


### PR DESCRIPTION
Currently, the Canvas component is missing a property that tells whether the sideBar is open or not. Due to that, when opening the Canvas Form, the Canvas cannot be centered taking in consideration the occupied space from the Side Bar.

relates: https://github.com/KaotoIO/kaoto-next/issues/507