### PR TITLE
feat(CanvasForm): Add support for ErrorHandler

### DIFF
--- a/packages/ui-tests/cypress/fixtures/flows/errorHandlerCR.yaml
+++ b/packages/ui-tests/cypress/fixtures/flows/errorHandlerCR.yaml
@@ -1,0 +1,11 @@
+- errorHandler:
+    defaultErrorHandler:
+      level: ERROR
+      redeliveryPolicy:
+        backOffMultiplier: "2.0"
+        collisionAvoidanceFactor: "0.15"
+        maximumRedeliveryDelay: "60000"
+        redeliveryDelay: "1000"
+        retriesExhaustedLogLevel: ERROR
+        retryAttemptedLogInterval: "1"
+        retryAttemptedLogLevel: DEBUG

--- a/packages/ui/src/components/Form/CustomAutoField.test.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.test.tsx
@@ -13,8 +13,42 @@ import { AutoFieldProps } from 'uniforms';
 import { CustomAutoField } from './CustomAutoField';
 import { DisabledField } from './customField/DisabledField';
 import { TypeaheadField } from './customField/TypeaheadField';
+import { OneOfField } from './OneOf/OneOfField';
 
 describe('CustomAutoField', () => {
+  it('should return `OneOfField` if `props.oneOf` is an array with a length > 0', () => {
+    const props: AutoFieldProps = {
+      oneOf: [{ type: 'string' }],
+      name: 'test',
+    };
+
+    const result = CustomAutoField(props);
+
+    expect(result).toBe(OneOfField);
+  });
+
+  it('should NOT return `OneOfField` if `props.oneOf` is an empty array', () => {
+    const props: AutoFieldProps = {
+      oneOf: [],
+      name: 'test',
+    };
+
+    const result = CustomAutoField(props);
+
+    expect(result).not.toBe(OneOfField);
+  });
+
+  it('should NOT return `OneOfField` if `props.oneOf` is not an array', () => {
+    const props: AutoFieldProps = {
+      oneOf: undefined,
+      name: 'test',
+    };
+
+    const result = CustomAutoField(props);
+
+    expect(result).not.toBe(OneOfField);
+  });
+
   it('should return `RadioField` if `props.options` & `props.checkboxes` are defined and `props.fieldType` is not `Array`', () => {
     const props: AutoFieldProps = {
       options: [],

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -9,6 +9,7 @@ import {
 } from '@kaoto-next/uniforms-patternfly';
 import { createAutoField } from 'uniforms';
 import { getValue } from '../../utils';
+import { OneOfField } from './OneOf/OneOfField';
 import { BeanReferenceField } from './bean/BeanReferenceField';
 import { DisabledField } from './customField/DisabledField';
 import { TypeaheadField } from './customField/TypeaheadField';
@@ -21,6 +22,10 @@ import { PropertiesField } from './properties/PropertiesField';
  * In case a field is not supported, it will render a DisabledField
  */
 export const CustomAutoField = createAutoField((props) => {
+  if (Array.isArray(props.oneOf) && props.oneOf.length > 0) {
+    return OneOfField;
+  }
+
   if (props.options) {
     return props.checkboxes && props.fieldType !== Array ? RadioField : TypeaheadField;
   }

--- a/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
@@ -1,0 +1,115 @@
+import { AutoForm } from '@kaoto-next/uniforms-patternfly';
+import { act, fireEvent, render } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { KaotoSchemaDefinition } from '../../../models/kaoto-schema';
+import { SchemaBridgeContext } from '../../../providers/schema-bridge.provider';
+import { SchemaService } from '../schema.service';
+import { OneOfField } from './OneOfField';
+
+describe('OneOfField', () => {
+  const oneOfSchema: KaotoSchemaDefinition['schema'] = {
+    oneOf: [
+      { title: 'Name schema', type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+      { title: 'Number schema', type: 'object', properties: { amount: { type: 'number' } }, required: ['amount'] },
+      { title: 'Boolean schema', type: 'object', properties: { isValid: { type: 'boolean' } }, required: ['isValid'] },
+    ],
+    type: 'object',
+    properties: {
+      name: {},
+      amount: {},
+      isValid: {},
+    },
+  };
+
+  it('should render', () => {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+      wrapper: (props) => (
+        <UniformsWrapper model={{}} schema={oneOfSchema}>
+          {props.children}
+        </UniformsWrapper>
+      ),
+    });
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly', () => {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+      wrapper: (props) => (
+        <UniformsWrapper model={{}} schema={oneOfSchema}>
+          {props.children}
+        </UniformsWrapper>
+      ),
+    });
+
+    const dropDownToggle = wrapper.getByText(SchemaService.DROPDOWN_PLACEHOLDER);
+    expect(dropDownToggle).toBeInTheDocument();
+  });
+
+  it('should render the appropriate schema when given a matching model', () => {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+      wrapper: (props) => (
+        <UniformsWrapper model={{ name: 'John Doe' }} schema={oneOfSchema}>
+          {props.children}
+        </UniformsWrapper>
+      ),
+    });
+
+    const nameField = wrapper.getByTestId('text-field');
+    expect(nameField).toBeInTheDocument();
+    expect(nameField).toHaveAttribute('label', 'Name');
+    expect(nameField).toHaveValue('John Doe');
+  });
+
+  it('should render a new selected schema', async () => {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+      wrapper: (props) => (
+        <UniformsWrapper model={{}} schema={oneOfSchema}>
+          {props.children}
+        </UniformsWrapper>
+      ),
+    });
+
+    await act(async () => {
+      const dropDownToggle = wrapper.getByText(SchemaService.DROPDOWN_PLACEHOLDER);
+      expect(dropDownToggle).toBeInTheDocument();
+
+      fireEvent.click(dropDownToggle);
+    });
+
+    await act(async () => {
+      const schema2Item = wrapper.getByText('Number schema');
+      fireEvent.click(schema2Item);
+    });
+
+    const nameField = wrapper.getByTestId('text-field');
+    expect(nameField).toBeInTheDocument();
+    expect(nameField).toHaveAttribute('label', 'Amount');
+    expect(nameField).toHaveValue('');
+  });
+});
+
+const UniformsWrapper: FunctionComponent<
+  PropsWithChildren<{
+    model: Record<string, unknown>;
+    schema: KaotoSchemaDefinition['schema'];
+  }>
+> = (props) => {
+  const schemaBridge = new SchemaService().getSchemaBridge(props.schema);
+  const divRef = useRef<HTMLDivElement>(null);
+  const [, setLastRenderTimestamp] = useState<number>(-1);
+
+  useEffect(() => {
+    /** Force re-render to update the divRef */
+    setLastRenderTimestamp(Date.now());
+  }, []);
+
+  return (
+    <SchemaBridgeContext.Provider value={{ schemaBridge, parentRef: divRef }}>
+      <AutoForm model={props.model} schema={schemaBridge}>
+        {props.children}
+      </AutoForm>
+      <div ref={divRef} />
+    </SchemaBridgeContext.Provider>
+  );
+};

--- a/packages/ui/src/components/Form/OneOf/OneOfField.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfField.tsx
@@ -1,0 +1,111 @@
+import { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { GuaranteedProps, connectField } from 'uniforms';
+import { useAppliedSchema, useSchemaBridgeContext } from '../../../hooks';
+import { KaotoSchemaDefinition } from '../../../models';
+import { SchemaBridgeProvider } from '../../../providers/schema-bridge.provider';
+import { ROOT_PATH, isDefined } from '../../../utils';
+import { OneOfSchemas, getOneOfSchemaList } from '../../../utils/get-oneof-schema-list';
+import { CustomAutoForm, CustomAutoFormRef } from '../CustomAutoForm';
+import { SchemaService } from '../schema.service';
+import { OneOfSchemaList } from './OneOfSchemaList';
+
+interface OneOfComponentProps extends GuaranteedProps<unknown> {
+  oneOf: KaotoSchemaDefinition['schema'][];
+}
+
+const applyDefinitionsToSchema = (
+  schema?: KaotoSchemaDefinition['schema'],
+  rootSchema?: KaotoSchemaDefinition['schema'],
+) => {
+  if (!isDefined(schema) || !isDefined(rootSchema)) {
+    return schema;
+  }
+
+  return Object.assign({}, schema, {
+    definitions: rootSchema.definitions,
+  });
+};
+
+const OneOfComponent: FunctionComponent<OneOfComponentProps> = ({ name: propsName, oneOf, onChange }) => {
+  const formRef = useRef<CustomAutoFormRef>(null);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const { schemaBridge, parentRef } = useSchemaBridgeContext();
+  const oneOfSchemas: OneOfSchemas[] = useMemo(
+    () => getOneOfSchemaList(oneOf, schemaBridge?.schema),
+    [oneOf, schemaBridge?.schema],
+  );
+
+  const appliedSchema = useAppliedSchema(propsName, oneOfSchemas);
+  const [selectedSchema, setSelectedSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>(
+    applyDefinitionsToSchema(appliedSchema?.schema, schemaBridge?.schema),
+  );
+  const [selectedSchemaName, setSelectedSchemaName] = useState<string | undefined>(appliedSchema?.name);
+
+  const onSchemaChanged = useCallback(
+    (schemaName: string | undefined) => {
+      if (schemaName === selectedSchemaName) return;
+      /** Remove existing properties */
+      const path = propsName === '' ? ROOT_PATH : `${propsName}.${selectedSchemaName}`;
+      onChange(undefined, path);
+
+      if (!isDefined(schemaName)) {
+        setSelectedSchema(undefined);
+        setSelectedSchemaName(undefined);
+        return;
+      }
+
+      const selectedSchema = oneOfSchemas.find((schema) => schema.name === schemaName);
+      const schemaWithDefinitions = applyDefinitionsToSchema(selectedSchema?.schema, schemaBridge?.schema);
+      setSelectedSchema(schemaWithDefinitions);
+      setSelectedSchemaName(schemaName);
+    },
+    [onChange, oneOfSchemas, propsName, schemaBridge?.schema, selectedSchemaName],
+  );
+
+  useEffect(() => {
+    formRef.current?.form.reset();
+  }, []);
+
+  const handleOnChangeIndividualProp = useCallback(
+    (path: string, value: unknown) => {
+      const updatedPath = propsName === '' ? path : `${propsName}.${path}`;
+      onChange(value, updatedPath);
+    },
+    [onChange, propsName],
+  );
+
+  return (
+    <OneOfSchemaList
+      name={propsName}
+      oneOfSchemas={oneOfSchemas}
+      selectedSchemaName={selectedSchemaName}
+      onSchemaChanged={onSchemaChanged}
+    >
+      {isDefined(selectedSchema) && (
+        <SchemaBridgeProvider schema={selectedSchema} parentRef={divRef}>
+          {isDefined(parentRef?.current) &&
+            createPortal(
+              <>
+                <CustomAutoForm
+                  key={propsName}
+                  ref={formRef}
+                  model={appliedSchema?.model ?? {}}
+                  onChange={handleOnChangeIndividualProp}
+                  sortFields={false}
+                  omitFields={SchemaService.OMIT_FORM_FIELDS}
+                  data-testid={`${propsName}-autoform`}
+                />
+                <div data-testid={`${propsName}-form-placeholder`} ref={divRef} />
+              </>,
+              parentRef.current,
+              propsName,
+            )}
+        </SchemaBridgeProvider>
+      )}
+    </OneOfSchemaList>
+  );
+};
+
+export const OneOfField = connectField(OneOfComponent as unknown as Parameters<typeof connectField>[0]);

--- a/packages/ui/src/components/Form/OneOf/OneOfSchemaList.test.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfSchemaList.test.tsx
@@ -1,0 +1,95 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { OneOfSchemas } from '../../../utils/get-oneof-schema-list';
+import { SchemaService } from '../schema.service';
+import { OneOfSchemaList } from './OneOfSchemaList';
+
+describe('OneOfSchemaList', () => {
+  const oneOfSchemas: OneOfSchemas[] = [
+    { name: 'Schema 1', schema: { type: 'object', properties: { name: { type: 'string' } } } },
+    { name: 'Schema 2', schema: { type: 'object', properties: { amount: { type: 'number' } } } },
+    { name: 'Schema 3', schema: { type: 'object', properties: { isValid: { type: 'boolean' } } } },
+  ];
+
+  it('should render', () => {
+    const wrapper = render(<OneOfSchemaList name="" oneOfSchemas={oneOfSchemas} onSchemaChanged={() => {}} />);
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it('should render the dropwdown toggle correctly', () => {
+    const wrapper = render(<OneOfSchemaList name="" oneOfSchemas={oneOfSchemas} onSchemaChanged={() => {}} />);
+
+    const dropDownToggle = wrapper.getByText(SchemaService.DROPDOWN_PLACEHOLDER);
+    expect(dropDownToggle).toBeInTheDocument();
+  });
+
+  it('should render the provided children', () => {
+    const wrapper = render(
+      <OneOfSchemaList name="" oneOfSchemas={oneOfSchemas} selectedSchemaName="Schema 1" onSchemaChanged={() => {}}>
+        <div data-testid="children">Children</div>
+      </OneOfSchemaList>,
+    );
+
+    const children = wrapper.getByTestId('children');
+    expect(children).toBeInTheDocument();
+  });
+
+  it('should notify the parent when a schema is selected', async () => {
+    const schemaChangedSpy = jest.fn();
+
+    const wrapper = render(
+      <OneOfSchemaList
+        name=""
+        oneOfSchemas={oneOfSchemas}
+        selectedSchemaName={undefined}
+        onSchemaChanged={schemaChangedSpy}
+      >
+        <div data-testid="children">Children</div>
+      </OneOfSchemaList>,
+    );
+
+    await act(async () => {
+      const dropDownToggle = wrapper.getByText(SchemaService.DROPDOWN_PLACEHOLDER);
+      expect(dropDownToggle).toBeInTheDocument();
+
+      fireEvent.click(dropDownToggle);
+    });
+
+    await act(async () => {
+      const schema2Item = wrapper.getByText('Schema 2');
+      fireEvent.click(schema2Item);
+    });
+
+    expect(schemaChangedSpy).toHaveBeenCalledWith('Schema 2');
+  });
+
+  it('should notify the parent when a schema is changed', async () => {
+    const schemaChangedSpy = jest.fn();
+
+    const wrapper = render(
+      <OneOfSchemaList
+        name=""
+        oneOfSchemas={oneOfSchemas}
+        selectedSchemaName="Schema 2"
+        onSchemaChanged={schemaChangedSpy}
+      >
+        <div data-testid="children">Children</div>
+      </OneOfSchemaList>,
+    );
+
+    await act(async () => {
+      const dropDownToggle = wrapper.getByText('Schema 2');
+      expect(dropDownToggle).toBeInTheDocument();
+
+      fireEvent.click(dropDownToggle);
+    });
+
+    await act(async () => {
+      const schema3Item = wrapper.getByText('Schema 3');
+      fireEvent.click(schema3Item);
+    });
+
+    expect(schemaChangedSpy).toHaveBeenCalledWith(undefined);
+    expect(schemaChangedSpy).toHaveBeenCalledWith('Schema 3');
+  });
+});

--- a/packages/ui/src/components/Form/OneOf/OneOfSchemaList.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfSchemaList.tsx
@@ -1,0 +1,111 @@
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { FunctionComponent, PropsWithChildren, Ref, useCallback, useEffect, useState } from 'react';
+import { OneOfSchemas } from '../../../utils/get-oneof-schema-list';
+import { isDefined } from '../../../utils/is-defined';
+import { SchemaService } from '../schema.service';
+
+interface OneOfComponentProps extends PropsWithChildren {
+  name: string;
+  oneOfSchemas: OneOfSchemas[];
+  selectedSchemaName?: string;
+  onSchemaChanged: (name: string | undefined) => void;
+}
+
+export const OneOfSchemaList: FunctionComponent<OneOfComponentProps> = ({
+  name,
+  oneOfSchemas,
+  selectedSchemaName,
+  onSchemaChanged,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onSelect = useCallback(
+    (_event: unknown, value: string | number | undefined) => {
+      setIsOpen(false);
+      onSchemaChanged(undefined);
+      onSchemaChanged(value as string);
+    },
+    [onSchemaChanged],
+  );
+
+  const onToggleClick = useCallback(() => {
+    setIsOpen(!isOpen);
+  }, [isOpen]);
+
+  const toggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <MenuToggle
+        id={`${name}-oneof-toggle`}
+        data-testid={`${name}-oneof-toggle`}
+        ref={toggleRef}
+        onClick={onToggleClick}
+        isFullWidth
+        isExpanded={isOpen}
+      >
+        {selectedSchemaName || (
+          <TextContent>
+            <Text component={TextVariants.small}>{SchemaService.DROPDOWN_PLACEHOLDER}</Text>
+          </TextContent>
+        )}
+      </MenuToggle>
+    ),
+    [isOpen, name, onToggleClick, selectedSchemaName],
+  );
+
+  useEffect(() => {
+    if (oneOfSchemas.length === 1 && isDefined(oneOfSchemas[0]) && !selectedSchemaName) {
+      onSchemaChanged(oneOfSchemas[0].name);
+    }
+  }, [onSchemaChanged, oneOfSchemas, selectedSchemaName]);
+
+  if (oneOfSchemas.length === 1) {
+    return children;
+  }
+
+  return (
+    <Card>
+      <CardTitle>
+        <Dropdown
+          id={`${name}-oneof-select`}
+          data-testid={`${name}-oneof-select`}
+          isOpen={isOpen}
+          selected={selectedSchemaName}
+          onSelect={onSelect}
+          onOpenChange={setIsOpen}
+          toggle={toggle}
+          isScrollable
+        >
+          <DropdownList data-testid={`${name}-oneof-select-dropdownlist`}>
+            {oneOfSchemas.map((schemaDef) => {
+              return (
+                <DropdownItem
+                  data-testid={`${name}-oneof-select-dropdownlist-${schemaDef.name}`}
+                  key={schemaDef.name}
+                  value={schemaDef.name}
+                  description={schemaDef.description}
+                >
+                  {schemaDef.name}
+                </DropdownItem>
+              );
+            })}
+          </DropdownList>
+        </Dropdown>
+      </CardTitle>
+
+      <CardBody>{children}</CardBody>
+    </Card>
+  );
+};

--- a/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfField.test.tsx.snap
+++ b/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfField.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OneOfField should render 1`] = `
+<DocumentFragment>
+  <form
+    class="pf-v5-c-form"
+    data-testid="base-form"
+    novalidate=""
+  >
+    <div
+      class="pf-v5-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-1"
+      data-ouia-component-type="PF5/Card"
+      data-ouia-safe="true"
+      id=""
+    >
+      <div
+        class="pf-v5-c-card__title"
+      >
+        <div
+          class="pf-v5-c-card__title-text"
+        >
+          <button
+            aria-expanded="false"
+            class="pf-v5-c-menu-toggle pf-m-full-width"
+            data-testid="-oneof-toggle"
+            id="-oneof-toggle"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-menu-toggle__text"
+            >
+              <div
+                class="pf-v5-c-content"
+              >
+                <small
+                  class=""
+                  data-ouia-component-id="OUIA-Generated-Text-1"
+                  data-ouia-component-type="PF5/Text"
+                  data-ouia-safe="true"
+                  data-pf-content="true"
+                >
+                  Select an option...
+                </small>
+              </div>
+            </span>
+            <span
+              class="pf-v5-c-menu-toggle__controls"
+            >
+              <span
+                class="pf-v5-c-menu-toggle__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v5-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-card__body"
+      />
+    </div>
+  </form>
+  <div />
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfSchemaList.test.tsx.snap
+++ b/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfSchemaList.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OneOfSchemaList should render 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="OUIA-Generated-Card-1"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__title"
+    >
+      <div
+        class="pf-v5-c-card__title-text"
+      >
+        <button
+          aria-expanded="false"
+          class="pf-v5-c-menu-toggle pf-m-full-width"
+          data-testid="-oneof-toggle"
+          id="-oneof-toggle"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-menu-toggle__text"
+          >
+            <div
+              class="pf-v5-c-content"
+            >
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-1"
+                data-ouia-component-type="PF5/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                Select an option...
+              </small>
+            </div>
+          </span>
+          <span
+            class="pf-v5-c-menu-toggle__controls"
+          >
+            <span
+              class="pf-v5-c-menu-toggle__toggle-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="pf-v5-c-card__body"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -22,6 +22,7 @@ interface CanvasFormProps {
 export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
   const formRef = useRef<CustomAutoFormRef>(null);
+  const divRef = useRef<HTMLDivElement>(null);
 
   const visualComponentSchema = useMemo(() => {
     const answer = props.selectedNode.data?.vizNode?.getComponentSchema();
@@ -75,25 +76,26 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
             nodeIcon={props.selectedNode.data?.vizNode?.data?.icon}
           />
         </CardHeader>
+
         <CardBody className="canvas-form__body">
           {stepFeatures.isUnknownComponent ? (
             <UnknownNode model={model} />
           ) : (
-            <>
+            <SchemaBridgeProvider schema={visualComponentSchema?.schema} parentRef={divRef}>
               {stepFeatures.isExpressionAwareStep && <StepExpressionEditor selectedNode={props.selectedNode} />}
               {stepFeatures.isDataFormatAwareStep && <DataFormatEditor selectedNode={props.selectedNode} />}
               {stepFeatures.isLoadBalanceAwareStep && <LoadBalancerEditor selectedNode={props.selectedNode} />}
-              <SchemaBridgeProvider schema={visualComponentSchema?.schema}>
-                <CustomAutoForm
-                  ref={formRef}
-                  model={model}
-                  onChange={handleOnChangeIndividualProp}
-                  sortFields={false}
-                  omitFields={SchemaService.OMIT_FORM_FIELDS}
-                  data-testid="autoform"
-                />
-              </SchemaBridgeProvider>
-            </>
+              <CustomAutoForm
+                key={props.selectedNode.id}
+                ref={formRef}
+                model={model}
+                onChange={handleOnChangeIndividualProp}
+                sortFields={false}
+                omitFields={SchemaService.OMIT_FORM_FIELDS}
+                data-testid="autoform"
+              />
+              <div data-testid="root-form-placeholder" ref={divRef} />
+            </SchemaBridgeProvider>
           )}
         </CardBody>
       </Card>

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -132,6 +132,9 @@ exports[`CanvasForm should render 1`] = `
           </div>
         </div>
       </form>
+      <div
+        data-testid="root-form-placeholder"
+      />
     </div>
   </div>
 </div>

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -3,9 +3,10 @@ import { TileFilter } from '../../components/Catalog';
 import { createCamelPropertiesSorter, isDefined } from '../../utils';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from '../visualization/flows';
+import { CamelErrorHandlerVisualEntity } from '../visualization/flows/camel-error-handler-visual-entity';
+import { CamelOnExceptionVisualEntity } from '../visualization/flows/camel-on-exception-visual-entity';
 import { FlowTemplateService } from '../visualization/flows/flow-templates-service';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
-import { CamelOnExceptionVisualEntity } from '../visualization/flows/camel-on-exception-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
 import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
 import { BeansEntity, isBeans } from '../visualization/metadata';
@@ -14,7 +15,7 @@ import { BaseCamelEntity } from './entities';
 import { SourceSchemaType } from './source-schema-type';
 
 export class CamelRouteResource implements CamelResource, BeansAwareResource {
-  static readonly SUPPORTED_ENTITIES = [CamelOnExceptionVisualEntity];
+  static readonly SUPPORTED_ENTITIES = [CamelOnExceptionVisualEntity, CamelErrorHandlerVisualEntity] as const;
   static readonly PARAMETERS_ORDER = ['id', 'description', 'uri', 'parameters', 'steps'];
   readonly sortFn = createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (
     a: unknown,
@@ -53,7 +54,9 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
 
   getVisualEntities(): CamelRouteVisualEntity[] {
     return this.entities.filter(
-      (entity) => entity instanceof CamelRouteVisualEntity || entity instanceof CamelOnExceptionVisualEntity,
+      (entity) =>
+        entity instanceof CamelRouteVisualEntity ||
+        CamelRouteResource.SUPPORTED_ENTITIES.some((SupportedEntity) => entity instanceof SupportedEntity),
     ) as CamelRouteVisualEntity[];
   }
 
@@ -117,6 +120,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
 
     for (const Entity of CamelRouteResource.SUPPORTED_ENTITIES) {
       if (Entity.isApplicable(rawItem)) {
+        // @ts-expect-error When iterating over the entities, we know that the entity is applicable but TS doesn't, hence causing an error
         return new Entity(rawItem);
       }
     }

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -1,0 +1,168 @@
+import { ErrorHandler, NoErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { useSchemasStore } from '../../../store';
+import { errorHandlerSchema } from '../../../stubs/error-handler';
+import { CamelErrorHandlerVisualEntity } from './camel-error-handler-visual-entity';
+import { EntityType } from '../../camel/entities';
+
+describe('CamelErrorHandlerVisualEntity', () => {
+  const ERROR_HANDLER_ID_REGEXP = /^errorHandler-[a-zA-Z0-9]{4}$/;
+  let errorHandlerDef: { errorHandler: ErrorHandler };
+
+  beforeAll(() => {
+    useSchemasStore.getState().setSchema('errorHandler', {
+      name: 'errorHandler',
+      version: '1.0.0',
+      tags: ['camel'],
+      uri: 'errorHandler',
+      schema: errorHandlerSchema,
+    });
+  });
+
+  beforeEach(() => {
+    errorHandlerDef = {
+      errorHandler: {
+        noErrorHandler: { id: 'noErrorHandlerId' },
+      },
+    };
+  });
+
+  describe('isApplicable', () => {
+    it.each([
+      [true, { errorHandler: { id: 'errorHandlerId' } }],
+      [false, { from: { id: 'from-1234', steps: [] } }],
+      [false, { errorHandler: { id: 'errorHandlerId' }, anotherProperty: true }],
+    ])('should return %s for %s', (result, definition) => {
+      expect(CamelErrorHandlerVisualEntity.isApplicable(definition)).toEqual(result);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should set id to generated id', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      expect(entity.id).toMatch(ERROR_HANDLER_ID_REGEXP);
+      expect((errorHandlerDef.errorHandler.noErrorHandler as NoErrorHandler).id).toEqual('noErrorHandlerId');
+    });
+  });
+
+  it('should return id', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.getId()).toMatch(ERROR_HANDLER_ID_REGEXP);
+  });
+
+  it('should set id', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+    const newId = 'newId';
+    entity.setId(newId);
+
+    expect(entity.getId()).toEqual(newId);
+  });
+
+  it('should return node label', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.getNodeLabel()).toEqual('errorHandler');
+  });
+
+  it('should return tooltip content', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.getTooltipContent()).toEqual('errorHandler');
+  });
+
+  describe('getComponentSchema', () => {
+    it('should return entity current definition', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      expect(entity.getComponentSchema().definition).toEqual(errorHandlerDef.errorHandler);
+    });
+
+    it('should return schema from store', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      expect(entity.getComponentSchema().schema).toEqual(errorHandlerSchema);
+    });
+
+    it('should return hardcoded schema title', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      expect(entity.getComponentSchema().title).toEqual('Error Handler');
+    });
+  });
+
+  describe('updateModel', () => {
+    it('should update model', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+      const path = 'errorHandler.noErrorHandler.id';
+      const value = 'newId';
+
+      entity.updateModel(path, value);
+
+      expect((errorHandlerDef.errorHandler.noErrorHandler as NoErrorHandler).id).toEqual(value);
+    });
+
+    it('should not update model if path is not defined', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+      const value = 'newId';
+
+      entity.updateModel(undefined, value);
+
+      expect((errorHandlerDef.errorHandler.noErrorHandler as NoErrorHandler).id).toEqual('noErrorHandlerId');
+    });
+
+    it('should reset the errorHandler object if it is not defined', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      entity.updateModel('errorHandler', {});
+
+      expect(errorHandlerDef.errorHandler).toEqual({});
+    });
+  });
+
+  it('return no interactions', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.getNodeInteraction()).toEqual({
+      canHavePreviousStep: false,
+      canHaveNextStep: false,
+      canHaveChildren: false,
+      canHaveSpecialChildren: false,
+      canRemoveStep: false,
+      canReplaceStep: false,
+    });
+  });
+
+  it('should return undefined validation text', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.getNodeValidationText()).toBeUndefined();
+  });
+
+  describe('toVizNode', () => {
+    it('should return visualization node', () => {
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      const vizNode = entity.toVizNode();
+
+      expect(vizNode.data).toEqual({
+        componentName: undefined,
+        entity: {
+          id: entity.getId(),
+          errorHandlerDef,
+          type: EntityType.ErrorHandler,
+        },
+        icon: '',
+        isGroup: true,
+        path: 'errorHandler',
+        processorName: 'errorHandler',
+      });
+    });
+  });
+
+  it('should serialize the errorHandler definition', () => {
+    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+    expect(entity.toJSON()).toEqual(errorHandlerDef);
+  });
+});

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -1,0 +1,110 @@
+import { ErrorHandler, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { useSchemasStore } from '../../../store';
+import { isDefined, setValue } from '../../../utils';
+import { EntityType } from '../../camel/entities/base-entity';
+import {
+  BaseVisualCamelEntity,
+  IVisualizationNode,
+  IVisualizationNodeData,
+  NodeInteraction,
+  VisualComponentSchema,
+} from '../base-visual-entity';
+import { CamelStepsService } from './support/camel-steps.service';
+
+export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
+  id: string;
+  readonly type = EntityType.ErrorHandler;
+
+  constructor(public errorHandlerDef: { errorHandler: ErrorHandler }) {
+    const id = getCamelRandomId('errorHandler');
+    this.id = id;
+  }
+
+  static isApplicable(errorHandlerDef: unknown): errorHandlerDef is { errorHandler: ErrorHandler } {
+    if (!isDefined(errorHandlerDef) || Array.isArray(errorHandlerDef) || typeof errorHandlerDef !== 'object') {
+      return false;
+    }
+
+    const objectKeys = Object.keys(errorHandlerDef!);
+
+    return (
+      objectKeys.length === 1 && 'errorHandler' in errorHandlerDef! && typeof errorHandlerDef.errorHandler === 'object'
+    );
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  setId(id: string): void {
+    this.id = id;
+  }
+
+  getNodeLabel(): string {
+    return 'errorHandler';
+  }
+
+  getTooltipContent(): string {
+    return 'errorHandler';
+  }
+
+  addStep(): void {
+    return;
+  }
+
+  removeStep(): void {
+    return;
+  }
+
+  getComponentSchema(): VisualComponentSchema {
+    const schema = useSchemasStore.getState().schemas['errorHandler'].schema;
+
+    return {
+      definition: Object.assign({}, this.errorHandlerDef.errorHandler),
+      schema: schema,
+      title: 'Error Handler',
+    };
+  }
+
+  updateModel(path: string | undefined, value: unknown): void {
+    if (!path) return;
+
+    setValue(this.errorHandlerDef, path, value);
+
+    if (!isDefined(this.errorHandlerDef.errorHandler)) {
+      this.errorHandlerDef.errorHandler = {};
+    }
+  }
+
+  getNodeInteraction(): NodeInteraction {
+    return {
+      canHavePreviousStep: false,
+      canHaveNextStep: false,
+      canHaveChildren: false,
+      canHaveSpecialChildren: false,
+      canRemoveStep: false,
+      canReplaceStep: false,
+    };
+  }
+
+  getNodeValidationText(): string | undefined {
+    return undefined;
+  }
+
+  toVizNode(): IVisualizationNode<IVisualizationNodeData> {
+    const errorHandlerGroupNode = CamelStepsService.getVizNodeFromProcessor(
+      'errorHandler',
+      { processorName: 'errorHandler' as keyof ProcessorDefinition },
+      this.errorHandlerDef,
+    );
+    errorHandlerGroupNode.data.entity = this;
+    errorHandlerGroupNode.data.isGroup = true;
+
+    return errorHandlerGroupNode;
+  }
+
+  toJSON(): unknown {
+    return this.errorHandlerDef;
+  }
+}


### PR DESCRIPTION
### Context
Currently, there's partial support for `oneOf` in the `uniforms` library.

This commit adds a new `OneOfField` component that shows a selector to pick which schema should the form generate.

Also, if a model is already defined, the closest schema is selected automatically.


fix: https://github.com/KaotoIO/kaoto-next/issues/560
relates: https://github.com/KaotoIO/kaoto-next/issues/948
Reusing the internal ID will be implemented here: https://github.com/KaotoIO/kaoto-next/issues/962