### PR TITLE
feat(canvas): Move Canvas to the left

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -183,6 +183,15 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = (props)
     controller.fromModel(model, false);
   }, [controller, props.entities, visibleFlows]);
 
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      controller.getGraph().fit(80);
+    }, 250);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [controller, selectedIds]);
+
   const handleCloseSideBar = useCallback(() => {
     setSelectedIds([]);
     setSelectedNode(undefined);


### PR DESCRIPTION
### Context
In small viewports, when opening the `CanvasForm`, there's a chance the selected node gets hidden by it.

This pull request moves the canvas to the left side when opening the `CanvasForm`, so this way we can still see the selected node.

### Screencast
#### Before
https://github.com/KaotoIO/kaoto-next/assets/16512618/96aa7e16-dc81-4ed2-ad53-5c03df762a72

#### After
https://github.com/KaotoIO/kaoto-next/assets/16512618/0b779662-a1af-4556-b77e-ce98e968aed4

fix: https://github.com/KaotoIO/kaoto-next/issues/507
