### PR TITLE
chore(deps): Update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "uniforms": "4.0.0-alpha.5",
     "uniforms-bridge-json-schema": "4.0.0-alpha.5",
     "uniforms-bridge-simple-schema-2": "4.0.0-alpha.5",
-    "simpl-schema": "3.4.6"
+    "simpl-schema": "3.4.6",
+    "typescript": "5.4.2"
   },
   "scripts": {
     "postinstall": "yarn workspace @kaoto-next/camel-catalog run build",

--- a/packages/camel-catalog/package.json
+++ b/packages/camel-catalog/package.json
@@ -34,6 +34,6 @@
     "prettier": "^3.0.0",
     "rimraf": "^5.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2"
+    "typescript": "^5.4.2"
   }
 }

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -57,7 +57,7 @@
     "start-server-and-test": "^2.0.0",
     "storybook-addon-react-router-v6": "^2.0.7",
     "storybook-fixtures": "0.12.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5"
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -121,7 +121,7 @@
     "stylelint-config-standard-scss": "^13.0.0",
     "stylelint-prettier": "^5.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2",
+    "typescript": "^5.4.2",
     "vite": "^4.4.5",
     "vite-plugin-dts": "^3.5.1",
     "vite-plugin-static-copy": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,7 +2395,7 @@ __metadata:
     prettier: ^3.0.0
     rimraf: ^5.0.1
     ts-node: ^10.9.1
-    typescript: ^5.0.2
+    typescript: ^5.4.2
   languageName: unknown
   linkType: soft
 
@@ -2439,7 +2439,7 @@ __metadata:
     storybook: ^7.2.3
     storybook-addon-react-router-v6: ^2.0.7
     storybook-fixtures: 0.12.0
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     vite: ^4.4.5
   languageName: unknown
   linkType: soft
@@ -2518,7 +2518,7 @@ __metadata:
     stylelint-config-standard-scss: ^13.0.0
     stylelint-prettier: ^5.0.0
     ts-node: ^10.9.1
-    typescript: ^5.0.2
+    typescript: ^5.4.2
     uniforms: 4.0.0-alpha.5
     uniforms-bridge-json-schema: 4.0.0-alpha.5
     usehooks-ts: ^2.15.1
@@ -18699,43 +18699,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.4":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: 797ac213c03a19749181c745647b4cab03d13bf4b6b738b05a3426f46c6b540f908989e839d9b0c89d7a4ee2bdb50493b4d4898d4ef1c897c3e9d0b082e78a67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, the project has 2 different versions of `typescript`, `5.2.2` and `5.0.4`:

```
├─ @kaoto-next/camel-catalog@workspace:packages/camel-catalog
│  └─ typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441 (via patch:typescript@^5.0.2#~builtin<compat/typescript>)
│
├─ @kaoto-next/ui-tests@workspace:packages/ui-tests
│  └─ typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441 (via patch:typescript@^5.0.2#~builtin<compat/typescript>)
│
├─ @kaoto-next/ui@workspace:packages/ui
│  └─ typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441 (via patch:typescript@^5.0.2#~builtin<compat/typescript>)
│
└─ @microsoft/api-extractor@npm:7.36.4
   └─ typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058 (via patch:typescript@~5.0.4#~builtin<compat/typescript>)
```

This causes to have one behavior in the IDE while having another during compilation time.

The workaround for now is to update `typescript` to the latest version and provide a resolution so all dependencies uses the same `typescript` version.