### PR TITLE
fix(code): Use YAML 1.1 for serializing

### DIFF
--- a/packages/ui/src/hooks/entities.test.tsx
+++ b/packages/ui/src/hooks/entities.test.tsx
@@ -2,7 +2,8 @@ import { act, renderHook } from '@testing-library/react';
 import { CamelResource, SourceSchemaType } from '../models/camel';
 import { CamelRouteVisualEntity } from '../models/visualization/flows';
 import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
-import { EventNotifier } from '../utils';
+import { camelRouteYaml_1_1_original, camelRouteYaml_1_1_updated } from '../stubs/camel-route-yaml-1.1';
+import { EventNotifier, setValue } from '../utils';
 import { useEntities } from './entities';
 
 describe('useEntities', () => {
@@ -42,9 +43,24 @@ describe('useEntities', () => {
     expect(result.current.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson.route)]);
   });
 
+  it('should serialize using YAML 1.1', () => {
+    const notifierSpy = jest.spyOn(eventNotifier, 'next');
+    const { result } = renderHook(() => useEntities());
+
+    act(() => {
+      eventNotifier.next('code:updated', camelRouteYaml_1_1_original);
+    });
+
+    act(() => {
+      setValue(result.current.visualEntities[0], 'route.from.parameters.bindingMode', 'off');
+      result.current.updateSourceCodeFromEntities();
+    });
+
+    expect(notifierSpy).toHaveBeenCalledWith('entities:updated', camelRouteYaml_1_1_updated);
+  });
+
   it('should notifiy subscribers when the entities are updated', () => {
     const notifierSpy = jest.spyOn(eventNotifier, 'next');
-
     const { result } = renderHook(() => useEntities());
 
     act(() => {

--- a/packages/ui/src/hooks/entities.ts
+++ b/packages/ui/src/hooks/entities.ts
@@ -57,7 +57,7 @@ export const useEntities = (): EntitiesContextResult => {
   }, [eventNotifier]);
 
   const updateSourceCodeFromEntities = useCallback(() => {
-    const code = stringify(camelResource, { sortMapEntries: camelResource.sortFn }) || '';
+    const code = stringify(camelResource, { sortMapEntries: camelResource.sortFn, schema: 'yaml-1.1' }) || '';
     eventNotifier.next('entities:updated', code);
   }, [camelResource, eventNotifier]);
 

--- a/packages/ui/src/stubs/camel-route-yaml-1.1.ts
+++ b/packages/ui/src/stubs/camel-route-yaml-1.1.ts
@@ -1,0 +1,21 @@
+export const camelRouteYaml_1_1_original = `
+- route:
+    id: route-3376
+    from:
+      id: from-3505
+      uri: rest:post:/newCustomer
+      parameters:
+        host: localhost
+      steps: []
+`;
+
+export const camelRouteYaml_1_1_updated = `- route:
+    id: route-3376
+    from:
+      id: from-3505
+      uri: rest:post:/newCustomer
+      parameters:
+        bindingMode: "off"
+        host: localhost
+      steps: []
+`;


### PR DESCRIPTION
### Context
Currently, Kaoto serializes to YAML using YAML 1.2.

This creates an edge for the Rest component since one of its parameters (`bindingMode`) accepts an `off` value which ultimately gets serialized as it is, causing it to be interpreted as `false`.

This commit changes the YAML serializing schema to 1.1 so `off` gets serialized as `"off"` avoiding this issue.

fix: https://github.com/KaotoIO/kaoto-next/issues/971