### PR TITLE
fix(Canvas): Restore contextual menu labels

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemInsertChildNode.tsx
@@ -48,7 +48,7 @@ export const ItemInsertChildNode: FunctionComponent<ItemInsertChildNodeProps> = 
 
   return shouldRender ? (
     <ContextMenuItem onClick={onInsertNode} data-testid={props['data-testid']}>
-      <AngleDoubleDownIcon /> Insert
+      <AngleDoubleDownIcon /> Insert {props.mode === AddStepMode.InsertSpecialChildStep ? 'special' : ''} step
     </ContextMenuItem>
   ) : null;
 };


### PR DESCRIPTION
### Context
After removing the node id from the contextual menu labels, some EIPs have duplicated `Insert` items, and that's not correct since one `Insert` is for inserting additional nodes while the other is to insert special nodes, like `when` or `otherwise`.

This PR restores the previous label while we get a better approach from a UX perspective.