### PR TITLE
fix(camel-catalog): Rename tokens after upgrading to Camel 4.5

### DIFF
--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelCatalogProcessor.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelCatalogProcessor.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.camel.catalog.DefaultCamelCatalog;
-import org.apache.camel.catalog.Kind;
 import org.apache.camel.tooling.model.ComponentModel;
 import org.apache.camel.tooling.model.EipModel;
 import org.apache.camel.tooling.model.JsonMapper;
+import org.apache.camel.tooling.model.Kind;
 
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -409,7 +409,7 @@ public class CamelCatalogProcessor {
                 propertySchema.put("title", "From");
                 propertySchema.put("description", "From");
                 continue;
-            } else if (List.of("inputType", "outputType").contains(propertyName)) {
+            } else if (List.of("inputType", "outputType", "errorHandler").contains(propertyName)) {
                 // no "inputType" and "outputType" in the catalog, just keep it as-is
                 continue;
             }

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
@@ -18,7 +18,7 @@ package io.kaoto.camelcatalog;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.camel.dsl.yaml.CamelYamlRoutesBuilderLoader;
+import org.apache.camel.dsl.yaml.YamlRoutesBuilderLoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -43,7 +43,7 @@ public class CamelCatalogProcessorTest {
 
     public CamelCatalogProcessorTest() throws Exception {
         this.jsonMapper = new ObjectMapper();
-        var is = CamelYamlRoutesBuilderLoader.class.getClassLoader().getResourceAsStream("schema/camelYamlDsl.json");
+        var is = YamlRoutesBuilderLoader.class.getClassLoader().getResourceAsStream("schema/camelYamlDsl.json");
         yamlDslSchema = (ObjectNode) jsonMapper.readTree(is);
         schemaProcessor = new CamelYamlDslSchemaProcessor(jsonMapper, yamlDslSchema);
         this.processor = new CamelCatalogProcessor(jsonMapper, schemaProcessor);

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparatorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDSLKeysComparatorTest.java
@@ -6,8 +6,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.camel.catalog.DefaultCamelCatalog;
-import org.apache.camel.catalog.Kind;
 import org.apache.camel.tooling.model.EipModel;
+import org.apache.camel.tooling.model.Kind;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
@@ -17,7 +17,7 @@ package io.kaoto.camelcatalog;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.camel.dsl.yaml.CamelYamlRoutesBuilderLoader;
+import org.apache.camel.dsl.yaml.YamlRoutesBuilderLoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,7 +31,7 @@ public class CamelYamlDslSchemaProcessorTest {
 
     public CamelYamlDslSchemaProcessorTest() throws Exception {
         jsonMapper = new ObjectMapper();
-        var is = CamelYamlRoutesBuilderLoader.class.getClassLoader().getResourceAsStream("schema/camelYamlDsl.json");
+        var is = YamlRoutesBuilderLoader.class.getClassLoader().getResourceAsStream("schema/camelYamlDsl.json");
         yamlDslSchema = (ObjectNode) jsonMapper.readTree(is);
         processor = new CamelYamlDslSchemaProcessor(jsonMapper, yamlDslSchema);
     }

--- a/packages/camel-catalog/pom.xml
+++ b/packages/camel-catalog/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.camel>4.4.1</version.camel>
+    <version.camel>4.5.0</version.camel>
     <version.camel-k-crds>2.2.0</version.camel-k-crds>
     <version.camel-kamelets>4.4.1</version.camel-kamelets>
     <version.jackson>2.16.2</version.jackson>


### PR DESCRIPTION
### Context
After updating to Camel 4.5, some tokens were renamed or removed.

[Related PR](https://github.com/apache/camel/pull/13135/files#diff-9e46a8c92d107cc1b4cd595bff2e454dd984d2fe3602ed0e39c756bff1ca8f8a)