### PR TITLE
Improvements for grouping in configuration panel

### DIFF
--- a/packages/ui/src/components/Form/customField/CustomNestField.scss
+++ b/packages/ui/src/components/Form/customField/CustomNestField.scss
@@ -1,4 +1,11 @@
-.custom-nestfield-spacing {
-  display: grid;
-  gap: var(--pf-v5-c-form--GridGap);
+.custom-nest-field {
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v5-c-card__body {
+    display: grid;
+    gap: var(--pf-v5-c-form--GridGap);
+  }
+
+  .pf-v5-c-expandable-section {
+    --pf-v5-c-expandable-section__content--MarginTop: 0;
+  }
 }

--- a/packages/ui/src/components/Form/customField/CustomNestField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomNestField.tsx
@@ -49,9 +49,6 @@ export const CustomNestField = connectField(
           const group: string = getValue(definition, 'group', '');
           if (group === '' || group === 'common' || group === 'producer' || group === 'consumer') {
             acc.common.push(name);
-          } else if (group.includes('advanced')) {
-            acc.groups['advanced'] ??= [];
-            acc.groups['advanced'].push(name);
           } else {
             acc.groups[group] ??= [];
             acc.groups[group].push(name);
@@ -63,30 +60,32 @@ export const CustomNestField = connectField(
     }, [props.properties]);
 
     return (
-      <Card data-testid={'nest-field'} {...filterDOMProps(props)}>
+      <Card className="custom-nest-field" data-testid={'nest-field'} {...filterDOMProps(props)}>
         <CardHeader>
           <CardTitle>{label}</CardTitle>
         </CardHeader>
-        <CardBody className="custom-nestfield-spacing">
+        <CardBody>
           {propertiesArray.common.map((field) => (
             <CustomAutoField key={field} name={field} />
           ))}
         </CardBody>
 
-        {Object.entries(propertiesArray.groups).map(([groupName, groupFields]) => (
-          <ExpandableSection
-            key={`${groupName}-section-toggle`}
-            toggleText={capitalize(`${groupName} properties`)}
-            toggleId="expandable-section-toggle"
-            contentId="expandable-section-content"
-          >
-            <CardBody className="custom-nestfield-spacing">
-              {groupFields.map((field) => (
-                <CustomAutoField key={field} name={field} />
-              ))}
-            </CardBody>
-          </ExpandableSection>
-        ))}
+        {Object.entries(propertiesArray.groups)
+          .sort((a, b) => (a[0] === 'advanced' ? 1 : b[0] === 'advanced' ? -1 : 0))
+          .map(([groupName, groupFields]) => (
+            <ExpandableSection
+              key={`${groupName}-section-toggle`}
+              toggleText={capitalize(`${groupName} properties`)}
+              toggleId="expandable-section-toggle"
+              contentId="expandable-section-content"
+            >
+              <CardBody>
+                {groupFields.map((field) => (
+                  <CustomAutoField key={field} name={field} />
+                ))}
+              </CardBody>
+            </ExpandableSection>
+          ))}
       </Card>
     );
   },


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto-next/issues/990

related to https://github.com/KaotoIO/kaoto-next/issues/278 

Also based on the decision from yesterdays discussion - removed the filtering for groups, so all will be showed in the sidepanel.

![Screenshot from 2024-04-04 10-16-53](https://github.com/KaotoIO/kaoto-next/assets/4180208/f863cb9c-a85f-4989-ae3f-2155a709d259)


- Update groups filtering - enable all groups in sidepanel
- Reduce the space between the group title and the first field
- Putt Advanced always at the end